### PR TITLE
Annotate from perform mode + scroll fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ next-env.d.ts
 /infra/cdk.out
 /infra/dist
 /cdk-outputs.json
+
+# Local-only project files and test artifacts (never commit)
+/Projects
+/e2e/screenshots
+/test-results
+/playwright-report

--- a/src/components/AnnotationLayer.tsx
+++ b/src/components/AnnotationLayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useScoreStore } from "@/store/score-store";
 import type { Annotation } from "@/lib/schema";
@@ -16,6 +16,12 @@ const COLOR_CLASSES: Record<Color, { bg: string; border: string; text: string; t
   green:  { bg: "bg-green-200",  border: "border-green-400",  text: "text-green-900",  tail: "#bbf7d0" },
 };
 
+// How far the pointer can drift between down and up before we treat it as
+// a drag (= scroll) instead of a tap (= place annotation). Generous enough
+// to forgive trembling fingers on touch devices but tight enough that any
+// real swipe registers as scroll.
+const TAP_THRESHOLD_PX = 10;
+
 export default function AnnotationLayer() {
   const score = useScoreStore((s) => s.score);
   const applyPatches = useScoreStore((s) => s.applyPatches);
@@ -26,6 +32,11 @@ export default function AnnotationLayer() {
 
   const [pendingAnchor, setPendingAnchor] = useState<{ x: number; y: number } | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
+
+  // Track the start of a pointer interaction to distinguish a tap (place
+  // annotation) from a drag (scroll). Without this, every touch on the
+  // overlay opens a popover and scrolling on iPad/touch devices breaks.
+  const pointerStart = useRef<{ x: number; y: number } | null>(null);
 
   const editingAnnotation = editingId
     ? annotations.find((a) => a.id === editingId) ?? null
@@ -39,17 +50,40 @@ export default function AnnotationLayer() {
     return true;
   });
 
-  const handleLayerClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
       if (!annotationMode) return;
+      // Don't capture pointer events when starting on an existing bubble —
+      // its own handler will fire on click.
+      if ((e.target as HTMLElement).closest("[data-annotation-bubble]")) {
+        pointerStart.current = null;
+        return;
+      }
+      pointerStart.current = { x: e.clientX, y: e.clientY };
+    },
+    [annotationMode],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!annotationMode) return;
+      const start = pointerStart.current;
+      pointerStart.current = null;
+      if (!start) return;
+      const dx = e.clientX - start.x;
+      const dy = e.clientY - start.y;
+      // If the pointer moved more than the tap threshold, this was a scroll
+      // gesture — leave it alone so the parent's overflow-auto can handle it.
+      if (Math.abs(dx) > TAP_THRESHOLD_PX || Math.abs(dy) > TAP_THRESHOLD_PX) return;
       if ((e.target as HTMLElement).closest("[data-annotation-bubble]")) return;
       const rect = e.currentTarget.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
       const x = (e.clientX - rect.left) / rect.width;
       const y = (e.clientY - rect.top) / rect.height;
       setPendingAnchor({ x, y });
       setEditingId(null);
     },
-    [annotationMode]
+    [annotationMode],
   );
 
   const handleBubbleClick = (e: React.MouseEvent, ann: Annotation) => {
@@ -98,11 +132,21 @@ export default function AnnotationLayer() {
 
   if (!score) return null;
 
+  // The layer must NOT eat scroll gestures. We set touch-action: pan-y so
+  // touch swipes always reach the parent's scroll handler; only single-tap
+  // (caught via pointerup with no movement) creates an annotation. When
+  // annotation mode is off, the layer is fully transparent to interaction.
+  const layerStyle: React.CSSProperties = {
+    pointerEvents: annotationMode ? "auto" : "none",
+    touchAction: annotationMode ? "pan-x pan-y" : "auto",
+  };
+
   return (
     <div
       className={`absolute inset-0 ${annotationMode ? "cursor-crosshair" : ""}`}
-      style={{ pointerEvents: annotationMode ? "auto" : "none" }}
-      onClick={handleLayerClick}
+      style={layerStyle}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
     >
       {/* Annotation bubbles */}
       {filteredAnnotations.map((ann) => {

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { Score } from "@/lib/schema";
 import ChordChartView from "@/components/ChordChartView";
 import PaginatedPerformChart from "@/components/PaginatedPerformChart";
+import AnnotationLayer from "@/components/AnnotationLayer";
 import { useScoreStore } from "@/store/score-store";
 import { getSongs, type SongBankEntry } from "@/lib/song-bank";
 
@@ -60,6 +61,11 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   const setUIState = useScoreStore(s => s.setUIState);
   const currentSongId = useScoreStore(s => s.uiState.currentSongId);
   const performFolder = useScoreStore(s => s.uiState.performFolder ?? null);
+  // Whether we're annotating from inside perform mode. The button below
+  // toggles uiState.annotationMode without leaving perform — same scroll
+  // position, same chrome — so the user can drop a note where they're
+  // already looking on the chart.
+  const annotationMode = useScoreStore(s => s.uiState.annotationMode);
   // 1-col scrolls the outer container vertically; 2-col scrolls the
   // PaginatedPerformChart's inner pages strip horizontally. They live in
   // different DOM nodes so we need separate refs.
@@ -176,13 +182,19 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
       style={wrapperVars}
     >
       {/* 1-col: vertical scroll, ChordChartView reused.
-          2-col: PaginatedPerformChart owns layout (Quark-style pages). */}
+          2-col: PaginatedPerformChart owns layout (Quark-style pages).
+          The relative inner wrapper sizes to content so AnnotationLayer's
+          absolute inset-0 spans the actual chord chart, not just the
+          viewport — annotations stay anchored to content while scrolling. */}
       {prefs.columns === 1 ? (
         <div
           ref={scrollRef}
           className="absolute inset-0 overflow-auto pt-[7vh] pb-[9vh]"
         >
-          <ChordChartView score={score} performMode performColumns={1} />
+          <div className="relative">
+            <ChordChartView score={score} performMode performColumns={1} />
+            <AnnotationLayer />
+          </div>
         </div>
       ) : (
         <PaginatedPerformChart
@@ -349,23 +361,46 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
         </>
       )}
 
-      {/* Done button is its own pinned element — never wraps off-screen,
-          higher z-index than everything else, and small enough not to
-          clash with the rest of the toolbar. The user got stuck once when
-          a wrap pushed it out of reach; that can't happen now. */}
-      <button
-        type="button"
-        onClick={onExit}
-        className="absolute top-3 right-3 z-30 px-4 h-11 rounded-xl bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-medium shadow border border-white/10"
-        aria-label="Exit perform mode"
-      >
-        Done
-      </button>
+      {/* Mode buttons — pinned to the top-right, never wrap off-screen.
+          Annotate toggles annotationMode while staying in perform (same
+          scroll position, same chrome) so the user can drop a sticky
+          note where they're already looking. Edit exits perform back to
+          the full editor. */}
+      <div className="absolute top-3 right-3 z-30 flex items-center gap-1 rounded-xl bg-gray-900/80 backdrop-blur-sm shadow border border-white/10 p-1">
+        <button
+          type="button"
+          onClick={() => setUIState({ annotationMode: !annotationMode })}
+          className={`px-3 h-11 rounded-lg text-sm font-medium transition-colors ${
+            annotationMode
+              ? "bg-yellow-400 text-gray-900 hover:bg-yellow-300"
+              : "text-gray-100 hover:bg-gray-800 active:bg-gray-700"
+          }`}
+          aria-pressed={annotationMode}
+          aria-label={annotationMode ? "Stop annotating" : "Annotate"}
+          title={annotationMode ? "Tap the chart to add a note. Tap Annotating to stop." : "Annotate — drop sticky notes on the chart"}
+        >
+          {annotationMode ? "Annotating" : "Annotate"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            // Leaving perform also clears annotate so the editor opens in
+            // its normal edit state, not in annotate-while-edit.
+            if (annotationMode) setUIState({ annotationMode: false });
+            onExit();
+          }}
+          className="px-3 h-11 rounded-lg bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-medium"
+          aria-label="Edit (exit perform mode)"
+        >
+          Edit
+        </button>
+      </div>
 
       {/* Floating toolbar — wrap-able cluster of style/columns controls
           plus a My Songs button. Positioned to the LEFT of the pinned
-          Done button. */}
-      <div className="absolute top-3 right-[5.5rem] flex flex-wrap items-center justify-end gap-2 max-w-[calc(100vw-7rem)]">
+          mode buttons. Width budget assumes both Edit + Annotate are
+          shown (~13rem). */}
+      <div className="absolute top-3 right-[14rem] flex flex-wrap items-center justify-end gap-2 max-w-[calc(100vw-15rem)]">
         <div className="flex items-center gap-1 bg-gray-900/80 backdrop-blur-sm rounded-xl p-1 shadow border border-white/10">
           <button
             type="button"


### PR DESCRIPTION
## Summary

User-reported issues addressed:

1. **'Can't scroll in annotate mode'** — touch swipes were placing annotations instead of scrolling. AnnotationLayer now distinguishes a tap (place annotation) from a drag (scroll) via pointerdown/up movement check. Browser's native pan-x/pan-y handles scroll while plain taps still drop a sticky note. Works on touch and mouse.
2. **No way to enter annotate from perform** — replaced the single 'Done' button in PerformView with a paired Edit / Annotate cluster:
   - **Annotate** toggles `annotationMode` without leaving perform — same scroll position, same chrome — so the user can drop a sticky note exactly where they were already looking.
   - **Edit** exits perform back to the full editor (clears annotationMode too).
3. **Annotation positions stayed pinned to viewport** when the chord chart scrolled. The layer is now rendered inside PerformView's scroll container wrapped in a content-sized `relative` div, so annotations scroll with content.

## Test plan

- [ ] Enter perform mode → tap **Annotate** → chart stays where it was, button shows 'Annotating' in yellow.
- [ ] Tap an empty spot on the chart → popover opens, save a note → bubble appears at the tap position.
- [ ] Swipe vertically → chart scrolls, no annotation gets placed.
- [ ] Scroll the chord chart → existing annotations move with the content.
- [ ] Tap **Edit** → returns to the full editor, annotationMode is off.
- [ ] On iPad / touch device, both vertical scroll and tap-to-annotate work without fighting each other.

## Out of scope

- 2-column performview path — annotation only enabled in 1-col layout for now.
- Edit-mode annotation positioning fix (annotations there still pin to viewport because ChordChartView owns its own scroll container; separate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)