### PR TITLE
Print/PDF improvements: page sizes, page numbers, headers/footers, Safari fix (#5)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,11 +35,16 @@ body {
   stroke-linejoin: round;
 }
 
+/* Print overlay elements — hidden on screen, visible only in print */
+.print-overlay {
+  display: none;
+}
+
 /* Print styles — show only the score */
 @media print {
   /* Reset page margins to minimum */
   @page {
-    margin: 0.3in;
+    margin: 0.4in 0.5in;
   }
 
   body {
@@ -88,5 +93,46 @@ body {
   /* Remove the rounded white container border/bg in print */
   .score-container > div.relative {
     border-radius: 0 !important;
+  }
+
+  /* Prevent OSMD systems (staff groups) from being split across pages */
+  .score-container svg > g {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Show print overlays */
+  .print-overlay {
+    display: block !important;
+    position: absolute;
+    left: 0;
+    right: 0;
+    font-family: Georgia, 'Times New Roman', serif;
+    color: #333;
+    pointer-events: none;
+    z-index: 100;
+  }
+
+  .print-header {
+    top: 4px;
+    text-align: center;
+    font-size: 9pt;
+    color: #555;
+  }
+
+  .print-footer-text {
+    bottom: 4px;
+    text-align: center;
+    font-size: 8pt;
+    color: #666;
+  }
+
+  .print-page-number {
+    bottom: 4px;
+    right: 0;
+    text-align: right;
+    font-size: 9pt;
+    color: #555;
+    padding-right: 4px;
   }
 }

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useScoreStore, DEFAULT_LAYOUT, PRINT_LAYOUT, LayoutSettings, MusicFont, TextFont } from "@/store/score-store";
+import { useScoreStore, DEFAULT_LAYOUT, PRINT_LAYOUT, LayoutSettings, MusicFont, TextFont, PageSize } from "@/store/score-store";
 import { KeySignature, Clef } from "@/lib/schema";
 import RevisionPanel from "./RevisionPanel";
 
@@ -272,9 +272,44 @@ export default function PropertiesPanel() {
                 className="accent-blue-500"
               />
               <span className="text-[10px] text-gray-400">
-                {layout.pageBreaks ? "Letter pages" : "Endless scroll"}
+                {layout.pageBreaks
+                  ? layout.pageSize === "a4" ? "A4 pages" : "Letter pages"
+                  : "Endless scroll"}
               </span>
             </div>
+            <div className="flex items-center gap-2">
+              <label className="text-[10px] text-gray-500 w-16 shrink-0">Page size</label>
+              <select
+                value={layout.pageSize}
+                onChange={(e) => setLayout({ pageSize: e.target.value as PageSize })}
+                className="flex-1 px-1 py-0.5 text-[10px] border border-gray-200 rounded bg-white text-gray-800"
+              >
+                <option value="letter">US Letter (8.5 &times; 11&quot;)</option>
+                <option value="a4">A4 (210 &times; 297mm)</option>
+              </select>
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-[10px] text-gray-500 w-16 shrink-0">Page #s</label>
+              <input
+                type="checkbox"
+                checked={layout.printPageNumbers}
+                onChange={(e) => setLayout({ printPageNumbers: e.target.checked })}
+                className="accent-blue-500"
+              />
+              <span className="text-[10px] text-gray-400">
+                {layout.printPageNumbers ? "Shown in print" : "Hidden"}
+              </span>
+            </div>
+            <Field
+              label="Header"
+              value={layout.printHeader}
+              onChange={(v) => setLayout({ printHeader: v })}
+            />
+            <Field
+              label="Footer"
+              value={layout.printFooter}
+              onChange={(v) => setLayout({ printFooter: v })}
+            />
           </div>
         </section>
       </div>

--- a/src/components/ScoreRenderer.tsx
+++ b/src/components/ScoreRenderer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Score } from "@/lib/schema";
 import { scoreToMusicXML } from "@/lib/musicxml";
-import { LayoutSettings, DEFAULT_LAYOUT, PRINT_LAYOUT, TEXT_FONT_STACKS } from "@/store/score-store";
+import { LayoutSettings, DEFAULT_LAYOUT, PRINT_LAYOUT, TEXT_FONT_STACKS, PAGE_DIMENSIONS } from "@/store/score-store";
 
 export interface ScoreRendererHandle {
   printScore: () => Promise<void>;
@@ -14,6 +14,58 @@ interface ScoreRendererProps {
   zoom?: number;
   layout?: LayoutSettings;
   onReady?: (handle: ScoreRendererHandle) => void;
+}
+
+/**
+ * Inject page-number, header, and footer overlays into each OSMD page's SVG container.
+ * OSMD renders each page as a separate child div inside the container. We append
+ * lightweight overlay divs that are visible only in print (via CSS class).
+ */
+function injectPrintOverlays(
+  container: HTMLDivElement | null,
+  layout: LayoutSettings,
+  title: string
+) {
+  if (!container) return;
+  // OSMD creates one child <div> per page when page breaks are enabled.
+  // Each child contains an <svg>. We overlay on each.
+  const pageEls = container.querySelectorAll<HTMLElement>(":scope > div");
+  const pages = pageEls.length > 0 ? Array.from(pageEls) : [container];
+
+  pages.forEach((page, index) => {
+    page.style.position = "relative";
+
+    if (layout.printHeader) {
+      const header = document.createElement("div");
+      header.className = "print-overlay print-header";
+      header.textContent = layout.printHeader === "{title}" ? title : layout.printHeader;
+      page.appendChild(header);
+    }
+
+    if (layout.printFooter) {
+      const footer = document.createElement("div");
+      footer.className = "print-overlay print-footer-text";
+      footer.textContent = layout.printFooter;
+      page.appendChild(footer);
+    }
+
+    if (layout.printPageNumbers && pages.length > 1) {
+      const pageNum = document.createElement("div");
+      pageNum.className = "print-overlay print-page-number";
+      pageNum.textContent = String(index + 1);
+      page.appendChild(pageNum);
+    }
+  });
+}
+
+/** Remove all injected print overlays. */
+function removePrintOverlays(container: HTMLDivElement | null) {
+  if (!container) return;
+  container.querySelectorAll(".print-overlay").forEach((el) => el.remove());
+  // Reset position style on page containers
+  container.querySelectorAll<HTMLElement>(":scope > div").forEach((el) => {
+    el.style.position = "";
+  });
 }
 
 function applyLayout(osmd: any, layout: LayoutSettings, zoomLevel: number) {
@@ -104,10 +156,11 @@ function applyLayout(osmd: any, layout: LayoutSettings, zoomLevel: number) {
   rules.MeasureLeftMargin = 0.8;
   rules.ClefRightMargin = 0.9;
 
-  // Page breaks: letter page format for pagination
+  // Page breaks: use selected page size for pagination
   if (layout.pageBreaks) {
+    const dims = PAGE_DIMENSIONS[layout.pageSize] || PAGE_DIMENSIONS.letter;
     const PF = rules.PageFormat.constructor as any;
-    rules.PageFormat = new PF(8.5, 11.0, "letter");
+    rules.PageFormat = new PF(dims.width, dims.height, layout.pageSize);
     rules.NewPageAtXMLNewPageAttribute = true;
   } else {
     // Endless scroll: undefined page format, huge page height
@@ -153,9 +206,22 @@ export default function ScoreRenderer({ score, zoom = 1.0, layout = DEFAULT_LAYO
     const scoreName = scoreRef.current?.title;
     if (scoreName) document.title = scoreName;
 
+    // Build the print layout, inheriting user's page size and print settings
+    const userLayout = layoutRef.current;
+    const printLayout: LayoutSettings = {
+      ...PRINT_LAYOUT,
+      pageSize: userLayout.pageSize,
+      printPageNumbers: userLayout.printPageNumbers,
+      printHeader: userLayout.printHeader,
+      printFooter: userLayout.printFooter,
+    };
+
     // Re-render with tight print layout
-    applyLayout(osmd, PRINT_LAYOUT, 1.0);
+    applyLayout(osmd, printLayout, 1.0);
     osmd.render();
+
+    // Inject print overlays (page numbers, headers, footers)
+    injectPrintOverlays(containerRef.current, printLayout, scoreName || "");
 
     // Wait for browser to paint via double-rAF, then print
     await new Promise<void>((resolve) => {
@@ -164,12 +230,12 @@ export default function ScoreRenderer({ score, zoom = 1.0, layout = DEFAULT_LAYO
       });
     });
 
-    window.print();
-
-    // Safari fires afterprint before capturing — delay restore
-    // so the print sheet captures the print layout DOM
-    setTimeout(() => {
+    // Restore after print completes — use afterprint event for Safari compatibility.
+    // Safari's window.print() is non-blocking, so we must wait for the afterprint
+    // event rather than restoring immediately after the call.
+    const restore = () => {
       document.title = prevTitle;
+      removePrintOverlays(containerRef.current);
       const saved = savedPrintLayoutRef.current;
       if (saved && osmdRef.current) {
         applyLayout(osmdRef.current, saved.layout, saved.zoom);
@@ -177,7 +243,24 @@ export default function ScoreRenderer({ score, zoom = 1.0, layout = DEFAULT_LAYO
         savedPrintLayoutRef.current = null;
       }
       printingRef.current = false;
-    }, 1000);
+    };
+
+    // Listen for afterprint — works on Safari, Chrome, Firefox
+    const onAfterPrint = () => {
+      window.removeEventListener("afterprint", onAfterPrint);
+      clearTimeout(fallbackTimer);
+      // Small delay ensures Safari has fully captured the print snapshot
+      setTimeout(restore, 100);
+    };
+    window.addEventListener("afterprint", onAfterPrint);
+
+    // Fallback timer in case afterprint never fires (e.g. some mobile browsers)
+    const fallbackTimer = setTimeout(() => {
+      window.removeEventListener("afterprint", onAfterPrint);
+      restore();
+    }, 30000);
+
+    window.print();
   }, []);
 
   // Notify parent when ready
@@ -257,8 +340,9 @@ export default function ScoreRenderer({ score, zoom = 1.0, layout = DEFAULT_LAYO
   // Restore layout after Cmd+P (system-initiated print, not our button)
   useEffect(() => {
     const handleAfterPrint = () => {
-      // If our printScore is handling the cycle, skip — it restores via timeout
+      // If our printScore is handling the cycle, skip — it restores via its own listener
       if (printingRef.current) return;
+      removePrintOverlays(containerRef.current);
       const osmd = osmdRef.current;
       if (!osmd) return;
       applyLayout(osmd, layoutRef.current, zoomRef.current);

--- a/src/store/score-store.ts
+++ b/src/store/score-store.ts
@@ -24,6 +24,12 @@ export interface RecordedOperation {
 
 export type MusicFont = "bravura" | "petaluma" | "gonville";
 export type TextFont = "georgia" | "palatino" | "garamond" | "times" | "helvetica" | "noto";
+export type PageSize = "letter" | "a4";
+
+export const PAGE_DIMENSIONS: Record<PageSize, { width: number; height: number; label: string }> = {
+  letter: { width: 8.5, height: 11.0, label: "US Letter" },
+  a4: { width: 8.27, height: 11.69, label: "A4" },
+};
 
 export const TEXT_FONT_STACKS: Record<TextFont, string> = {
   georgia: "Georgia, 'Times New Roman', serif",
@@ -46,9 +52,13 @@ export interface LayoutSettings {
   compactMode: boolean;
   measuresPerSystem: number; // 0 = auto, >0 = fixed
   pageBreaks: boolean;      // enable page-height pagination
+  pageSize: PageSize;       // page dimensions for print/pagination
   noteSize: number;         // notation scale factor (1.0 = default, 0.7 = smaller)
   musicFont: MusicFont;     // VexFlow music notation font
   textFont: TextFont;       // CSS text font for lyrics, titles, etc.
+  printPageNumbers: boolean; // show page numbers in print output
+  printHeader: string;       // header text for printed pages (empty = none)
+  printFooter: string;       // footer/copyright text for printed pages (empty = none)
 }
 
 export const DEFAULT_LAYOUT: LayoutSettings = {
@@ -63,9 +73,13 @@ export const DEFAULT_LAYOUT: LayoutSettings = {
   compactMode: false,
   measuresPerSystem: 0,
   pageBreaks: false,
+  pageSize: "letter",
   noteSize: 1.0,
   musicFont: "bravura",
   textFont: "georgia",
+  printPageNumbers: true,
+  printHeader: "",
+  printFooter: "",
 };
 
 export const PRINT_LAYOUT: LayoutSettings = {
@@ -80,9 +94,13 @@ export const PRINT_LAYOUT: LayoutSettings = {
   compactMode: true,
   measuresPerSystem: 4,
   pageBreaks: true,
+  pageSize: "letter",
   noteSize: 0.65,
   musicFont: "bravura",
   textFont: "palatino",
+  printPageNumbers: true,
+  printHeader: "",
+  printFooter: "",
 };
 
 export interface SavedRevision {
@@ -265,7 +283,7 @@ export const useScoreStore = create<ProjectState>()(
     }),
     {
       name: "notation-app-store",
-      version: 7,
+      version: 8,
       migrate: (persisted: any, version: number) => {
         if (version < 2) {
           persisted = { ...persisted, savedRevisions: persisted.savedRevisions ?? [] };
@@ -288,6 +306,19 @@ export const useScoreStore = create<ProjectState>()(
               noteSize: layout.noteSize ?? 1.0,
               musicFont: layout.musicFont ?? "bravura",
               textFont: layout.textFont ?? "georgia",
+            },
+          };
+        }
+        if (version < 8) {
+          const layout = persisted.layout ?? DEFAULT_LAYOUT;
+          persisted = {
+            ...persisted,
+            layout: {
+              ...layout,
+              pageSize: layout.pageSize ?? "letter",
+              printPageNumbers: layout.printPageNumbers ?? true,
+              printHeader: layout.printHeader ?? "",
+              printFooter: layout.printFooter ?? "",
             },
           };
         }


### PR DESCRIPTION
- Add Letter/A4 page size selection (previously hardcoded to Letter)
- Add page numbering overlay for multi-page scores
- Add configurable header/footer text for print output (e.g. copyright)
- Fix Safari print by using afterprint event instead of fixed timeout
- Add break-inside:avoid CSS to prevent OSMD systems splitting across pages
- Add print settings UI controls in PropertiesPanel
- Bump store version to 8 with migration for new layout fields

https://claude.ai/code/session_01Tn1Am3FwdC2cGV19dzCov1