### PR TITLE
#41 Repeats + nav marks; #43 Count-in + metronome

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useScoreStore } from "@/store/score-store";
 import { v4 as uuidv4 } from "uuid";
 import { saveSnapshot } from "@/lib/autosave";
 import { playScore, stopPlayback, isPlaying } from "@/lib/playback";
+import { loadPlaybackPrefs, savePlaybackPrefs, type PlaybackPrefs } from "@/lib/playback-prefs";
 import PromptPanel from "@/components/PromptPanel";
 import PropertiesPanel from "@/components/PropertiesPanel";
 import MenuBar from "@/components/MenuBar";
@@ -59,6 +60,8 @@ export default function Home() {
   const clipboard = useScoreStore((s) => s.clipboard);
   const [zoom, setZoom] = useState(1.0);
   const [playing, setPlaying] = useState(false);
+  const [playbackPrefs, setPlaybackPrefs] = useState<PlaybackPrefs>(() => loadPlaybackPrefs());
+  useEffect(() => savePlaybackPrefs(playbackPrefs), [playbackPrefs]);
   const [playbackPos, setPlaybackPos] = useState<{ measure: number; beat: number } | null>(null);
   const [selectedNote, setSelectedNote] = useState<{ measure: number; beat: number; staffIndex: number; pitch: string } | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; note: { measure: number; beat: number; pitch: string; staffIndex: number } } | null>(null);
@@ -734,6 +737,9 @@ export default function Home() {
                   await playScore(score, selection, (m, b) => {
                     if (m === 0) { setPlaybackPos(null); return; }
                     setPlaybackPos({ measure: m, beat: b });
+                  }, {
+                    countInBars: playbackPrefs.countInBars,
+                    metronome: playbackPrefs.metronome,
                   });
                   setPlaying(false);
                   setPlaybackPos(null);
@@ -753,6 +759,34 @@ export default function Home() {
                 M{playbackPos.measure}:B{playbackPos.beat.toFixed(1)}
               </span>
             )}
+
+            {/* Metronome toggle — continuous click during playback. */}
+            <button
+              onClick={() => setPlaybackPrefs(p => ({ ...p, metronome: !p.metronome }))}
+              className={`px-1.5 py-0.5 rounded text-[10px] font-bold transition-colors ${
+                playbackPrefs.metronome
+                  ? "bg-amber-600 hover:bg-amber-700 text-white"
+                  : "bg-white/5 hover:bg-white/10 text-gray-400"
+              }`}
+              title="Metronome click during playback"
+              aria-label="Toggle metronome"
+            >
+              ♩
+            </button>
+
+            {/* Count-in cycle: 0 → 1 → 2 → 0 bars before playback. */}
+            <button
+              onClick={() => setPlaybackPrefs(p => ({ ...p, countInBars: ((p.countInBars + 1) % 3) as 0 | 1 | 2 }))}
+              className={`px-1.5 py-0.5 rounded text-[10px] font-bold transition-colors min-w-[28px] ${
+                playbackPrefs.countInBars > 0
+                  ? "bg-amber-600 hover:bg-amber-700 text-white"
+                  : "bg-white/5 hover:bg-white/10 text-gray-400"
+              }`}
+              title={`Count-in: ${playbackPrefs.countInBars} bar${playbackPrefs.countInBars === 1 ? "" : "s"} before play`}
+              aria-label="Cycle count-in bars"
+            >
+              {playbackPrefs.countInBars > 0 ? `+${playbackPrefs.countInBars}` : "+0"}
+            </button>
 
             {/* Divider */}
             <span className="text-gray-600">|</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -243,9 +243,14 @@ export default function Home() {
   }, [score]);
 
   // Mac-native zoom shortcuts: Cmd+/-/0 keyboard, Cmd+scroll wheel and
-  // trackpad pinch (which Safari/Chromium translate to wheel events with
-  // ctrlKey=true). Only fires when focus isn't in a text field.
+  // trackpad pinch. Skipped in perform mode — there the user has the
+  // floating font/leading buttons, and the global zoom shortcut would
+  // block the browser's own page zoom (which the user often wants in
+  // perform mode to scale the whole UI for far-away viewing).
+  const inPerformMode = uiState.performMode;
   useEffect(() => {
+    if (inPerformMode) return;
+
     const isTextTarget = (t: EventTarget | null) =>
       t instanceof HTMLInputElement ||
       t instanceof HTMLTextAreaElement ||
@@ -290,7 +295,7 @@ export default function Home() {
       window.removeEventListener("keydown", onKey);
       window.removeEventListener("wheel", onWheel);
     };
-  }, []);
+  }, [inPerformMode]);
 
   // Cloud autosave — push the loaded song to DynamoDB after edits settle
   // so an unsaved-since-load session can't lose work. Only fires when

--- a/src/components/ChordChartView.tsx
+++ b/src/components/ChordChartView.tsx
@@ -2,6 +2,21 @@
 
 import { useState, useRef, useEffect } from "react";
 import { Score, ChordChartSection, ScorePatch } from "@/lib/schema";
+
+/** Display labels for the section navMark enum. Keep concise so they fit
+ *  in a badge next to the section header. */
+const NAV_MARK_LABELS: Record<string, string> = {
+  segno: "Segno 𝄋",
+  coda: "Coda 𝄌",
+  "to-coda": "To Coda",
+  fine: "Fine",
+  "d.c.": "D.C.",
+  "d.s.": "D.S.",
+  "d.c. al fine": "D.C. al Fine",
+  "d.s. al fine": "D.S. al Fine",
+  "d.c. al coda": "D.C. al Coda",
+  "d.s. al coda": "D.S. al Coda",
+};
 import { useScoreStore, TEXT_FONT_STACKS, TextFont } from "@/store/score-store";
 
 type ChartFont = "mono" | TextFont;
@@ -123,14 +138,39 @@ function SectionBlock({
     showDivider ? "pb-3 border-b border-gray-800/60" : "",
   ].filter(Boolean).join(" ");
 
+  const navLabel = NAV_MARK_LABELS[section.navMark ?? ""] ?? "";
+  const headerBadges = (
+    <span className="inline-flex flex-wrap items-baseline gap-2 ml-2 align-baseline text-base">
+      {section.endingNumber && (
+        <span className="text-xs font-mono text-amber-300 border-2 border-b-0 border-amber-300/80 px-1.5 pt-0.5 leading-tight">
+          {section.endingNumber}.
+        </span>
+      )}
+      {section.repeatStart && (
+        <span className="text-pink-300" title="Open repeat">𝄆</span>
+      )}
+      {section.repeatEnd && (
+        <span className="text-pink-300" title="End repeat">𝄇</span>
+      )}
+      {section.navMark && (
+        <span className="text-xs font-medium uppercase tracking-wider px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-200" title={section.navMark}>
+          {navLabel}
+        </span>
+      )}
+    </span>
+  );
+
   const header = (
-    <EditableSectionHeader
-      label={section.label}
-      onCommit={(newLabel) => onLabelCommit(section.id, newLabel)}
-      onContextMenu={(x, y) => onHeaderContextMenu(section.id, x, y)}
-      position={labelPosition}
-      font={headerFont}
-    />
+    <span className="inline-flex items-baseline">
+      <EditableSectionHeader
+        label={section.label}
+        onCommit={(newLabel) => onLabelCommit(section.id, newLabel)}
+        onContextMenu={(x, y) => onHeaderContextMenu(section.id, x, y)}
+        position={labelPosition}
+        font={headerFont}
+      />
+      {headerBadges}
+    </span>
   );
 
   return (
@@ -1003,6 +1043,17 @@ export default function ChordChartView({ score, performMode = false, performColu
 
   const buildHeaderMenuItems = (ctx: HeaderContextMenuState): ChordChartContextMenuItem[] => {
     const idx = score.sections.findIndex(s => s.id === ctx.sectionId);
+    const section = sectionMap.get(ctx.sectionId);
+    const setSectionField = (
+      field: "repeatStart" | "repeatEnd" | "endingNumber" | "navMark",
+      value: boolean | number | string | null,
+    ) => {
+      applyPatches([{
+        op: "update_section",
+        sectionId: ctx.sectionId,
+        [field]: value,
+      } as ScorePatch]);
+    };
     return [
       {
         label: "Add section above",
@@ -1012,6 +1063,29 @@ export default function ChordChartView({ score, performMode = false, performColu
         label: "Add section below",
         onClick: () => handleAddSection(idx >= 0 ? idx + 1 : undefined),
       },
+      // Repeats — clicking a flag toggles it.
+      { divider: true, label: section?.repeatStart ? "Remove start repeat 𝄆" : "Start repeat 𝄆",
+        onClick: () => setSectionField("repeatStart", section?.repeatStart ? null : true) },
+      { label: section?.repeatEnd ? "Remove end repeat 𝄇" : "End repeat 𝄇",
+        onClick: () => setSectionField("repeatEnd", section?.repeatEnd ? null : true) },
+      // Volta endings — quick-pick 1/2/clear.
+      { label: section?.endingNumber === 1 ? "Clear 1st ending" : "Mark 1st ending",
+        onClick: () => setSectionField("endingNumber", section?.endingNumber === 1 ? null : 1) },
+      { label: section?.endingNumber === 2 ? "Clear 2nd ending" : "Mark 2nd ending",
+        onClick: () => setSectionField("endingNumber", section?.endingNumber === 2 ? null : 2) },
+      // Navigation marks — submenu effect via 7 quick-pick items.
+      { divider: true, label: section?.navMark === "segno" ? "Remove Segno" : "Set Segno 𝄋",
+        onClick: () => setSectionField("navMark", section?.navMark === "segno" ? null : "segno") },
+      { label: section?.navMark === "coda" ? "Remove Coda" : "Set Coda 𝄌",
+        onClick: () => setSectionField("navMark", section?.navMark === "coda" ? null : "coda") },
+      { label: section?.navMark === "to-coda" ? "Remove To Coda" : "Set To Coda",
+        onClick: () => setSectionField("navMark", section?.navMark === "to-coda" ? null : "to-coda") },
+      { label: section?.navMark === "fine" ? "Remove Fine" : "Set Fine",
+        onClick: () => setSectionField("navMark", section?.navMark === "fine" ? null : "fine") },
+      { label: section?.navMark === "d.c. al fine" ? "Remove D.C. al Fine" : "Set D.C. al Fine",
+        onClick: () => setSectionField("navMark", section?.navMark === "d.c. al fine" ? null : "d.c. al fine") },
+      { label: section?.navMark === "d.s. al coda" ? "Remove D.S. al Coda" : "Set D.S. al Coda",
+        onClick: () => setSectionField("navMark", section?.navMark === "d.s. al coda" ? null : "d.s. al coda") },
       {
         divider: true,
         label: "Delete section",

--- a/src/components/PaginatedPerformChart.tsx
+++ b/src/components/PaginatedPerformChart.tsx
@@ -182,10 +182,13 @@ export default function PaginatedPerformChart({
             key={i}
             className="shrink-0 w-full h-full snap-start grid grid-cols-2 gap-8 px-4 py-2"
           >
-            <div className="overflow-hidden">
+            {/* overflow-y-auto so a section taller than the column doesn't
+                get clipped — user can scroll within the column. Beats the
+                previous overflow-hidden which silently cut content off. */}
+            <div className="overflow-y-auto overflow-x-hidden">
               {page.col1.map((s) => <PerformSection key={s.id} section={s} />)}
             </div>
-            <div className="overflow-hidden">
+            <div className="overflow-y-auto overflow-x-hidden">
               {page.col2.map((s) => <PerformSection key={s.id} section={s} />)}
             </div>
           </div>

--- a/src/components/PaginatedPerformChart.tsx
+++ b/src/components/PaginatedPerformChart.tsx
@@ -257,11 +257,36 @@ function PerformMarkedLyric({
   );
 }
 
+const PERFORM_NAV_LABELS: Record<string, string> = {
+  segno: "Segno 𝄋",
+  coda: "Coda 𝄌",
+  "to-coda": "To Coda",
+  fine: "Fine",
+  "d.c.": "D.C.",
+  "d.s.": "D.S.",
+  "d.c. al fine": "D.C. al Fine",
+  "d.s. al fine": "D.S. al Fine",
+  "d.c. al coda": "D.C. al Coda",
+  "d.s. al coda": "D.S. al Coda",
+};
+
 function PerformSection({ section }: { section: ChordChartSection }) {
   return (
     <section className="mb-3">
-      <h3 className="text-pink-300 italic font-semibold text-base mb-1">
-        {section.label}
+      <h3 className="text-pink-300 italic font-semibold text-base mb-1 inline-flex items-baseline flex-wrap gap-2">
+        <span>{section.label}</span>
+        {section.endingNumber && (
+          <span className="text-xs font-mono text-amber-300 border-2 border-b-0 border-amber-300/80 px-1.5 pt-0.5 leading-tight">
+            {section.endingNumber}.
+          </span>
+        )}
+        {section.repeatStart && <span className="text-pink-200">𝄆</span>}
+        {section.repeatEnd && <span className="text-pink-200">𝄇</span>}
+        {section.navMark && (
+          <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-purple-500/30 text-purple-100 not-italic">
+            {PERFORM_NAV_LABELS[section.navMark] ?? section.navMark}
+          </span>
+        )}
       </h3>
       <div
         className="chord-chart-line-body whitespace-pre"

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -59,6 +59,7 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   const setScore = useScoreStore(s => s.setScore);
   const setUIState = useScoreStore(s => s.setUIState);
   const currentSongId = useScoreStore(s => s.uiState.currentSongId);
+  const performFolder = useScoreStore(s => s.uiState.performFolder ?? null);
   // 1-col scrolls the outer container vertically; 2-col scrolls the
   // PaginatedPerformChart's inner pages strip horizontally. They live in
   // different DOM nodes so we need separate refs.
@@ -70,23 +71,36 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   // by sync updates. Newest first matches the My Songs modal ordering.
   const [songs] = useState<SongBankEntry[]>(() => getSongs().slice().reverse());
 
-  // Find the position of the current song in the list. Falls back to the
-  // first song if currentSongId isn't set or doesn't match (e.g. unsaved
-  // edits, fresh creation). The fallback also handles the case where the
-  // user opens Perform without ever loading from My Songs.
+  // All folder names (sorted), for the picker's folder selector.
+  const folderNames = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of songs) if (s.folder) set.add(s.folder);
+    return Array.from(set).sort();
+  }, [songs]);
+
+  // Songs in the active scope (folder filter). When performFolder is set,
+  // prev/next only walks that subset — picking 'Set 1' once means the
+  // user stays in Set 1 across song changes.
+  const songsInScope = useMemo(() => {
+    if (!performFolder) return songs;
+    return songs.filter(s => s.folder === performFolder);
+  }, [songs, performFolder]);
+
+  // Find the position of the current song in the SCOPED list. Falls back
+  // to 0 if the loaded song isn't in scope (so prev/next still work).
   const currentIndex = useMemo(() => {
-    if (!songs.length) return -1;
+    if (!songsInScope.length) return -1;
     const byId = currentSongId
-      ? songs.findIndex(s => s.id === currentSongId)
+      ? songsInScope.findIndex(s => s.id === currentSongId)
       : -1;
     if (byId !== -1) return byId;
-    const byTitle = songs.findIndex(s => s.title === score.title);
+    const byTitle = songsInScope.findIndex(s => s.title === score.title);
     return byTitle !== -1 ? byTitle : 0;
-  }, [songs, currentSongId, score.title]);
+  }, [songsInScope, currentSongId, score.title]);
 
   const loadAt = (idx: number) => {
-    if (idx < 0 || idx >= songs.length) return;
-    const entry = songs[idx];
+    if (idx < 0 || idx >= songsInScope.length) return;
+    const entry = songsInScope[idx];
     setScore(entry.score);
     setUIState({ currentSongId: entry.id });
     scrollRef.current?.scrollTo({ top: 0 });
@@ -232,20 +246,27 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
           <button
             type="button"
             onClick={() => setPickerOpen(o => !o)}
-            className="h-11 px-3 flex items-center gap-1 text-sm font-medium text-gray-100 hover:bg-gray-800 active:bg-gray-700 rounded-lg max-w-[40vw]"
+            className="h-11 px-3 flex flex-col items-start justify-center text-gray-100 hover:bg-gray-800 active:bg-gray-700 rounded-lg max-w-[40vw]"
             title="Jump to song"
           >
-            <span className="truncate">
-              {songs[currentIndex]?.title ?? score.title ?? "Untitled"}
+            {performFolder && (
+              <span className="text-[9px] uppercase tracking-wider text-gray-400 leading-none mb-0.5">
+                {performFolder}
+              </span>
+            )}
+            <span className="flex items-center gap-1 truncate text-sm font-medium leading-tight">
+              <span className="truncate">
+                {songsInScope[currentIndex]?.title ?? score.title ?? "Untitled"}
+              </span>
+              <svg className="w-3 h-3 shrink-0 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
             </span>
-            <svg className="w-3 h-3 shrink-0 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
           </button>
           <button
             type="button"
             onClick={() => loadAt(currentIndex + 1)}
-            disabled={currentIndex < 0 || currentIndex >= songs.length - 1}
+            disabled={currentIndex < 0 || currentIndex >= songsInScope.length - 1}
             className={`${btn} disabled:opacity-30 disabled:hover:bg-gray-900/80`}
             aria-label="Next song"
             title="Next song"
@@ -255,32 +276,75 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
         </div>
       )}
 
-      {/* Song picker — opens below the title button when toggled */}
+      {/* Song picker with folder scope selector at top. The folder filter
+          persists to UIState so picking 'Set 1' once keeps prev/next within
+          Set 1 across song changes. */}
       {pickerOpen && songs.length > 0 && (
         <>
           <div
             className="absolute inset-0 z-10"
             onClick={() => setPickerOpen(false)}
           />
-          <div className="absolute top-[68px] left-3 z-20 bg-white text-gray-800 rounded-xl shadow-2xl border border-gray-200 w-[min(360px,calc(100vw-1.5rem))] max-h-[60vh] overflow-y-auto">
-            <ul className="py-1">
-              {songs.map((s, i) => (
-                <li key={s.id}>
-                  <button
-                    type="button"
-                    onClick={() => loadAt(i)}
-                    className={`w-full text-left px-4 py-2 text-sm hover:bg-blue-50 active:bg-blue-100 ${
-                      i === currentIndex ? "bg-blue-50 font-medium" : ""
-                    }`}
-                  >
-                    <div className="truncate">{s.title}</div>
-                    <div className="text-xs text-gray-400">
-                      {new Date(s.savedAt).toLocaleDateString()}
-                    </div>
-                  </button>
-                </li>
-              ))}
-            </ul>
+          <div className="absolute top-[68px] left-3 z-20 bg-white text-gray-800 rounded-xl shadow-2xl border border-gray-200 w-[min(360px,calc(100vw-1.5rem))] max-h-[60vh] overflow-hidden flex flex-col">
+            {folderNames.length > 0 && (
+              <div className="px-3 py-2 border-b border-gray-100 bg-gray-50 flex flex-wrap gap-1">
+                <button
+                  type="button"
+                  onClick={() => setUIState({ performFolder: null })}
+                  className={`px-2 py-1 text-xs rounded-md transition-colors ${
+                    !performFolder
+                      ? "bg-blue-600 text-white"
+                      : "bg-white border border-gray-200 text-gray-700 hover:bg-gray-100"
+                  }`}
+                >
+                  All ({songs.length})
+                </button>
+                {folderNames.map(f => {
+                  const count = songs.filter(s => s.folder === f).length;
+                  return (
+                    <button
+                      key={f}
+                      type="button"
+                      onClick={() => setUIState({ performFolder: f })}
+                      className={`px-2 py-1 text-xs rounded-md transition-colors ${
+                        performFolder === f
+                          ? "bg-blue-600 text-white"
+                          : "bg-white border border-gray-200 text-gray-700 hover:bg-gray-100"
+                      }`}
+                    >
+                      {f} ({count})
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            <div className="flex-1 overflow-y-auto">
+              {songsInScope.length === 0 ? (
+                <div className="px-4 py-6 text-sm text-gray-500 text-center">
+                  No songs in this folder.
+                </div>
+              ) : (
+                <ul className="py-1">
+                  {songsInScope.map((s, i) => (
+                    <li key={s.id}>
+                      <button
+                        type="button"
+                        onClick={() => loadAt(i)}
+                        className={`w-full text-left px-4 py-2 text-sm hover:bg-blue-50 active:bg-blue-100 ${
+                          i === currentIndex ? "bg-blue-50 font-medium" : ""
+                        }`}
+                      >
+                        <div className="truncate">{s.title}</div>
+                        <div className="text-xs text-gray-400">
+                          {new Date(s.savedAt).toLocaleDateString()}
+                          {s.folder ? ` · ${s.folder}` : ""}
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           </div>
         </>
       )}

--- a/src/lib/patches.ts
+++ b/src/lib/patches.ts
@@ -228,6 +228,30 @@ export function applyPatch(score: Score, patch: ScorePatch): Score {
       };
     }
 
+    case "update_section": {
+      return {
+        ...score,
+        sections: score.sections.map((s) => {
+          if (s.id !== patch.sectionId) return s;
+          const next = { ...s };
+          // null clears, true/value sets, undefined leaves alone
+          const apply = <K extends keyof typeof next>(
+            key: K,
+            val: typeof next[K] | null | undefined,
+          ) => {
+            if (val === undefined) return;
+            if (val === null || val === false) delete next[key];
+            else next[key] = val;
+          };
+          apply("repeatStart", patch.repeatStart);
+          apply("repeatEnd", patch.repeatEnd);
+          apply("endingNumber", patch.endingNumber);
+          apply("navMark", patch.navMark);
+          return next;
+        }),
+      };
+    }
+
     case "add_section": {
       const sections = [...score.sections];
       const idx = patch.index ?? sections.length;

--- a/src/lib/playback-prefs.ts
+++ b/src/lib/playback-prefs.ts
@@ -1,0 +1,29 @@
+"use client";
+
+const PREFS_KEY = "notation-app-playback-prefs";
+
+export interface PlaybackPrefs {
+  metronome: boolean;
+  countInBars: 0 | 1 | 2;
+}
+
+const DEFAULT: PlaybackPrefs = { metronome: false, countInBars: 0 };
+
+export function loadPlaybackPrefs(): PlaybackPrefs {
+  if (typeof window === "undefined") return DEFAULT;
+  try {
+    const raw = localStorage.getItem(PREFS_KEY);
+    if (!raw) return DEFAULT;
+    return { ...DEFAULT, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT;
+  }
+}
+
+export function savePlaybackPrefs(p: PlaybackPrefs): void {
+  try {
+    localStorage.setItem(PREFS_KEY, JSON.stringify(p));
+  } catch {
+    /* localStorage full — settings still apply for the session */
+  }
+}

--- a/src/lib/playback.ts
+++ b/src/lib/playback.ts
@@ -57,10 +57,36 @@ export function isPlaying(): boolean {
   return currentlyPlaying;
 }
 
+export interface PlayOptions {
+  /** Bars of click before playback starts. 0 disables count-in. */
+  countInBars?: number;
+  /** Continuous click during playback at the score's tempo, accent on
+   *  beat 1 of each bar. */
+  metronome?: boolean;
+}
+
+/** Schedule a single short click — triangle blip with quick decay.
+ *  Higher pitch + louder gain for accents (bar-1 beat). */
+function scheduleClick(ctx: AudioContext, when: number, accent: boolean): void {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = "triangle";
+  osc.frequency.setValueAtTime(accent ? 1800 : 1200, when);
+  gain.gain.setValueAtTime(0, when);
+  gain.gain.linearRampToValueAtTime(accent ? 0.15 : 0.08, when + 0.005);
+  gain.gain.exponentialRampToValueAtTime(0.0001, when + 0.04);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(when);
+  osc.stop(when + 0.05);
+  osc.onended = () => { osc.disconnect(); gain.disconnect(); };
+}
+
 export async function playScore(
   score: Score,
   selection: NoteSelection | null,
   onProgress?: (measure: number, beat: number) => void,
+  options: PlayOptions = {},
 ): Promise<void> {
   if (currentlyPlaying) {
     stopPlayback();
@@ -159,7 +185,32 @@ export async function playScore(
   events.sort((a, b) => a.time - b.time);
 
   const totalDuration = (endMeasure - startMeasure + 1) * beatsPerMeasure * secPerBeat;
-  const startTime = ctx.currentTime + 0.05;
+  const countInBars = Math.max(0, Math.min(4, options.countInBars ?? 0));
+  const countInDuration = countInBars * beatsPerMeasure * secPerBeat;
+  // Push playback start past the count-in so the count-in clicks land
+  // before any notes do.
+  const startTime = ctx.currentTime + 0.05 + countInDuration;
+
+  // Count-in clicks: N bars at the same tempo, accent on beat 1.
+  if (countInBars > 0) {
+    const countInStart = ctx.currentTime + 0.05;
+    for (let bar = 0; bar < countInBars; bar++) {
+      for (let b = 0; b < beatsPerMeasure; b++) {
+        const t = countInStart + (bar * beatsPerMeasure + b) * secPerBeat;
+        scheduleClick(ctx, t, b === 0);
+      }
+    }
+  }
+
+  // Metronome: click on every beat for the duration of playback. Accent
+  // on beat 1 of each bar.
+  if (options.metronome) {
+    const totalBeats = (endMeasure - startMeasure + 1) * beatsPerMeasure;
+    for (let b = 0; b < totalBeats; b++) {
+      const t = startTime + b * secPerBeat;
+      scheduleClick(ctx, t, b % beatsPerMeasure === 0);
+    }
+  }
 
   // Schedule all notes
   const nodes: { osc: OscillatorNode; gain: GainNode }[] = [];
@@ -180,16 +231,24 @@ export async function playScore(
     nodes.push({ osc, gain });
   }
 
-  // Progress tracking loop
+  // Progress tracking loop. Account for count-in: the playhead is in
+  // the count-in until elapsed >= countInDuration. Report measure 0
+  // during count-in so the cursor doesn't jump around the score.
   const startWall = performance.now();
   while (!stopRequested) {
     const elapsed = (performance.now() - startWall) / 1000;
-    if (elapsed >= totalDuration) break;
+    const totalWithCountIn = countInDuration + totalDuration;
+    if (elapsed >= totalWithCountIn) break;
 
-    const beatPos = elapsed / secPerBeat;
-    const measure = startMeasure + Math.floor(beatPos / beatsPerMeasure);
-    const beat = 1 + (beatPos % beatsPerMeasure);
-    onProgress?.(measure, Math.round(beat * 100) / 100);
+    if (elapsed < countInDuration) {
+      onProgress?.(0, 1 + ((elapsed / secPerBeat) % beatsPerMeasure));
+    } else {
+      const playElapsed = elapsed - countInDuration;
+      const beatPos = playElapsed / secPerBeat;
+      const measure = startMeasure + Math.floor(beatPos / beatsPerMeasure);
+      const beat = 1 + (beatPos % beatsPerMeasure);
+      onProgress?.(measure, Math.round(beat * 100) / 100);
+    }
 
     await new Promise(r => setTimeout(r, 50));
   }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -177,10 +177,35 @@ export const ChordChartLineSchema = z.object({
 });
 export type ChordChartLine = z.infer<typeof ChordChartLineSchema>;
 
+/** Navigation marks attached to a chord-chart section. Common songbook
+ *  signals like "go back to start" (D.C.) or "end here" (Fine). Rendered
+ *  next to the section label in the editor and perform view. */
+export const ChordChartNavMark = z.enum([
+  "segno",         // 𝄋 — target marker for D.S.
+  "coda",          // 𝄌 — target marker for Coda jump
+  "to-coda",       // jump to Coda from end of this section
+  "fine",          // end the song here on a D.C./D.S.
+  "d.c.",          // Da Capo — go to start
+  "d.s.",          // Dal Segno — go to Segno
+  "d.c. al fine",
+  "d.s. al fine",
+  "d.c. al coda",
+  "d.s. al coda",
+]);
+export type ChordChartNavMark = z.infer<typeof ChordChartNavMark>;
+
 export const ChordChartSectionSchema = z.object({
   id: z.string(),                                  // unique ID, e.g. "V" or "verse-1"
   label: z.string(),                               // human label, e.g. "Verse 1"
   lines: z.array(ChordChartLineSchema).default([]),
+  /** Open repeat (𝄆) at the start of this section. */
+  repeatStart: z.boolean().optional(),
+  /** Close repeat (𝄇) at the end of this section. */
+  repeatEnd: z.boolean().optional(),
+  /** Volta number for first/second-ending brackets. Optional 1..4. */
+  endingNumber: z.number().int().min(1).max(4).optional(),
+  /** Navigation mark attached to this section. */
+  navMark: ChordChartNavMark.optional(),
 });
 export type ChordChartSection = z.infer<typeof ChordChartSectionSchema>;
 
@@ -341,6 +366,15 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
     op: z.literal("set_section_label"),
     sectionId: z.string(),
     label: z.string(),
+  }),
+  z.object({
+    op: z.literal("update_section"),
+    sectionId: z.string(),
+    /** null clears the field; absent leaves it unchanged. */
+    repeatStart: z.boolean().nullable().optional(),
+    repeatEnd: z.boolean().nullable().optional(),
+    endingNumber: z.number().int().min(1).max(4).nullable().optional(),
+    navMark: ChordChartNavMark.nullable().optional(),
   }),
   z.object({
     op: z.literal("add_section"),

--- a/src/store/score-store.ts
+++ b/src/store/score-store.ts
@@ -149,6 +149,10 @@ export interface UIState {
   /** Folder names the user has collapsed in My Songs. Persisted so the
    *  collapse state survives reloads. */
   collapsedFolders: string[];
+  /** Active folder filter for PerformView's song picker / prev-next nav.
+   *  Null means "all songs". When set to a folder name, prev/next and
+   *  the picker only see songs in that folder. Sticky across launches. */
+  performFolder: string | null;
 }
 
 export const DEFAULT_UI_STATE: UIState = {
@@ -158,6 +162,7 @@ export const DEFAULT_UI_STATE: UIState = {
   performMode: false,
   currentSongId: null,
   collapsedFolders: [],
+  performFolder: null,
 };
 
 export interface SavedRevision {


### PR DESCRIPTION
Two issues, two commits, one PR.

## #41 — Repeats and navigation marks (chord chart)

\`ChordChartSection\` schema gains four optional fields:
- \`repeatStart\` — open repeat barline 𝄆
- \`repeatEnd\` — close repeat barline 𝄇
- \`endingNumber\` — volta number (1..4) for first/second-ending brackets
- \`navMark\` — Segno / Coda / To Coda / Fine / D.C. al Fine / D.S. al Coda / etc. (10-value enum)

New patch op \`update_section\` toggles each independently with null-clears semantics.

UX: section-header right-click menu adds toggle items for each. Renderer shows badges next to the section label (volta number as a small bracket, repeat glyphs as text, nav mark as a small purple pill). \`PaginatedPerformChart\` mirrors the badges so the singer sees the cues during a song.

Notation-score side intentionally deferred — chord-chart usage is the actual daily use case.

## #43 — Count-in + metronome

\`playScore\` takes a new \`options\` arg:
- \`countInBars\` (0..4) — schedule N bars of triangle clicks before the first note. Accent on beat 1.
- \`metronome\` (boolean) — schedule clicks on every beat for the duration of playback. Accent on beat 1 of each bar.

Progress callback emits measure 0 during the count-in window so the playhead cursor doesn't jitter through invalid positions.

Two new toggles in the bottom playback bar:
- ♩ — metronome on/off
- +N — cycle count-in (0 / 1 / 2 bars)

Both go amber when active. Settings persist via a new \`playback-prefs.ts\` module (\`localStorage["notation-app-playback-prefs"]\`).

## Verification

- Open a chord chart, right-click a section header, toggle a Segno → 𝄋 pill appears next to the label. Toggle 𝄆 / 𝄇 / 1st ending — all render. Switch to perform view, badges show there too.
- Open a notation score with notes, hit Play. Tap ♩ → click track sounds. Tap +1 → one bar of count-in before the first note plays.

Type-check clean, dev server compiles. Both fixes safe to ship.