### PR TITLE
Autonomous batch 3 2026-05-06: palette, mute, slurs, presets, print

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -296,6 +296,23 @@ body {
     page-break-inside: avoid;
   }
 
+  /* Hide on-screen affordances that would otherwise leak into print:
+   * - selection-highlight: blue translucent range overlay
+   * - note-selected: blue tint + glow on a single note
+   * Step/playback cursors already carry .print-hide on their elements. */
+  .selection-highlight {
+    display: none !important;
+  }
+  .note-selected path,
+  .note-selected line,
+  .note-selected polygon {
+    fill: black !important;
+    stroke: black !important;
+  }
+  .note-selected {
+    filter: none !important;
+  }
+
   /* Show print overlays */
   .print-overlay {
     display: block !important;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import MenuBar from "@/components/MenuBar";
 import MidiKeyboard from "@/components/MidiKeyboard";
 import LyricEntryBar from "@/components/LyricEntryBar";
 import NoteContextMenu from "@/components/NoteContextMenu";
+import ArticulationsPalette from "@/components/ArticulationsPalette";
 import CommandPalette, { PaletteCommand } from "@/components/CommandPalette";
 import InlineAIPrompt from "@/components/InlineAIPrompt";
 import ChordChartView from "@/components/ChordChartView";
@@ -723,30 +724,33 @@ export default function Home() {
                 <AnnotationLayer />
               </div>
             ) : (
-              <div className="score-container h-full relative">
-                <ScoreRenderer
-                  score={score}
-                  zoom={zoom}
-                  layout={layout}
-                  onReady={(h) => { printFnRef.current = h.printScore; }}
-                  cursorPosition={cursorPosition}
-                  selectedNote={selectedNote}
-                  onScoreClick={handleScoreClick}
-                  selection={selection}
-                  playbackPosition={
-                    playbackPos
-                      ? {
-                          measure: playbackPos.measure,
-                          beat: playbackPos.beat,
-                          // Show on first staff during playback — most users have
-                          // a single staff anyway. A future improvement: track
-                          // which staff/voice each scheduled event came from.
-                          staffIndex: 0,
-                        }
-                      : null
-                  }
-                />
-                <AnnotationLayer />
+              <div className="score-container h-full flex flex-col relative">
+                <ArticulationsPalette selectedNote={selectedNote} />
+                <div className="flex-1 min-h-0 relative">
+                  <ScoreRenderer
+                    score={score}
+                    zoom={zoom}
+                    layout={layout}
+                    onReady={(h) => { printFnRef.current = h.printScore; }}
+                    cursorPosition={cursorPosition}
+                    selectedNote={selectedNote}
+                    onScoreClick={handleScoreClick}
+                    selection={selection}
+                    playbackPosition={
+                      playbackPos
+                        ? {
+                            measure: playbackPos.measure,
+                            beat: playbackPos.beat,
+                            // Show on first staff during playback — most users have
+                            // a single staff anyway. A future improvement: track
+                            // which staff/voice each scheduled event came from.
+                            staffIndex: 0,
+                          }
+                        : null
+                    }
+                  />
+                  <AnnotationLayer />
+                </div>
               </div>
             )
           ) : (

--- a/src/components/ArticulationsPalette.tsx
+++ b/src/components/ArticulationsPalette.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useScoreStore } from "@/store/score-store";
+
+interface ArticulationsPaletteProps {
+  selectedNote: { measure: number; beat: number; staffIndex: number; pitch: string } | null;
+}
+
+/** Always-visible palette of articulations + dynamics + accidentals, rendered
+ *  above the score in notation mode. Click a button to apply (or remove) the
+ *  marking on the currently-selected note. When nothing is selected the
+ *  palette shows in a disabled state with a hint. */
+export default function ArticulationsPalette({ selectedNote }: ArticulationsPaletteProps) {
+  const { score, applyPatches } = useScoreStore();
+
+  const target = (() => {
+    if (!score || !selectedNote) return null;
+    const staff = score.staves[selectedNote.staffIndex];
+    if (!staff) return null;
+    const voice = staff.voices[0];
+    if (!voice) return null;
+    const note = voice.notes.find(
+      (n) =>
+        n.measure === selectedNote.measure &&
+        Math.abs(n.beat - selectedNote.beat) < 0.05 &&
+        n.pitch === selectedNote.pitch,
+    );
+    if (!note) return null;
+    return { staff, voice, note };
+  })();
+
+  const enabled = !!target;
+
+  const toggleArticulation = (art: string) => {
+    if (!target) return;
+    const existing = target.note.articulations || [];
+    const arts = existing.includes(art as never)
+      ? existing.filter((a) => a !== art)
+      : [...existing, art as never];
+    applyPatches([
+      {
+        op: "update_note",
+        staffId: target.staff.id,
+        voiceId: target.voice.id,
+        measure: selectedNote!.measure,
+        beat: selectedNote!.beat,
+        pitch: selectedNote!.pitch,
+        updates: { articulations: arts },
+      },
+    ]);
+  };
+
+  const setDynamic = (dyn: string | undefined) => {
+    if (!target) return;
+    applyPatches([
+      {
+        op: "update_note",
+        staffId: target.staff.id,
+        voiceId: target.voice.id,
+        measure: selectedNote!.measure,
+        beat: selectedNote!.beat,
+        pitch: selectedNote!.pitch,
+        updates: { dynamic: dyn as never },
+      },
+    ]);
+  };
+
+  const setAccidental = (acc: "none" | "sharp" | "flat" | "natural") => {
+    if (!target) return;
+    applyPatches([
+      {
+        op: "update_note",
+        staffId: target.staff.id,
+        voiceId: target.voice.id,
+        measure: selectedNote!.measure,
+        beat: selectedNote!.beat,
+        pitch: selectedNote!.pitch,
+        updates: { accidental: acc },
+      },
+    ]);
+  };
+
+  const ARTS: { art: string; sym: string; title: string }[] = [
+    { art: "accent",          sym: ">",  title: "Accent" },
+    { art: "strong-accent",   sym: "^",  title: "Strong accent (marcato)" },
+    { art: "staccato",        sym: "·",  title: "Staccato" },
+    { art: "staccatissimo",   sym: "'",  title: "Staccatissimo" },
+    { art: "tenuto",          sym: "—",  title: "Tenuto" },
+    { art: "detached-legato", sym: "—·", title: "Detached legato" },
+    { art: "fermata",         sym: "𝄐",  title: "Fermata" },
+  ];
+
+  const DYNS = ["ppp", "pp", "p", "mp", "mf", "f", "ff", "fff"] as const;
+  const ACCS: { acc: "none" | "sharp" | "flat" | "natural"; sym: string }[] = [
+    { acc: "none",    sym: "♮" },
+    { acc: "sharp",   sym: "♯" },
+    { acc: "flat",    sym: "♭" },
+  ];
+
+  const activeArts = target?.note.articulations || [];
+  const activeDyn = target?.note.dynamic;
+  const activeAcc = target?.note.accidental || "none";
+
+  const btnBase = "px-1.5 py-0.5 text-[11px] rounded transition-colors";
+  const btnIdle = "bg-white/5 hover:bg-white/15 text-gray-300";
+  const btnActive = "bg-blue-500/30 text-blue-200 ring-1 ring-blue-400/40";
+  const btnDisabled = "opacity-40 cursor-not-allowed";
+
+  return (
+    <div className="print-hide flex items-center gap-3 px-3 py-1 bg-[#0f0f23] border-b border-white/10 text-xs">
+      {/* Articulations */}
+      <div className="flex items-center gap-1">
+        <span className="text-[10px] uppercase tracking-wider text-gray-500 mr-1">Artic</span>
+        {ARTS.map((a) => {
+          const on = activeArts.includes(a.art as never);
+          return (
+            <button
+              key={a.art}
+              onClick={() => toggleArticulation(a.art)}
+              disabled={!enabled}
+              title={a.title}
+              className={`${btnBase} ${!enabled ? btnDisabled : on ? btnActive : btnIdle}`}
+            >
+              {a.sym}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Accidentals */}
+      <div className="flex items-center gap-1">
+        <span className="text-[10px] uppercase tracking-wider text-gray-500 mr-1">Acc</span>
+        {ACCS.map((a) => {
+          const on = activeAcc === a.acc;
+          return (
+            <button
+              key={a.acc}
+              onClick={() => setAccidental(a.acc)}
+              disabled={!enabled}
+              title={a.acc}
+              className={`${btnBase} text-base ${!enabled ? btnDisabled : on ? btnActive : btnIdle}`}
+            >
+              {a.sym}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Dynamics */}
+      <div className="flex items-center gap-1">
+        <span className="text-[10px] uppercase tracking-wider text-gray-500 mr-1">Dyn</span>
+        {DYNS.map((d) => {
+          const on = activeDyn === d;
+          return (
+            <button
+              key={d}
+              onClick={() => setDynamic(on ? undefined : d)}
+              disabled={!enabled}
+              title={d}
+              className={`${btnBase} italic ${!enabled ? btnDisabled : on ? btnActive : btnIdle}`}
+            >
+              {d}
+            </button>
+          );
+        })}
+      </div>
+
+      {!enabled && (
+        <span className="text-[10px] text-gray-500 italic ml-auto">
+          Select a note to apply
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ChordChartView.tsx
+++ b/src/components/ChordChartView.tsx
@@ -48,6 +48,7 @@ import {
   ChordToken,
 } from "@/lib/chord-line";
 import ChordChartContextMenu, { ChordChartContextMenuItem } from "@/components/ChordChartContextMenu";
+import { transposeChordLine } from "@/lib/chord-transpose";
 
 interface ChordChartViewProps {
   score: Score;
@@ -844,6 +845,22 @@ export default function ChordChartView({ score, performMode = false, performColu
 
   const sectionMap = new Map(score.sections.map(s => [s.id, s]));
 
+  // Shift every chord token in every section by `semitones`. Bars and
+  // non-chord characters are preserved. Sharp/flat preference follows each
+  // token's own flavor (auto) so e.g. "C" → "Db" but "C" with sharp-leaning
+  // context stays sharp.
+  const transposeAllChords = (semitones: number) => {
+    const patches = score.sections.flatMap((section) =>
+      section.lines.map((line, lineIdx) => ({
+        op: "update_section_line" as const,
+        sectionId: section.id,
+        lineIdx,
+        chords: transposeChordLine(line.chords, semitones, "auto"),
+      })),
+    );
+    if (patches.length > 0) applyPatches(patches);
+  };
+
   // Each section has ONE physical position in the chart, in `score.sections`
   // order. The `form` field stays as playback metadata only (rendered at the
   // top of the header). If we ordered display by form, "Add section above
@@ -1361,6 +1378,30 @@ export default function ChordChartView({ score, performMode = false, performColu
           <span className="font-mono font-bold">|</span>
           <span>Bars{barMode ? " on" : ""}</span>
         </button>
+
+        {/* Transpose: shift every chord token in every section by ±1
+         * semitone. Sharp/flat preference follows the input's own
+         * accidental flavor per token (auto). For a key-aware shift the
+         * user can edit the score's keySignature separately. */}
+        <div className="inline-flex items-center gap-0.5 ml-1" title="Transpose all chords">
+          <button
+            type="button"
+            onClick={() => transposeAllChords(-1)}
+            className="px-1.5 py-0.5 rounded border bg-[#1a1a2e] border-gray-700 text-gray-300 hover:bg-[#22223a]"
+            aria-label="Transpose down a half-step"
+          >
+            ♭
+          </button>
+          <span className="text-[10px] uppercase tracking-wider px-1 text-gray-500">Trans</span>
+          <button
+            type="button"
+            onClick={() => transposeAllChords(+1)}
+            className="px-1.5 py-0.5 rounded border bg-[#1a1a2e] border-gray-700 text-gray-300 hover:bg-[#22223a]"
+            aria-label="Transpose up a half-step"
+          >
+            ♯
+          </button>
+        </div>
 
         <span className="font-semibold uppercase tracking-wider">Style:</span>
 

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -5,6 +5,7 @@ import { useScoreStore } from "@/store/score-store";
 import { scoreToMusicXML } from "@/lib/musicxml";
 import { downloadScoreAsMidi } from "@/lib/midi-export";
 import { downloadScoreAsChordPro } from "@/lib/chordpro-export";
+import { parseChordPro } from "@/lib/chordpro-import";
 import { ScoreSchema } from "@/lib/schema";
 import CloudSaveIndicator from "@/components/CloudSaveIndicator";
 import ModeSelector from "@/components/ModeSelector";
@@ -297,6 +298,27 @@ export default function MenuBar({
       return;
     }
 
+    // ChordPro family \u2014 pure client-side, works in static export.
+    if (filename.endsWith(".cho") || filename.endsWith(".crd") || filename.endsWith(".pro") || filename.endsWith(".chopro")) {
+      try {
+        const text = await file.text();
+        const { score: parsed, warnings } = parseChordPro(text);
+        const validated = ScoreSchema.safeParse(parsed);
+        if (!validated.success) {
+          addMessage({ id: uuidv4(), role: "assistant", content: `Import error: ${validated.error.issues.map(i => i.message).join(", ")}`, timestamp: Date.now() });
+          return;
+        }
+        setScore(validated.data);
+        const note = warnings.length ? ` (${warnings.join("; ")})` : "";
+        addMessage({ id: uuidv4(), role: "assistant", content: `Loaded ${file.name}${note}.`, timestamp: Date.now() });
+      } catch (err: any) {
+        addMessage({ id: uuidv4(), role: "assistant", content: `Import error: ${err.message}`, timestamp: Date.now() });
+      } finally {
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
+      return;
+    }
+
     if (IS_STATIC_EXPORT) {
       addMessage({ id: uuidv4(), role: "assistant", content: STATIC_FEATURE_DISABLED_MESSAGE, timestamp: Date.now() });
       return;
@@ -425,7 +447,7 @@ export default function MenuBar({
   return (
     <>
       {/* Hidden file inputs */}
-      <input ref={fileInputRef} type="file" accept=".mid,.midi,.snt,.musicxml,.mxl,.xml,.json" onChange={handleImport} className="hidden" />
+      <input ref={fileInputRef} type="file" accept=".mid,.midi,.snt,.musicxml,.mxl,.xml,.json,.cho,.crd,.pro,.chopro" onChange={handleImport} className="hidden" />
       <input ref={audioInputRef} type="file" accept=".mp3,.m4a,.wav,.aif,.aiff,.ogg,.flac,.mp4" onChange={handleTranscribe} className="hidden" />
       <input ref={projectInputRef} type="file" accept=".notation,.json" onChange={handleOpenProject} className="hidden" />
 

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useScoreStore } from "@/store/score-store";
 import { scoreToMusicXML } from "@/lib/musicxml";
+import { downloadScoreAsMidi } from "@/lib/midi-export";
 import { ScoreSchema } from "@/lib/schema";
 import CloudSaveIndicator from "@/components/CloudSaveIndicator";
 import ModeSelector from "@/components/ModeSelector";
@@ -213,6 +214,11 @@ export default function MenuBar({
     downloadFile(svgData, `${score?.title || "score"}.svg`, "image/svg+xml");
   };
 
+  const handleExportMidi = () => {
+    if (!score) return;
+    downloadScoreAsMidi(score);
+  };
+
   const handlePrint = () => {
     if (!score) return;
     if (onPrint) onPrint();
@@ -377,6 +383,7 @@ export default function MenuBar({
     { label: "Save Project", action: handleSaveProject, enabled: !!score },
     { separator: true },
     { label: "Export MusicXML", action: handleExportMusicXML, enabled: !!score },
+    { label: "Export MIDI", action: handleExportMidi, enabled: !!score },
     { label: "Export SVG", action: handleExportSVG, enabled: !!score },
     { label: "Export JSON", action: handleExportJSON, enabled: !!score },
     { separator: true },

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useScoreStore } from "@/store/score-store";
 import { scoreToMusicXML } from "@/lib/musicxml";
 import { downloadScoreAsMidi } from "@/lib/midi-export";
+import { downloadScoreAsChordPro } from "@/lib/chordpro-export";
 import { ScoreSchema } from "@/lib/schema";
 import CloudSaveIndicator from "@/components/CloudSaveIndicator";
 import ModeSelector from "@/components/ModeSelector";
@@ -219,6 +220,11 @@ export default function MenuBar({
     downloadScoreAsMidi(score);
   };
 
+  const handleExportChordPro = () => {
+    if (!score) return;
+    downloadScoreAsChordPro(score);
+  };
+
   const handlePrint = () => {
     if (!score) return;
     if (onPrint) onPrint();
@@ -384,6 +390,7 @@ export default function MenuBar({
     { separator: true },
     { label: "Export MusicXML", action: handleExportMusicXML, enabled: !!score },
     { label: "Export MIDI", action: handleExportMidi, enabled: !!score },
+    { label: "Export ChordPro", action: handleExportChordPro, enabled: !!(score && score.sections && score.sections.length > 0) },
     { label: "Export SVG", action: handleExportSVG, enabled: !!score },
     { label: "Export JSON", action: handleExportJSON, enabled: !!score },
     { separator: true },

--- a/src/components/MidiKeyboard.tsx
+++ b/src/components/MidiKeyboard.tsx
@@ -26,6 +26,42 @@ const DUR_LABELS: Record<string, string> = {
 // Letter-key pitch entry: A-G enter notes at sensible octaves relative to clef
 const PITCH_LETTERS = ["C", "D", "E", "F", "G", "A", "B"];
 
+/** Musical-typing keyboard layout: piano-style chromatic mapping that turns
+ *  a QWERTY keyboard into a one-row keyboard. Values are MIDI offsets from
+ *  the chromatic base octave (C of that octave = +0). */
+const MUSICAL_TYPING_MAP: Record<string, number> = {
+  // Lower-octave row — A through J carries the home-row whites,
+  // W/E/T/Y/U adds the blacks above them. Mirrors GarageBand / StaveNTabs.
+  a: 0,   // C
+  w: 1,   // C#
+  s: 2,   // D
+  e: 3,   // D#
+  d: 4,   // E
+  f: 5,   // F
+  t: 6,   // F#
+  g: 7,   // G
+  y: 8,   // G#
+  h: 9,   // A
+  u: 10,  // A#
+  j: 11,  // B
+  // Upper-octave continuation
+  k: 12,  // C
+  o: 13,  // C#
+  l: 14,  // D
+  p: 15,  // D#
+  ";": 16, // E
+  "'": 17, // F
+};
+
+const CHROMATIC_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+function midiOffsetToPitch(offset: number, baseOctave: number): string {
+  const total = baseOctave * 12 + offset;
+  const octave = Math.floor(total / 12);
+  const name = CHROMATIC_NAMES[((total % 12) + 12) % 12];
+  return `${name}${octave}`;
+}
+
 /** Resolve a pitch letter to octave nearest to lastPitch, defaulting by clef */
 function resolvePitch(letter: string, lastPitch: string | null, clef: string): string {
   const defaultOctave = clef === "bass" ? 3 : clef === "alto" ? 4 : 4;
@@ -78,10 +114,32 @@ export default function MidiKeyboard() {
   const [currentDuration, setCurrentDuration] = useState<string>("3"); // default quarter
   const [lastPitch, setLastPitch] = useState<string | null>(null);
 
+  // Musical-typing mode: piano-style chromatic mapping over QWERTY (#36).
+  // When on, A/W/S/E/D/F/T/G/Y/H/U/J/K/O/L/P/;/' enter chromatic pitches at
+  // a configurable base octave; ',' and '.' shift octave; '[' and ']'
+  // change duration. Toggle with the on-screen button or Cmd+Opt+K.
+  const [musicalTyping, setMusicalTyping] = useState(false);
+  const [chromaticOctave, setChromaticOctave] = useState(4);
+
   const midiRef = useRef<MidiKeyboardInput | null>(null);
   const activeKeysRef = useRef<Set<number>>(new Set());
   const stepEntryRef = useRef<StepEntryState | null>(null);
   stepEntryRef.current = stepEntry;
+
+  // Cmd+Opt+K (Mac) / Ctrl+Alt+K (Windows) — toggle musical typing mode.
+  // Lives in its own effect so it works regardless of whether step-entry
+  // is active. The chromatic key intercepts above only fire when step
+  // entry is on, but the user can pre-toggle with this shortcut.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.altKey && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        setMusicalTyping((m) => !m);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   const connectMidi = useCallback(async () => {
     if (midiRef.current) {
@@ -343,6 +401,60 @@ export default function MidiKeyboard() {
         return;
       }
 
+      // Musical-typing mode (#36): piano-style chromatic layout takes
+      // precedence over the A-G letter handler, comma/period octave
+      // shift, and the T tuplet shortcut. Numbers (1-7) still set
+      // duration. Disable musical typing to access tuplets.
+      if (musicalTyping && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const k = e.key;
+        const lower = k.length === 1 ? k.toLowerCase() : k;
+        // Octave shift
+        if (k === ",") {
+          e.preventDefault();
+          setChromaticOctave((o) => Math.max(0, o - 1));
+          return;
+        }
+        if (k === ".") {
+          e.preventDefault();
+          setChromaticOctave((o) => Math.min(8, o + 1));
+          return;
+        }
+        // Duration cycle via brackets
+        if (k === "[" || k === "]") {
+          e.preventDefault();
+          const order = ["1", "2", "3", "4", "5", "6", "7"];
+          const idx = order.indexOf(currentDuration);
+          if (idx >= 0) {
+            const nextIdx = k === "]"
+              ? Math.min(order.length - 1, idx + 1)
+              : Math.max(0, idx - 1);
+            setCurrentDuration(order[nextIdx]);
+          }
+          return;
+        }
+        // Rest
+        if (lower === "x") {
+          e.preventDefault();
+          const durInfo = DURATION_MAP[currentDuration];
+          if (!durInfo) return;
+          const tupletInfo = tupletMode ? { actualNotes: tupletMode.actualNotes, normalNotes: tupletMode.normalNotes } : undefined;
+          placeNote("rest", durInfo.dur, durInfo.beats, tupletInfo);
+          return;
+        }
+        // Chromatic pitch
+        if (Object.prototype.hasOwnProperty.call(MUSICAL_TYPING_MAP, lower)) {
+          e.preventDefault();
+          const durInfo = DURATION_MAP[currentDuration];
+          if (!durInfo) return;
+          const offset = MUSICAL_TYPING_MAP[lower];
+          const pitch = midiOffsetToPitch(offset, chromaticOctave);
+          const tupletInfo = tupletMode ? { actualNotes: tupletMode.actualNotes, normalNotes: tupletMode.normalNotes } : undefined;
+          placeNote(pitch, durInfo.dur, durInfo.beats, tupletInfo);
+          setLastPitch(pitch);
+          return;
+        }
+      }
+
       // Dot = add dot to last note
       if (e.key === ".") {
         e.preventDefault();
@@ -461,11 +573,22 @@ export default function MidiKeyboard() {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keyup", handleKeyUp);
     };
-  }, [stepEntry, score, spaceHeld, tupletMode, tupletPending, currentDuration, lastPitch, placeNote, addDotToLast, deleteLastNote, setStepEntry, stepBack]);
+  }, [stepEntry, score, spaceHeld, tupletMode, tupletPending, currentDuration, lastPitch, musicalTyping, chromaticOctave, placeNote, addDotToLast, deleteLastNote, setStepEntry, stepBack]);
 
   return (
     <div className="flex items-center gap-2">
       {/* MIDI connect */}
+      <button
+        onClick={() => setMusicalTyping((m) => !m)}
+        className={`px-2 py-1.5 text-xs font-medium rounded transition-colors ${
+          musicalTyping
+            ? "bg-blue-100 text-blue-700 ring-1 ring-blue-300"
+            : "text-gray-600 bg-gray-100 hover:bg-gray-200"
+        }`}
+        title="Musical typing — turn QWERTY into a chromatic piano (A=C, W=C#, S=D, …). Octave: , / .  Duration: [ / ]  Rest: X"
+      >
+        {musicalTyping ? `♪ Type · O${chromaticOctave}` : "♪ Type"}
+      </button>
       {!connected ? (
         <button
           onClick={connectMidi}

--- a/src/components/NoteContextMenu.tsx
+++ b/src/components/NoteContextMenu.tsx
@@ -133,6 +133,36 @@ export default function NoteContextMenu({ x, y, note, onClose, onLyricEdit, onAI
     });
   };
 
+  const toggleSlurStart = () => {
+    if (!scoreNote) return;
+    doAction(() => {
+      applyPatches([{
+        op: "update_note",
+        staffId: staff.id,
+        voiceId: voice.id,
+        measure: note.measure,
+        beat: note.beat,
+        pitch: note.pitch,
+        updates: { slurStart: !scoreNote.slurStart },
+      }]);
+    });
+  };
+
+  const toggleSlurEnd = () => {
+    if (!scoreNote) return;
+    doAction(() => {
+      applyPatches([{
+        op: "update_note",
+        staffId: staff.id,
+        voiceId: voice.id,
+        measure: note.measure,
+        beat: note.beat,
+        pitch: note.pitch,
+        updates: { slurEnd: !scoreNote.slurEnd },
+      }]);
+    });
+  };
+
   const setAccidental = (acc: "sharp" | "flat" | "natural" | "none") => {
     doAction(() => {
       applyPatches([{
@@ -227,6 +257,37 @@ export default function NoteContextMenu({ x, y, note, onClose, onLyricEdit, onAI
       <button onClick={toggleTie} className="w-full text-left px-3 py-1.5 hover:bg-gray-50 flex justify-between">
         <span>{scoreNote?.tieStart ? "Remove Tie" : "Add Tie"}</span>
       </button>
+
+      {/* Slur — separate from tie. Slur connects different pitches into a
+       *  phrase; tie joins identical pitches. Use slurStart on the first
+       *  note of the phrase, slurEnd on the last. */}
+      <div className="border-t border-gray-100 px-1 py-1">
+        <div className="px-2 py-0.5 text-[10px] text-gray-400 uppercase">Slur</div>
+        <div className="flex gap-0.5 px-2">
+          <button
+            onClick={toggleSlurStart}
+            className={`px-2 py-0.5 text-xs rounded transition-colors ${
+              scoreNote?.slurStart
+                ? "bg-blue-100 text-blue-700 font-medium"
+                : "hover:bg-gray-100 text-gray-600"
+            }`}
+            title="Start a slur on this note"
+          >
+            ⌒ Start
+          </button>
+          <button
+            onClick={toggleSlurEnd}
+            className={`px-2 py-0.5 text-xs rounded transition-colors ${
+              scoreNote?.slurEnd
+                ? "bg-blue-100 text-blue-700 font-medium"
+                : "hover:bg-gray-100 text-gray-600"
+            }`}
+            title="End a slur on this note"
+          >
+            ⌒ End
+          </button>
+        </div>
+      </div>
 
       {/* Accidentals */}
       <div className="border-t border-gray-100 px-1 py-1">

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useScoreStore, DEFAULT_LAYOUT, PRINT_LAYOUT, REALBOOK_LAYOUT, STYLE_PRESETS, StylePreset, LayoutSettings, MusicFont, TextFont, PageSize } from "@/store/score-store";
+import { downloadScoreAsMidi } from "@/lib/midi-export";
 import { KeySignature, Clef } from "@/lib/schema";
 import { v4 as uuidv4 } from "uuid";
 import RevisionPanel from "./RevisionPanel";
@@ -79,6 +80,13 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
                       title={staff.hidden ? "Show this staff in the score" : "Hide this staff from the score (data preserved)"}
                     >
                       {staff.hidden ? "Hidden" : "Hide"}
+                    </button>
+                    <button
+                      onClick={() => downloadScoreAsMidi(score, { staffId: staff.id })}
+                      className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-white/10 text-gray-300 hover:bg-white/15 transition-colors"
+                      title={`Export this staff as a single-track MIDI file`}
+                    >
+                      .mid
                     </button>
                     {score.staves.length > 1 && (
                       <button onClick={() => applyPatches([{ op: "remove_staff", staffId: staff.id }])} className="text-[10px] text-red-400/60 hover:text-red-400">Remove</button>

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -65,9 +65,18 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
                   onChange={(v) => applyPatches([{ op: "update_staff", staffId: staff.id, clef: v as Clef }])} />
                 <div className="flex items-center justify-between">
                   <span className="text-[10px] text-gray-500">{staff.voices.length}v, {staff.voices.reduce((n, v) => n + v.notes.length, 0)} notes</span>
-                  {score.staves.length > 1 && (
-                    <button onClick={() => applyPatches([{ op: "remove_staff", staffId: staff.id }])} className="text-[10px] text-red-400/60 hover:text-red-400">Remove</button>
-                  )}
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => applyPatches([{ op: "update_staff", staffId: staff.id, muted: !staff.muted }])}
+                      className={`px-1.5 py-0.5 text-[10px] font-medium rounded transition-colors ${staff.muted ? "bg-orange-500/30 text-orange-200" : "bg-white/10 text-gray-300 hover:bg-white/15"}`}
+                      title={staff.muted ? "Unmute (include this staff in playback)" : "Mute (silent during playback)"}
+                    >
+                      {staff.muted ? "Muted" : "Mute"}
+                    </button>
+                    {score.staves.length > 1 && (
+                      <button onClick={() => applyPatches([{ op: "remove_staff", staffId: staff.id }])} className="text-[10px] text-red-400/60 hover:text-red-400">Remove</button>
+                    )}
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -73,6 +73,13 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
                     >
                       {staff.muted ? "Muted" : "Mute"}
                     </button>
+                    <button
+                      onClick={() => applyPatches([{ op: "update_staff", staffId: staff.id, hidden: !staff.hidden }])}
+                      className={`px-1.5 py-0.5 text-[10px] font-medium rounded transition-colors ${staff.hidden ? "bg-purple-500/30 text-purple-200" : "bg-white/10 text-gray-300 hover:bg-white/15"}`}
+                      title={staff.hidden ? "Show this staff in the score" : "Hide this staff from the score (data preserved)"}
+                    >
+                      {staff.hidden ? "Hidden" : "Hide"}
+                    </button>
                     {score.staves.length > 1 && (
                       <button onClick={() => applyPatches([{ op: "remove_staff", staffId: staff.id }])} className="text-[10px] text-red-400/60 hover:text-red-400">Remove</button>
                     )}

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -85,7 +85,7 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
 
         {/* Style & Layout */}
         <PropSection title="Style" defaultOpen>
-          <div className="flex gap-1 mb-3">
+          <div className="flex flex-wrap gap-1 mb-3">
             {(Object.entries(STYLE_PRESETS) as [StylePreset, { label: string; layout: LayoutSettings }][]).map(([key, preset]) => {
               const isActive = layout.musicFont === preset.layout.musicFont && layout.textFont === preset.layout.textFont;
               return (
@@ -314,7 +314,7 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
           <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
             Style
           </h3>
-          <div className="flex gap-1 mb-3">
+          <div className="flex flex-wrap gap-1 mb-3">
             {(Object.entries(STYLE_PRESETS) as [StylePreset, { label: string; layout: LayoutSettings }][]).map(([key, preset]) => {
               const isActive = layout.musicFont === preset.layout.musicFont && layout.textFont === preset.layout.textFont;
               return (
@@ -330,7 +330,7 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
           <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
             Layout
           </h3>
-          <div className="flex gap-1 mb-3">
+          <div className="flex flex-wrap gap-1 mb-3">
             <button
               onClick={() => setLayout({ compactMode: !layout.compactMode })}
               className={`px-2 py-1 text-[10px] font-medium rounded transition-colors ${

--- a/src/lib/chord-transpose.ts
+++ b/src/lib/chord-transpose.ts
@@ -1,0 +1,115 @@
+/**
+ * Chord-chart transpose helper.
+ *
+ * Walks a chord-chart line (text like "C  G/B  Am F#m7") and shifts every
+ * chord token by N semitones, preserving bars, suffixes, and bass-note
+ * slashes. Sharp/flat preference is chosen to match the new key — if the
+ * destination is e.g. F major, accidentals come out as flats; if D major,
+ * sharps. Caller passes the destination preference explicitly when known.
+ */
+
+const SHARP_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+const FLAT_NAMES  = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+
+const NAME_TO_SEMITONE: Record<string, number> = {
+  C: 0, "C#": 1, Db: 1, D: 2, "D#": 3, Eb: 3, E: 4, Fb: 4, "E#": 5, F: 5,
+  "F#": 6, Gb: 6, G: 7, "G#": 8, Ab: 8, A: 9, "A#": 10, Bb: 10, B: 11, Cb: 11,
+};
+
+export type Accidental = "sharp" | "flat" | "auto";
+
+function transposeRoot(root: string, semitones: number, prefer: Accidental): string {
+  const semi = NAME_TO_SEMITONE[root];
+  if (semi === undefined) return root;
+  const newSemi = ((semi + semitones) % 12 + 12) % 12;
+  if (prefer === "flat") return FLAT_NAMES[newSemi];
+  if (prefer === "sharp") return SHARP_NAMES[newSemi];
+  // Auto: keep the input's accidental flavor when possible. If input had a
+  // flat letter, prefer flat; if sharp, prefer sharp; otherwise sharp.
+  if (root.includes("b") || root.includes("♭")) return FLAT_NAMES[newSemi];
+  return SHARP_NAMES[newSemi];
+}
+
+/** Match a single chord-token at the start of a string. Returns the matched
+ *  text (root + suffix + optional /bass) and its length, or null if no
+ *  chord starts here. */
+function matchChordAt(text: string, start: number): { token: string; length: number } | null {
+  // Root: A-G plus optional accidental
+  const rootMatch = /^[A-G][b#♭♯]?/.exec(text.slice(start));
+  if (!rootMatch) return null;
+  let i = start + rootMatch[0].length;
+  // Suffix: chord quality / extensions — letters, digits, +, °, ø, parens,
+  // commas. Stop at whitespace or '|' or '/' (bass-note follows).
+  while (i < text.length && /[a-zA-Z0-9+°ø()Δ△,#♯b♭\-]/.test(text[i])) i++;
+  // Optional bass note after a slash
+  if (text[i] === "/") {
+    const bassMatch = /^\/[A-G][b#♭♯]?/.exec(text.slice(i));
+    if (bassMatch) i += bassMatch[0].length;
+  }
+  return { token: text.slice(start, i), length: i - start };
+}
+
+/** Split a chord token into root, suffix, bass-root, bass-acc.
+ *  e.g. "F#m7/A" -> { root: "F#", suffix: "m7", bass: "A" }. */
+function splitChordToken(token: string): { root: string; suffix: string; bass?: string } {
+  const m = /^([A-G][b#♭♯]?)(.*)$/.exec(token);
+  if (!m) return { root: token, suffix: "" };
+  let suffix = m[2];
+  let bass: string | undefined;
+  const slash = suffix.indexOf("/");
+  if (slash >= 0) {
+    const bassPart = suffix.slice(slash + 1);
+    const bassMatch = /^[A-G][b#♭♯]?/.exec(bassPart);
+    if (bassMatch) {
+      bass = bassMatch[0];
+      suffix = suffix.slice(0, slash);
+    }
+  }
+  return { root: m[1], suffix, bass };
+}
+
+function normalizeAccidental(s: string): string {
+  return s.replace(/♯/g, "#").replace(/♭/g, "b");
+}
+
+/** Transpose a single chord token. Preserves the suffix and bass note. */
+export function transposeChordToken(
+  token: string,
+  semitones: number,
+  prefer: Accidental = "auto",
+): string {
+  const norm = normalizeAccidental(token);
+  const parts = splitChordToken(norm);
+  const newRoot = transposeRoot(parts.root, semitones, prefer);
+  const newBass = parts.bass ? transposeRoot(parts.bass, semitones, prefer) : undefined;
+  return newRoot + parts.suffix + (newBass ? "/" + newBass : "");
+}
+
+/** Walk a chord-chart line, replacing each chord token with its transposed
+ *  equivalent. Bars, spaces, and any non-chord characters pass through
+ *  untouched so column alignment is preserved as much as possible (note:
+ *  if a transposed token has a different length, columns will shift). */
+export function transposeChordLine(
+  line: string,
+  semitones: number,
+  prefer: Accidental = "auto",
+): string {
+  let out = "";
+  let i = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    // Only attempt chord-match on uppercase A-G — skip everything else
+    // verbatim so bars, spaces, commas etc. survive.
+    if (ch >= "A" && ch <= "G") {
+      const m = matchChordAt(line, i);
+      if (m) {
+        out += transposeChordToken(m.token, semitones, prefer);
+        i += m.length;
+        continue;
+      }
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}

--- a/src/lib/chordpro-export.ts
+++ b/src/lib/chordpro-export.ts
@@ -1,0 +1,109 @@
+/**
+ * ChordPro export — convert a chord-chart Score into the widely-used
+ * ChordPro format (.cho / .crd / .pro). Lets users pull songs into
+ * OnSong, SongBook, ChordPro readers, etc.
+ *
+ * Format:
+ *   {title: ...}
+ *   {artist: ...}
+ *   {key: ...}
+ *   {tempo: ...}
+ *
+ *   {c: Verse 1}
+ *   [C]Hello [Am]world how [F]are you to[G]day
+ *
+ * Our internal model has the chord line and the lyric line stored as two
+ * separate columns-aligned strings. Reconstructing inline-bracket form means
+ * walking the chord line, finding each chord token's start column, and
+ * splicing "[chord]" into the lyric line at that column.
+ */
+
+import { Score } from "./schema";
+
+/** Match a chord-or-bar token that may appear on the chords line. We treat
+ *  bars as separate emissions because ChordPro carries them inline as `|`
+ *  too (some readers honor them, others ignore — either way they're
+ *  preserved). */
+const CHORD_TOKEN_RE = /[A-G][b#♭♯]?[a-zA-Z0-9+°ø()Δ△,#♯b♭\-]*(?:\/[A-G][b#♭♯]?)?|\|/g;
+
+interface PlacedToken {
+  col: number;
+  text: string;
+}
+
+function tokenizeChordLine(line: string): PlacedToken[] {
+  const out: PlacedToken[] = [];
+  CHORD_TOKEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = CHORD_TOKEN_RE.exec(line)) !== null) {
+    out.push({ col: m.index, text: m[0] });
+  }
+  return out;
+}
+
+/** Splice "[chord]" markers into a lyric line at the columns where chords
+ *  start. Tokens past the end of the lyric line are appended at the end. */
+function mergeChordsIntoLyric(chordLine: string, lyricLine: string): string {
+  const tokens = tokenizeChordLine(chordLine);
+  if (tokens.length === 0) return lyricLine;
+
+  // Pad lyric with spaces so any chord column past the lyric end has room.
+  const lastCol = tokens[tokens.length - 1].col;
+  const padded = lyricLine.padEnd(lastCol + 1, " ");
+
+  // Splice from rightmost to leftmost so earlier insertions don't shift
+  // the indices of later ones.
+  let result = padded;
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const t = tokens[i];
+    const before = result.slice(0, t.col);
+    const after = result.slice(t.col);
+    const marker = t.text === "|" ? "|" : `[${t.text}]`;
+    result = before + marker + after;
+  }
+  return result.trimEnd();
+}
+
+export function scoreToChordPro(score: Score): string {
+  const lines: string[] = [];
+
+  // Headers — ChordPro's standard directives.
+  if (score.title) lines.push(`{title: ${score.title}}`);
+  if (score.composer) lines.push(`{artist: ${score.composer}}`);
+  if (score.keySignature) lines.push(`{key: ${score.keySignature}}`);
+  if (score.tempo) lines.push(`{tempo: ${score.tempo}}`);
+  lines.push("");
+
+  // Optional form line as a comment so it survives roundtrip even though
+  // ChordPro has no native concept of song form.
+  if (score.form && score.form.length > 0) {
+    lines.push(`{comment: Form — ${score.form.join(" → ")}}`);
+    lines.push("");
+  }
+
+  for (const section of score.sections || []) {
+    // Section label as a ChordPro `{c:}` (comment) directive — most
+    // readers render this as a section heading.
+    lines.push(`{c: ${section.label}}`);
+    for (const line of section.lines) {
+      const merged = mergeChordsIntoLyric(line.chords ?? "", line.lyrics ?? "");
+      lines.push(merged);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+}
+
+export function downloadScoreAsChordPro(score: Score): void {
+  const text = scoreToChordPro(score);
+  const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${score.title || "song"}.cho`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/chordpro-import.ts
+++ b/src/lib/chordpro-import.ts
@@ -1,0 +1,193 @@
+/**
+ * ChordPro import — parse a .cho/.crd/.pro/.txt file into a Score with
+ * chord-chart sections. Handles the common subset:
+ *
+ *   {title: ...} {artist: ...} {key: ...} {tempo: ...}
+ *   {c: Section Label}        — also {comment:}, {start_of_chorus}, etc.
+ *   [C]Hello [G]world         — inline-bracket chord lines
+ *
+ * Inline-bracket chord text is split into our two-line representation:
+ * a chords line with chord tokens at column N, and a lyrics line that
+ * contains everything else with the chord position implied by alignment.
+ * The format is what `scoreToChordPro` emits, so roundtrip is loss-tolerant.
+ */
+
+import { Score, ChordChartSection } from "./schema";
+import { v4 as uuidv4 } from "uuid";
+
+interface SectionInProgress {
+  id: string;
+  label: string;
+  lines: { chords: string; lyrics: string }[];
+}
+
+function splitInlineLine(raw: string): { chords: string; lyrics: string } {
+  // Walk the raw text. Each `[token]` becomes a chord placed at the
+  // current column of the lyric output.
+  let lyrics = "";
+  let chords = "";
+  let i = 0;
+  while (i < raw.length) {
+    if (raw[i] === "[") {
+      const end = raw.indexOf("]", i + 1);
+      if (end === -1) {
+        // Unterminated bracket — drop into lyrics verbatim
+        lyrics += raw.slice(i);
+        break;
+      }
+      const token = raw.slice(i + 1, end);
+      // Pad chord line out to current lyric column, then write the token.
+      while (chords.length < lyrics.length) chords += " ";
+      chords += token;
+      i = end + 1;
+      continue;
+    }
+    lyrics += raw[i];
+    i++;
+  }
+  // Trim trailing chord-only padding.
+  return {
+    chords: chords.replace(/\s+$/, ""),
+    lyrics: lyrics.replace(/\s+$/, ""),
+  };
+}
+
+const DIRECTIVE_RE = /^\{\s*([a-zA-Z_]+)\s*(?::\s*(.*?))?\s*\}\s*$/;
+
+export interface ChordProImportResult {
+  score: Score;
+  warnings: string[];
+}
+
+export function parseChordPro(text: string): ChordProImportResult {
+  const warnings: string[] = [];
+  let title = "Imported Song";
+  let composer = "";
+  let key: Score["keySignature"] = "C";
+  let tempo = 120;
+  const sections: ChordChartSection[] = [];
+  let current: SectionInProgress | null = null;
+
+  const startSection = (label: string) => {
+    current = {
+      id: uuidv4().slice(0, 8),
+      label,
+      lines: [],
+    };
+    sections.push(current);
+  };
+
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+
+  for (const raw of lines) {
+    const trimmed = raw.trim();
+    if (trimmed === "") continue;
+
+    const dirMatch = DIRECTIVE_RE.exec(trimmed);
+    if (dirMatch) {
+      const [, name, value] = dirMatch;
+      const v = (value ?? "").trim();
+      switch (name.toLowerCase()) {
+        case "title":
+        case "t":
+          title = v || title;
+          break;
+        case "artist":
+        case "subtitle":
+        case "st":
+          composer = v || composer;
+          break;
+        case "key":
+          if (v) {
+            // Coerce to one of our supported key labels — anything else is
+            // recorded as a warning but doesn't fail the import.
+            const allowed = new Set([
+              "C", "G", "D", "A", "E", "B", "F#", "Gb", "Db", "Ab", "Eb",
+              "Bb", "F", "Am", "Em", "Bm", "F#m", "C#m", "G#m", "D#m",
+              "A#m", "Bbm", "Dm", "Gm", "Cm", "Fm", "Ebm",
+            ]);
+            if (allowed.has(v)) {
+              key = v as Score["keySignature"];
+            } else {
+              warnings.push(`Unknown key "${v}", defaulting to C.`);
+            }
+          }
+          break;
+        case "tempo": {
+          const n = parseInt(v, 10);
+          if (!isNaN(n) && n > 0) tempo = n;
+          break;
+        }
+        case "c":
+        case "comment":
+          // Comments often carry section labels in the wild. Heuristic:
+          // if it's short-ish and not already in a section, start one.
+          if (v && v.length <= 32) {
+            startSection(v);
+          } else if (v) {
+            // Long comments → preserve as a one-line lyrics-only entry.
+            if (!current) startSection("Verse 1");
+            current!.lines.push({ chords: "", lyrics: v });
+          }
+          break;
+        case "start_of_chorus":
+        case "soc":
+          startSection("Chorus");
+          break;
+        case "start_of_verse":
+        case "sov":
+          startSection(`Verse ${sections.filter(s => s.label.startsWith("Verse")).length + 1}`);
+          break;
+        case "start_of_bridge":
+        case "sob":
+          startSection("Bridge");
+          break;
+        case "end_of_chorus":
+        case "eoc":
+        case "end_of_verse":
+        case "eov":
+        case "end_of_bridge":
+        case "eob":
+          // No-op — section just ends; the next directive or lyric line
+          // will start a new section if needed.
+          break;
+        default:
+          // Unknown directive — silently drop.
+          break;
+      }
+      continue;
+    }
+
+    // Body line — inline brackets.
+    if (!current) startSection("Verse 1");
+    current!.lines.push(splitInlineLine(raw));
+  }
+
+  // Fallback: empty section list means we have a truly bare file. Make
+  // one section with a placeholder so the chord-chart view renders.
+  if (sections.length === 0) {
+    startSection("Verse 1");
+    current!.lines.push({ chords: "", lyrics: "" });
+  }
+
+  const score: Score = {
+    id: uuidv4(),
+    title,
+    composer,
+    tempo,
+    timeSignature: "4/4",
+    keySignature: key,
+    measures: 1,
+    anacrusis: false,
+    staves: [],
+    chordSymbols: [],
+    rehearsalMarks: [],
+    repeats: [],
+    sections,
+    form: [],
+    annotations: [],
+    metadata: {},
+  };
+
+  return { score, warnings };
+}

--- a/src/lib/midi-export.ts
+++ b/src/lib/midi-export.ts
@@ -1,0 +1,158 @@
+/**
+ * MIDI export — convert a Score into a Type-1 MIDI file (#14).
+ *
+ * Strategy: one MIDI track per visible (non-hidden) staff. Tied notes are
+ * merged into a single longer note on the starting beat. Dots and tuplets
+ * scale durations; rests advance the playhead but emit no note.
+ *
+ * Tempo, time signature, and key signature are written into the header so
+ * the imported result lines up with our internal representation.
+ */
+
+import { Midi } from "@tonejs/midi";
+import { Score, Note } from "./schema";
+
+const PITCH_TO_MIDI_BASE: Record<string, number> = {
+  C: 0, "C#": 1, Db: 1, D: 2, "D#": 3, Eb: 3, E: 4, Fb: 4, F: 5,
+  "E#": 5, "F#": 6, Gb: 6, G: 7, "G#": 8, Ab: 8, A: 9, "A#": 10,
+  Bb: 10, B: 11, Cb: 11, "B#": 12,
+};
+
+const DUR_BEATS: Record<string, number> = {
+  whole: 4, half: 2, quarter: 1, eighth: 0.5, sixteenth: 0.25,
+  "thirty-second": 0.125, "sixty-fourth": 0.0625,
+};
+
+/** Convert a scientific pitch ("C4", "F#3", "Bb5") into a MIDI number. */
+function pitchToMidi(pitch: string): number | null {
+  if (pitch === "rest") return null;
+  const match = pitch.match(/^([A-G][b#]?)(-?\d+)$/);
+  if (!match) return null;
+  const [, name, octStr] = match;
+  const base = PITCH_TO_MIDI_BASE[name];
+  if (base === undefined) return null;
+  const octave = parseInt(octStr, 10);
+  return (octave + 1) * 12 + base;
+}
+
+/** Compute a note's duration in beats, accounting for dots and tuplets. */
+function noteBeats(note: Note): number {
+  let beats = DUR_BEATS[note.duration] ?? 1;
+  if (note.dots === 1) beats *= 1.5;
+  if (note.dots === 2) beats *= 1.75;
+  if (note.tuplet) beats *= note.tuplet.normalNotes / note.tuplet.actualNotes;
+  return beats;
+}
+
+export interface MidiExportOptions {
+  /** Restrict export to a single staff id. When omitted, every visible
+   *  (non-hidden) staff becomes its own MIDI track. */
+  staffId?: string;
+}
+
+/** Build a Type-1 MIDI file from a Score. Returns the raw bytes ready to be
+ *  saved with `new Blob([...])`. */
+export function scoreToMidi(score: Score, options: MidiExportOptions = {}): Uint8Array {
+  const midi = new Midi();
+  const bpm = score.tempo || 120;
+  midi.header.setTempo(bpm);
+
+  const [tsNum, tsDen] = score.timeSignature.split("/").map(Number);
+  // tonejs-midi expects a [num, den] tuple where den is the actual lower
+  // number of the time signature (4 for 4/4, 8 for 6/8 etc).
+  midi.header.timeSignatures.push({ ticks: 0, timeSignature: [tsNum, tsDen] });
+
+  const beatsPerMeasure = tsNum * (4 / tsDen);
+  const secPerBeat = 60 / bpm;
+
+  const sourceStaves = score.staves.filter((s) => {
+    if (s.hidden) return false;
+    if (options.staffId && s.id !== options.staffId) return false;
+    return true;
+  });
+
+  for (const staff of sourceStaves) {
+    const track = midi.addTrack();
+    track.name = staff.name;
+
+    for (const voice of staff.voices) {
+      // Sort notes by absolute beat position so tie chains can be resolved
+      // forward — tie continuations are skipped after merging into the
+      // starting note's duration.
+      const sorted = [...voice.notes]
+        .filter((n) => n.pitch !== "rest")
+        .sort((a, b) => a.measure - b.measure || a.beat - b.beat);
+
+      const skip = new Set<string>();
+      for (const note of sorted) {
+        if (note.tieEnd) {
+          skip.add(`${note.measure}:${note.beat}:${note.pitch}`);
+        }
+      }
+
+      for (const note of sorted) {
+        const key = `${note.measure}:${note.beat}:${note.pitch}`;
+        if (skip.has(key)) continue;
+
+        const midiNum = pitchToMidi(note.pitch);
+        if (midiNum == null) continue;
+
+        // Walk the tie chain forward, accumulating duration onto the
+        // starting note. Each subsequent tied note is already in `skip`
+        // so it won't be emitted again.
+        let beats = noteBeats(note);
+        if (note.tieStart) {
+          let current = note;
+          while (current.tieStart) {
+            const next = sorted.find((n) =>
+              n.tieEnd &&
+              n.pitch === current.pitch &&
+              (n.measure > current.measure ||
+                (n.measure === current.measure && n.beat > current.beat))
+            );
+            if (!next) break;
+            beats += noteBeats(next);
+            if (next.tieStart) current = next;
+            else break;
+          }
+        }
+
+        const measureOffset = (note.measure - 1) * beatsPerMeasure;
+        const beatOffset = note.beat - 1;
+        const timeSec = (measureOffset + beatOffset) * secPerBeat;
+        const durSec = beats * secPerBeat;
+
+        track.addNote({
+          midi: midiNum,
+          time: timeSec,
+          duration: durSec,
+          velocity: 0.78,
+        });
+      }
+    }
+  }
+
+  return midi.toArray();
+}
+
+/** Convenience helper — bundles `scoreToMidi` with a download trigger.
+ *  Pass an optional staffId to export a single staff. */
+export function downloadScoreAsMidi(score: Score, options: MidiExportOptions = {}): void {
+  const bytes = scoreToMidi(score, options);
+  // Wrap in a fresh ArrayBuffer view so the Blob constructor accepts it
+  // — the typed-array signature is fussy about SharedArrayBuffer overlap
+  // even when the underlying buffer is a regular ArrayBuffer.
+  const buf = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  const blob = new Blob([buf], { type: "audio/midi" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  const suffix = options.staffId
+    ? `-${score.staves.find((s) => s.id === options.staffId)?.name || "staff"}`
+    : "";
+  a.href = url;
+  a.download = `${score.title || "score"}${suffix}.mid`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/musicxml.ts
+++ b/src/lib/musicxml.ts
@@ -193,9 +193,11 @@ export function scoreToMusicXML(score: Score): string {
     lines.push("  </identification>");
   }
 
-  // Part list
+  // Part list — hidden staves are omitted entirely so OSMD doesn't allocate
+  // a system slot for them. Their notes remain in the data model.
+  const visibleStaves = score.staves.filter((s) => !s.hidden);
   lines.push("  <part-list>");
-  for (const staff of score.staves) {
+  for (const staff of visibleStaves) {
     lines.push(`    <score-part id="${esc(staff.id)}">`);
     lines.push(
       `      <part-name>${esc(staff.name)}</part-name>`
@@ -219,9 +221,10 @@ export function scoreToMusicXML(score: Score): string {
   // Measure duration in divisions
   const measureDivisions = beats * (64 / beatType);
 
-  // Parts
-  for (let si = 0; si < score.staves.length; si++) {
-    const staff = score.staves[si];
+  // Parts — iterate visibleStaves so isFirstPart correctly identifies the
+  // first emitted part (used to attach time/key signature attributes).
+  for (let si = 0; si < visibleStaves.length; si++) {
+    const staff = visibleStaves[si];
     const clef = clefToMusicXML(staff.clef);
     const isFirstPart = si === 0;
 

--- a/src/lib/musicxml.ts
+++ b/src/lib/musicxml.ts
@@ -511,10 +511,16 @@ function emitVoiceNotes(
     const nonFermataArticulations = note.articulations?.filter((a: Articulation) => a !== "fermata") ?? [];
     const hasTupletStart = note.tuplet && isTupletStart(notes, ni);
     const hasTupletStop = note.tuplet && isTupletEnd(notes, ni);
-    if (note.tieStart || note.tieEnd || hasArticulations || hasTupletStart || hasTupletStop) {
+    const hasSlur = note.slurStart || note.slurEnd;
+    if (note.tieStart || note.tieEnd || hasArticulations || hasTupletStart || hasTupletStop || hasSlur) {
       lines.push("        <notations>");
       if (note.tieEnd) lines.push('          <tied type="stop"/>');
       if (note.tieStart) lines.push('          <tied type="start"/>');
+      // Slur — number=1 keeps overlapping slurs distinct in MusicXML; OSMD
+      // pairs each <slur type="start"/> with the next <slur type="stop"/>
+      // by number.
+      if (note.slurEnd) lines.push('          <slur number="1" type="stop"/>');
+      if (note.slurStart) lines.push('          <slur number="1" type="start"/>');
       if (hasTupletStart) lines.push('          <tuplet type="start"/>');
       if (hasTupletStop) lines.push('          <tuplet type="stop"/>');
       if (nonFermataArticulations.length > 0) {

--- a/src/lib/patches.ts
+++ b/src/lib/patches.ts
@@ -56,6 +56,7 @@ export function applyPatch(score: Score, patch: ScorePatch): Score {
                   lyricsMode: patch.lyricsMode,
                 }),
                 ...(patch.muted !== undefined && { muted: patch.muted }),
+                ...(patch.hidden !== undefined && { hidden: patch.hidden }),
               }
             : s
         ),

--- a/src/lib/patches.ts
+++ b/src/lib/patches.ts
@@ -55,6 +55,7 @@ export function applyPatch(score: Score, patch: ScorePatch): Score {
                 ...(patch.lyricsMode !== undefined && {
                   lyricsMode: patch.lyricsMode,
                 }),
+                ...(patch.muted !== undefined && { muted: patch.muted }),
               }
             : s
         ),

--- a/src/lib/playback.ts
+++ b/src/lib/playback.ts
@@ -113,7 +113,7 @@ export async function playScore(
 
   for (const staff of score.staves) {
     if (staffFilter && !staffFilter.includes(staff.id)) continue;
-    if (staff.muted) continue;
+    if (staff.muted || staff.hidden) continue;
     for (const voice of staff.voices) {
       // Sort notes by position for tie resolution
       const sorted = [...voice.notes]

--- a/src/lib/playback.ts
+++ b/src/lib/playback.ts
@@ -113,6 +113,7 @@ export async function playScore(
 
   for (const staff of score.staves) {
     if (staffFilter && !staffFilter.includes(staff.id)) continue;
+    if (staff.muted) continue;
     for (const voice of staff.voices) {
       // Sort notes by position for tie resolution
       const sorted = [...voice.notes]

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -127,6 +127,9 @@ export const StaffSchema = z.object({
   transposition: z.number().int().optional(),
   lyricsMode: z.enum(["attached", "none"]).default("attached"),
   voices: z.array(VoiceSchema).default([]),
+  /** When true, the staff is silent during playback. Doesn't affect
+   *  rendering — the notes still appear on screen. */
+  muted: z.boolean().default(false).optional(),
 });
 export type Staff = z.infer<typeof StaffSchema>;
 
@@ -330,6 +333,7 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
     name: z.string().optional(),
     clef: Clef.optional(),
     lyricsMode: z.enum(["attached", "none"]).optional(),
+    muted: z.boolean().optional(),
   }),
   z.object({
     op: z.literal("add_staff"),

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -135,6 +135,10 @@ export const StaffSchema = z.object({
   /** When true, the staff is silent during playback. Doesn't affect
    *  rendering — the notes still appear on screen. */
   muted: z.boolean().default(false).optional(),
+  /** When true, the staff is omitted from the rendered score (and from
+   *  print/export). The staff still exists in the data model so its
+   *  notes are preserved; toggle off to bring it back. */
+  hidden: z.boolean().default(false).optional(),
 });
 export type Staff = z.infer<typeof StaffSchema>;
 
@@ -339,6 +343,7 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
     clef: Clef.optional(),
     lyricsMode: z.enum(["attached", "none"]).optional(),
     muted: z.boolean().optional(),
+    hidden: z.boolean().optional(),
   }),
   z.object({
     op: z.literal("add_staff"),

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -84,6 +84,11 @@ export const NoteSchema = z.object({
   accidental: z.enum(["sharp", "flat", "natural", "none"]).default("none"),
   tieStart: z.boolean().default(false),
   tieEnd: z.boolean().default(false),
+  /** Note begins a slur (curved phrase mark) that ends on the next note
+   *  with slurEnd=true. Distinct from a tie: a slur connects different
+   *  pitches into a phrase, a tie joins identical pitches into one. */
+  slurStart: z.boolean().optional(),
+  slurEnd: z.boolean().optional(),
   lyric: z.string().optional(),
   dynamic: DynamicMarking.optional(),
   articulations: z.array(Articulation).optional(),
@@ -365,6 +370,8 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
     updates: z.object({
       tieStart: z.boolean().optional(),
       tieEnd: z.boolean().optional(),
+      slurStart: z.boolean().optional(),
+      slurEnd: z.boolean().optional(),
       dots: z.number().int().min(0).max(2).optional(),
       accidental: z.enum(["sharp", "flat", "natural", "none"]).optional(),
       duration: NoteDuration.optional(),

--- a/src/store/score-store.ts
+++ b/src/store/score-store.ts
@@ -107,6 +107,75 @@ export const PRINT_LAYOUT: LayoutSettings = {
   printFooter: "",
 };
 
+/** Manuscript / chamber-music style — engraved feel with the Gonville
+ *  music font and Garamond text. Roomier than print, tighter than modern. */
+export const MANUSCRIPT_LAYOUT: LayoutSettings = {
+  titleSize: 2.6,
+  composerSize: 1.3,
+  titleTopDistance: 4,
+  titleBottomDistance: 1,
+  pageTopMargin: 4,
+  pageLeftMargin: 4,
+  pageRightMargin: 4,
+  systemSpacing: 4,
+  compactMode: false,
+  measuresPerSystem: 0,
+  pageBreaks: true,
+  pageSize: "letter",
+  noteSize: 0.85,
+  musicFont: "gonville",
+  textFont: "garamond",
+  printPageNumbers: true,
+  printHeader: "",
+  printFooter: "",
+};
+
+/** Lead sheet — clean modern sans for titles/lyrics, slightly larger
+ *  notes and wider systems. Aimed at single-line melody charts. */
+export const LEAD_SHEET_LAYOUT: LayoutSettings = {
+  titleSize: 2.6,
+  composerSize: 1.3,
+  titleTopDistance: 5,
+  titleBottomDistance: 1,
+  pageTopMargin: 5,
+  pageLeftMargin: 5,
+  pageRightMargin: 5,
+  systemSpacing: 6,
+  compactMode: false,
+  measuresPerSystem: 4,
+  pageBreaks: false,
+  pageSize: "letter",
+  noteSize: 1.05,
+  musicFont: "bravura",
+  textFont: "helvetica",
+  printPageNumbers: false,
+  printHeader: "",
+  printFooter: "",
+};
+
+/** Classroom — very large notation, generous spacing, easy to read from
+ *  a distance. Useful when projecting on a screen for students. */
+export const CLASSROOM_LAYOUT: LayoutSettings = {
+  titleSize: 3.0,
+  composerSize: 1.6,
+  titleTopDistance: 6,
+  titleBottomDistance: 2,
+  pageTopMargin: 6,
+  pageLeftMargin: 6,
+  pageRightMargin: 6,
+  systemSpacing: 8,
+  compactMode: false,
+  measuresPerSystem: 2,
+  pageBreaks: false,
+  pageSize: "letter",
+  noteSize: 1.2,
+  musicFont: "bravura",
+  textFont: "noto",
+  printPageNumbers: false,
+  printHeader: "",
+  printFooter: "",
+};
+
 /** Real Book style — handwritten feel, compact, like classic jazz fake books */
 export const REALBOOK_LAYOUT: LayoutSettings = {
   titleSize: 3.2,
@@ -129,11 +198,20 @@ export const REALBOOK_LAYOUT: LayoutSettings = {
   printFooter: "",
 };
 
-export type StylePreset = "modern" | "realbook" | "print";
+export type StylePreset =
+  | "modern"
+  | "lead-sheet"
+  | "manuscript"
+  | "realbook"
+  | "classroom"
+  | "print";
 
 export const STYLE_PRESETS: Record<StylePreset, { label: string; layout: LayoutSettings }> = {
   modern: { label: "Modern", layout: DEFAULT_LAYOUT },
+  "lead-sheet": { label: "Lead Sheet", layout: LEAD_SHEET_LAYOUT },
+  manuscript: { label: "Manuscript", layout: MANUSCRIPT_LAYOUT },
   realbook: { label: "Real Book", layout: REALBOOK_LAYOUT },
+  classroom: { label: "Classroom", layout: CLASSROOM_LAYOUT },
   print: { label: "Print", layout: PRINT_LAYOUT },
 };
 


### PR DESCRIPTION
## Summary

Two rounds of isolated UI/playback improvements bundled into one branch.

**Round 1:**
- Context menu cutoff fix — viewport clamp/flip
- #30 Always-visible articulations palette
- #44 Per-staff mute (playback gate)
- #29 Slur start/end UI + MusicXML
- #21 Three new style presets (Lead Sheet, Manuscript, Classroom)
- #5 Print: hide selection highlights / blue selected-note in print
- `.gitignore` polish

**Round 2:**
- #36 Musical-typing keyboard mode — chromatic-piano layout over QWERTY (Cmd+Opt+K)
- #44 finish — Per-staff Hide/Show
- #14 MIDI export — Score → .mid via @tonejs/midi (full score + per-staff)
- #28 closed (already implemented)
- #16 partial — Chord-chart ♭/♯ transpose buttons
- ChordPro export (.cho) for chord-chart songs
- ChordPro import (.cho/.crd/.pro/.chopro) — roundtrips OnSong/SongBook files

## Test plan

**Round 1:**
- [ ] Right-click near the bottom edge — menu flips upward, fully visible.
- [ ] Articulation/accidental/dynamic palette buttons reflect selected note's state and update on click.
- [ ] Mute toggles a staff silent during playback (multi-staff score).
- [ ] Add a slur (Start on note A, End on note B); MusicXML emits `<slur>` tags.
- [ ] Cycle through six style presets — fonts/spacing change.
- [ ] Print with a selection — no blue overlays leak through.

**Round 2:**
- [ ] Cmd+Opt+K toggles ♪ Type. With step entry on, A/W/S/E/D/F/T/G/Y/H/U/J enter chromatic notes; `,` `.` octave; `[` `]` duration; `X` rest.
- [ ] Hide on a staff card removes it from the rendered score; toggle off restores. Hidden staves don't play.
- [ ] File → Export MIDI downloads .mid with one track per visible staff. Per-staff `.mid` button exports single-track files.
- [ ] In a chord chart, click ♯ — every chord shifts up a semitone, suffixes/bars preserved. Undo returns.
- [ ] File → Export ChordPro downloads .cho with inline `[Chord]` syntax. Re-import the same file → song reappears.

## Out of scope

- Per-staff transpose / volume (transposition field exists, no UI)
- Songbook with embedded notation, voicings, two-page layout (#16 large)
- Safari print, off-screen PDF generation (#5 large)
- Real-time MIDI recording, OCR, audio transcription

🤖 Generated with [Claude Code](https://claude.com/claude-code)