### PR TITLE
feat: feedback form with sanitized localStorage storage (#53)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ import MySongsModal from "@/components/MySongsModal";
 import JoinSongbookModal from "@/components/JoinSongbookModal";
 import PerformView from "@/components/PerformView";
 import PersistFailureBanner from "@/components/PersistFailureBanner";
+import FeedbackModal from "@/components/FeedbackModal";
 import { CLOUD_ENABLED, getDeviceId } from "@/lib/song-cloud";
 import { autosaveToCloud } from "@/lib/cloud-autosave";
 import AnnotationLayer from "@/components/AnnotationLayer";
@@ -83,6 +84,7 @@ export default function Home() {
   const [autosaveDialogOpen, setAutosaveDialogOpen] = useState(false);
   const [pasteLyricsOpen, setPasteLyricsOpen] = useState(false);
   const [mySongsOpen, setMySongsOpen] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [joinCode, setJoinCode] = useState<string | null>(null);
   const [inlineAI, setInlineAI] = useState<{ note: { measure: number; beat: number; pitch: string; staffIndex: number }; position: { x: number; y: number } } | null>(null);
   const printFnRef = useRef<(() => Promise<void>) | null>(null);
@@ -665,6 +667,7 @@ export default function Home() {
           onOpenAutosave={() => setAutosaveDialogOpen(true)}
           onPasteLyrics={() => setPasteLyricsOpen(true)}
           onMySongs={() => setMySongsOpen(true)}
+          onSendFeedback={() => setFeedbackOpen(true)}
         />
       </div>
 
@@ -1214,6 +1217,22 @@ export default function Home() {
           onExit={() => setUIState({ performMode: false })}
           onOpenMySongs={() => setMySongsOpen(true)}
         />
+      )}
+
+      {/* Floating feedback button — visible in all modes, above status bar. */}
+      <button
+        type="button"
+        onClick={() => setFeedbackOpen(true)}
+        title="Send feedback"
+        aria-label="Send feedback"
+        className="print-hide fixed bottom-12 right-4 z-40 w-10 h-10 rounded-full bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white shadow-lg flex items-center justify-center text-lg font-semibold transition-colors"
+      >
+        ?
+      </button>
+
+      {/* Feedback modal */}
+      {feedbackOpen && (
+        <FeedbackModal onClose={() => setFeedbackOpen(false)} />
       )}
     </div>
   );

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { submitFeedback, type FeedbackCategory } from "@/lib/feedback-store";
+
+interface FeedbackModalProps {
+  onClose: () => void;
+}
+
+const MAX_MESSAGE = 1000;
+const MAX_EMAIL = 200;
+
+const CATEGORIES: { value: FeedbackCategory; label: string }[] = [
+  { value: "bug", label: "Bug" },
+  { value: "feature", label: "Feature Request" },
+  { value: "other", label: "Other" },
+];
+
+export default function FeedbackModal({ onClose }: FeedbackModalProps) {
+  const [category, setCategory] = useState<FeedbackCategory>("bug");
+  const [message, setMessage] = useState("");
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      submitFeedback({
+        category,
+        message,
+        email: email.trim() || undefined,
+      });
+      setDone(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Could not save feedback.";
+      setError(msg);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center pt-[10vh] bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl border border-gray-200 w-[480px] max-w-[92vw] flex flex-col overflow-hidden text-gray-800"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h2 className="text-base font-semibold">Send Feedback</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-800 p-1 rounded"
+            aria-label="Close"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
+
+        {done ? (
+          <div className="px-5 py-8 flex flex-col items-center text-center gap-3">
+            <div className="w-12 h-12 rounded-full bg-green-100 text-green-600 flex items-center justify-center">
+              <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <p className="text-base font-medium">Thanks for your feedback!</p>
+            <p className="text-sm text-gray-600">
+              We read every submission and use it to make NotationApp better.
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="mt-2 px-4 py-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col">
+            <div className="px-5 py-4 space-y-4">
+              <div>
+                <label className="block text-xs font-semibold uppercase tracking-wider text-gray-600 mb-2">
+                  Category
+                </label>
+                <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Feedback category">
+                  {CATEGORIES.map((c) => {
+                    const active = category === c.value;
+                    return (
+                      <button
+                        key={c.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        onClick={() => setCategory(c.value)}
+                        className={`px-4 py-3 text-sm rounded-lg border transition-colors ${
+                          active
+                            ? "bg-blue-600 text-white border-blue-600"
+                            : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                        }`}
+                      >
+                        {c.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label htmlFor="feedback-message" className="block text-xs font-semibold uppercase tracking-wider text-gray-600">
+                    Message
+                  </label>
+                  <span className={`text-[11px] tabular-nums ${message.length > MAX_MESSAGE ? "text-red-600" : "text-gray-500"}`}>
+                    {message.length}/{MAX_MESSAGE}
+                  </span>
+                </div>
+                <textarea
+                  id="feedback-message"
+                  ref={textareaRef}
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  required
+                  maxLength={MAX_MESSAGE + 200}
+                  rows={5}
+                  placeholder="Tell us what's on your mind…"
+                  className="w-full px-3 py-3 text-sm bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-y"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="feedback-email" className="block text-xs font-semibold uppercase tracking-wider text-gray-600 mb-2">
+                  Email <span className="font-normal normal-case text-gray-400">(optional, if you&apos;d like a reply)</span>
+                </label>
+                <input
+                  id="feedback-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  maxLength={MAX_EMAIL}
+                  placeholder="you@example.com"
+                  className="w-full px-3 py-3 text-sm bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+
+              {error && (
+                <p className="text-sm text-red-600" role="alert">{error}</p>
+              )}
+            </div>
+
+            <div className="px-5 py-3 border-t border-gray-200 bg-gray-50 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-3 text-sm text-gray-700 bg-white border border-gray-200 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg transition-colors"
+              >
+                Send Feedback
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -20,6 +20,7 @@ interface MenuBarProps {
   onOpenAutosave?: () => void;
   onPasteLyrics?: () => void;
   onMySongs?: () => void;
+  onSendFeedback?: () => void;
 }
 
 type MenuItem = {
@@ -111,7 +112,7 @@ function MenuDropdown({ label, items, isOpen, onToggle, onClose }: {
 
 export default function MenuBar({
   zoom, onZoomChange, onPrint, onOpenAutosave, onPasteLyrics, onMySongs,
-  onToggleSidebar, sidebarOpen,
+  onToggleSidebar, sidebarOpen, onSendFeedback,
 }: MenuBarProps) {
   const {
     score, undo, redo, history, historyIndex, reset, setScore,
@@ -394,6 +395,8 @@ export default function MenuBar({
     { label: "Clear Selection", shortcut: "Esc", action: () => setSelection(null), enabled: !!selection },
     { separator: true },
     { label: "Paste Lyrics / Chords\u2026", action: () => onPasteLyrics?.(), enabled: !!score },
+    { separator: true },
+    { label: "Send Feedback\u2026", action: () => onSendFeedback?.() },
   ];
 
   const viewMenu: MenuItem[] = [

--- a/src/lib/feedback-store.ts
+++ b/src/lib/feedback-store.ts
@@ -1,0 +1,104 @@
+/**
+ * localStorage-backed feedback storage. Submissions are sanitized before
+ * write — HTML tags stripped, trimmed, length-capped — so anything later
+ * displayed back from this store is safe regardless of how it was entered.
+ */
+
+export type FeedbackCategory = "bug" | "feature" | "other";
+
+export interface FeedbackEntry {
+  id: string;
+  timestamp: number;
+  category: FeedbackCategory;
+  message: string;
+  email?: string;
+}
+
+const STORAGE_KEY = "notation-app-feedback";
+const MAX_MESSAGE_LENGTH = 1000;
+const MAX_EMAIL_LENGTH = 200;
+
+/** Strip HTML tags, decode common entities, collapse whitespace, trim, cap length. */
+function sanitizeText(input: string, maxLength: number): string {
+  if (typeof input !== "string") return "";
+  // Remove anything that looks like an HTML tag, including malformed/unclosed
+  // ones — repeat until stable so nested constructs like "<<b>script>" don't
+  // leave a residual "<b>".
+  let prev = "";
+  let cur = input;
+  while (prev !== cur) {
+    prev = cur;
+    cur = cur.replace(/<[^>]*>?/g, "");
+  }
+  // Decode a small set of HTML entities so "&lt;script&gt;" doesn't survive
+  // as visible markup-looking text.
+  cur = cur
+    .replace(/&lt;/gi, "")
+    .replace(/&gt;/gi, "")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#x?[0-9a-f]+;/gi, "");
+  return cur.trim().slice(0, maxLength);
+}
+
+/** Read the stored feedback array, recovering from corruption by returning []. */
+export function getFeedback(): FeedbackEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is FeedbackEntry =>
+        e &&
+        typeof e === "object" &&
+        typeof e.id === "string" &&
+        typeof e.timestamp === "number" &&
+        (e.category === "bug" || e.category === "feature" || e.category === "other") &&
+        typeof e.message === "string"
+    );
+  } catch {
+    return [];
+  }
+}
+
+export interface FeedbackInput {
+  category: FeedbackCategory;
+  message: string;
+  email?: string;
+}
+
+/**
+ * Sanitize and persist a feedback submission. Returns the stored entry, or
+ * throws if the message is empty after sanitization.
+ */
+export function submitFeedback(entry: FeedbackInput): FeedbackEntry {
+  const message = sanitizeText(entry.message, MAX_MESSAGE_LENGTH);
+  if (!message) {
+    throw new Error("Message is required.");
+  }
+  const emailRaw = entry.email ? sanitizeText(entry.email, MAX_EMAIL_LENGTH) : "";
+  const stored: FeedbackEntry = {
+    id:
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `fb-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    timestamp: Date.now(),
+    category: entry.category,
+    message,
+    ...(emailRaw ? { email: emailRaw } : {}),
+  };
+
+  const existing = getFeedback();
+  const next = [...existing, stored];
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch (err) {
+      console.warn("[feedback-store] write failed", err);
+      throw err;
+    }
+  }
+  return stored;
+}


### PR DESCRIPTION
## Summary
- Adds a Send Feedback flow: a modal with category (Bug / Feature Request / Other), required message with live char counter, and an optional email field.
- Submissions persist to `localStorage` under `notation-app-feedback` after HTML-tag stripping, trim, and length caps (message 1000, email 200) — entries are safe to render back.
- Entry points: a "Send Feedback…" item at the bottom of the Edit menu and a floating "?" button anchored bottom-right, visible in all modes.

Closes #53.

## Test plan
- [ ] Open the Edit menu → click "Send Feedback…" → modal opens.
- [ ] Click the floating "?" in the bottom-right → same modal opens (works in Edit / Perform / Annotate modes).
- [ ] Try to submit with an empty message → blocked.
- [ ] Submit with `<script>alert(1)</script>` in the message → no script runs; persisted entry has tags stripped.
- [ ] Type past 1000 chars → counter turns red and the entry is capped on save.
- [ ] After submit, a success state shows "Thanks for your feedback!".
- [ ] Inspect `localStorage.getItem("notation-app-feedback")` → JSON array contains the sanitized entry with `id`, `timestamp`, `category`, `message`, optional `email`.
- [ ] Tap targets read comfortably on iPad (buttons use `py-3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)