### PR TITLE
feat: user interaction analytics with localStorage ring buffer (#54)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,8 @@ import { autosaveToCloud } from "@/lib/cloud-autosave";
 import AnnotationLayer from "@/components/AnnotationLayer";
 import AnnotationFilterBar from "@/components/AnnotationFilterBar";
 import { cleanScoreOverflow } from "@/lib/score-cleanup";
+import DebugOverlay from "@/components/DebugOverlay";
+import { logEvent, scoreTypeOf, type ScoreType } from "@/lib/analytics";
 
 // Dynamic import to prevent SSR for OSMD (uses browser APIs)
 const ScoreRenderer = dynamic(() => import("@/components/ScoreRenderer"), {
@@ -396,6 +398,22 @@ export default function Home() {
     return () => clearTimeout(id);
   }, [score, currentSongId]);
 
+  // Analytics: detect notation↔chord-chart type switches and log them.
+  // We diff against the previous render's type so we only fire when the
+  // category actually changes (not on every score edit). The very first
+  // assignment (none → notation/chord-chart) is also a switch.
+  const prevScoreTypeRef = useRef<ScoreType>("none");
+  useEffect(() => {
+    const next = scoreTypeOf(score);
+    const prev = prevScoreTypeRef.current;
+    if (next !== prev) {
+      if (prev !== "none" && next !== "none") {
+        logEvent({ event: "score_type_switch", name: `${prev}->${next}` });
+      }
+      prevScoreTypeRef.current = next;
+    }
+  }, [score]);
+
   // Songbook share-link: visiting `?join=<deviceId>` prompts to take over
   // that device's songbook. The param is stripped after the user decides
   // (Join or Cancel) so a refresh doesn't re-prompt.
@@ -695,7 +713,15 @@ export default function Home() {
             </DrawerSection>
 
             {/* AI Chat drawer */}
-            <DrawerSection title="AI Assistant" open={uiState.aiDrawerOpen} onToggle={(v) => setUIState({ aiDrawerOpen: v })} flex>
+            <DrawerSection
+              title="AI Assistant"
+              open={uiState.aiDrawerOpen}
+              onToggle={(v) => {
+                logEvent({ event: v ? "ai_panel_open" : "ai_panel_close", scoreType: scoreTypeOf(score) });
+                setUIState({ aiDrawerOpen: v });
+              }}
+              flex
+            >
               <PromptPanel />
             </DrawerSection>
           </div>
@@ -757,6 +783,7 @@ export default function Home() {
                 <button
                   type="button"
                   onClick={() => {
+                    logEvent({ event: "score_new", name: "notation" });
                     resetStore();
                     setScore({
                       id: uuidv4(),
@@ -790,6 +817,7 @@ export default function Home() {
                 <button
                   type="button"
                   onClick={() => {
+                    logEvent({ event: "score_new", name: "chord-chart" });
                     resetStore();
                     setScore({
                       id: uuidv4(),
@@ -1215,6 +1243,9 @@ export default function Home() {
           onOpenMySongs={() => setMySongsOpen(true)}
         />
       )}
+
+      {/* Analytics debug overlay (?debug=1 / Ctrl+Shift+D) */}
+      <DebugOverlay />
     </div>
   );
 }

--- a/src/components/AnnotationLayer.tsx
+++ b/src/components/AnnotationLayer.tsx
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 import { useScoreStore } from "@/store/score-store";
 import type { Annotation } from "@/lib/schema";
 import AnnotationPopover from "./AnnotationPopover";
+import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
 type Color = Annotation["color"];
 type Visibility = Annotation["visibility"];
@@ -62,6 +63,7 @@ export default function AnnotationLayer() {
     text: string; color: Color; visibility: Visibility; label: string;
   }) => {
     if (!pendingAnchor) return;
+    logEvent({ event: "annotation_create", scoreType: scoreTypeOf(score) });
     applyPatches([{
       op: "add_annotation",
       annotation: {
@@ -82,11 +84,13 @@ export default function AnnotationLayer() {
     id: string,
     updates: { text?: string; color?: Color; visibility?: Visibility; label?: string }
   ) => {
+    logEvent({ event: "annotation_edit", scoreType: scoreTypeOf(score) });
     applyPatches([{ op: "update_annotation", id, updates }]);
     setEditingId(null);
   };
 
   const handleDelete = (id: string) => {
+    logEvent({ event: "annotation_delete", scoreType: scoreTypeOf(score) });
     applyPatches([{ op: "remove_annotation", id }]);
     setEditingId(null);
   };

--- a/src/components/DebugOverlay.tsx
+++ b/src/components/DebugOverlay.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { getEvents, clearEvents, type AnalyticsEvent } from "@/lib/analytics";
+
+const DEBUG_FLAG_KEY = "notation-app-debug";
+const VISIBLE_EVENT_COUNT = 20;
+
+// Show the overlay when either ?debug=1 is in the URL, or
+// localStorage["notation-app-debug"] === "true". Pressing Ctrl+Shift+D
+// toggles the flag (and the overlay).
+function readInitialVisibility(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("debug") === "1") return true;
+    return window.localStorage.getItem(DEBUG_FLAG_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function setPersistedFlag(on: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (on) window.localStorage.setItem(DEBUG_FLAG_KEY, "true");
+    else window.localStorage.removeItem(DEBUG_FLAG_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export default function DebugOverlay() {
+  const [visible, setVisible] = useState(false);
+  const [events, setEvents] = useState<AnalyticsEvent[]>([]);
+
+  // Set initial visibility once mounted. Initial state is `false` so the
+  // server-rendered HTML matches; we then read the URL/localStorage on the
+  // client and toggle if needed. The setState-in-effect is intentional —
+  // it's the SSR-safe pattern for reading browser-only state.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setVisible(readInitialVisibility());
+  }, []);
+
+  // Refresh the event list when the overlay becomes visible, and subscribe
+  // to logEvent's window CustomEvent so the list stays live. The initial
+  // setEvents pulls the persisted buffer — needed because the analytics
+  // store is an external system, not React state.
+  useEffect(() => {
+    if (!visible) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setEvents(getEvents());
+    const onChange = () => setEvents(getEvents());
+    window.addEventListener("notation-app-analytics", onChange);
+    return () => window.removeEventListener("notation-app-analytics", onChange);
+  }, [visible]);
+
+  // Ctrl+Shift+D toggle. Persists the flag so a refresh keeps state.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === "D" || e.key === "d")) {
+        // Skip when typing in an input/contenteditable so we don't hijack
+        // the user's text editing.
+        const t = e.target;
+        const isText =
+          t instanceof HTMLInputElement ||
+          t instanceof HTMLTextAreaElement ||
+          (t instanceof HTMLElement && t.isContentEditable);
+        if (isText) return;
+        e.preventDefault();
+        setVisible((v) => {
+          const next = !v;
+          setPersistedFlag(next);
+          return next;
+        });
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const onClear = useCallback(() => {
+    clearEvents();
+    setEvents([]);
+  }, []);
+
+  if (!visible) return null;
+
+  const recent = events.slice(-VISIBLE_EVENT_COUNT).reverse();
+
+  return (
+    <div
+      className="fixed bottom-3 right-3 z-50 w-72 max-h-80 rounded-lg shadow-lg flex flex-col font-mono text-[10px] border border-white/10"
+      style={{ backgroundColor: "rgba(10, 10, 25, 0.85)", color: "#d1d5db", backdropFilter: "blur(4px)" }}
+      role="status"
+      aria-label="Analytics debug overlay"
+    >
+      <div className="flex items-center justify-between px-2.5 py-1.5 border-b border-white/10">
+        <span className="font-semibold uppercase tracking-wider text-gray-400">
+          Analytics ({events.length})
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={onClear}
+            className="px-1.5 py-0.5 rounded bg-white/10 hover:bg-white/20 text-gray-300 transition-colors"
+            title="Clear all events"
+          >
+            Clear
+          </button>
+          <button
+            onClick={() => {
+              setVisible(false);
+              setPersistedFlag(false);
+            }}
+            className="px-1.5 py-0.5 rounded bg-white/10 hover:bg-white/20 text-gray-300 transition-colors"
+            title="Hide (Ctrl+Shift+D to reopen)"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+      <ul className="overflow-y-auto flex-1 px-2 py-1 space-y-0.5">
+        {recent.length === 0 ? (
+          <li className="text-gray-500 italic px-1 py-2">No events yet.</li>
+        ) : (
+          recent.map((ev, i) => (
+            <li key={`${ev.timestamp}-${i}`} className="flex gap-2 leading-tight">
+              <span className="text-gray-500 shrink-0 tabular-nums">
+                {formatTimestamp(ev.timestamp)}
+              </span>
+              <span className="text-gray-200 truncate">{ev.event}</span>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -10,6 +10,7 @@ import { CLOUD_ENABLED, cloudCreateNamedRevision } from "@/lib/song-cloud";
 import { getSongs } from "@/lib/song-bank";
 import { IS_STATIC_EXPORT, STATIC_FEATURE_DISABLED_MESSAGE } from "@/lib/api-availability";
 import { v4 as uuidv4 } from "uuid";
+import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
 interface MenuBarProps {
   zoom: number;
@@ -34,12 +35,13 @@ type MenuItem = {
   label?: never;
 };
 
-function MenuDropdown({ label, items, isOpen, onToggle, onClose }: {
+function MenuDropdown({ label, items, isOpen, onToggle, onClose, onItemClick }: {
   label: string;
   items: MenuItem[];
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
+  onItemClick?: (itemLabel: string) => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -83,6 +85,7 @@ function MenuDropdown({ label, items, isOpen, onToggle, onClose }: {
                 key={i}
                 onClick={() => {
                   if (item.enabled === false) return;
+                  onItemClick?.(item.label);
                   item.action?.();
                   onClose();
                 }}
@@ -138,6 +141,7 @@ export default function MenuBar({
   // ── Handlers (moved from Toolbar) ─────────────────────────────────
 
   const handleNew = () => {
+    logEvent({ event: "score_new", name: "notation" });
     reset();
     setScore({
       id: uuidv4(),
@@ -169,6 +173,7 @@ export default function MenuBar({
    *  empty line — the user fills in lyrics and chords from there. No
    *  staves, so the renderer switches to ChordChartView. */
   const handleNewChordChart = () => {
+    logEvent({ event: "score_new", name: "chord-chart" });
     reset();
     setScore({
       id: uuidv4(),
@@ -278,6 +283,7 @@ export default function MenuBar({
         setScore(result.data);
         addMessage({ id: uuidv4(), role: "assistant", content: `Loaded ${file.name}.`, timestamp: Date.now() });
       } catch (err: any) {
+        logEvent({ event: "error", name: "import_json" });
         addMessage({ id: uuidv4(), role: "assistant", content: `Import error: ${err.message}`, timestamp: Date.now() });
       } finally {
         if (fileInputRef.current) fileInputRef.current.value = "";
@@ -301,6 +307,7 @@ export default function MenuBar({
       if (data.warnings?.length) setWarnings(data.warnings);
       addMessage({ id: uuidv4(), role: "assistant", content: data.message || `Imported ${file.name}.`, timestamp: Date.now() });
     } catch (err: any) {
+      logEvent({ event: "error", name: "import" });
       addMessage({ id: uuidv4(), role: "assistant", content: `Import error: ${err.message}`, timestamp: Date.now() });
     } finally {
       setIsGenerating(false);
@@ -329,6 +336,7 @@ export default function MenuBar({
       });
       addMessage({ id: uuidv4(), role: "assistant", content: `Opened project "${file.name}" \u2014 "${result.data.title}".`, timestamp: Date.now() });
     } catch (err: any) {
+      logEvent({ event: "error", name: "open_project" });
       addMessage({ id: uuidv4(), role: "assistant", content: `Open project error: ${err.message}`, timestamp: Date.now() });
     } finally {
       if (projectInputRef.current) projectInputRef.current.value = "";
@@ -353,6 +361,7 @@ export default function MenuBar({
       setScore(data.score);
       addMessage({ id: uuidv4(), role: "assistant", content: data.message || `Transcribed ${file.name}.`, timestamp: Date.now() });
     } catch (err: any) {
+      logEvent({ event: "error", name: "transcribe" });
       addMessage({ id: uuidv4(), role: "assistant", content: `Transcription error: ${err.message}`, timestamp: Date.now() });
     } finally {
       setIsGenerating(false);
@@ -420,10 +429,38 @@ export default function MenuBar({
         <span className="text-sm font-bold text-gray-100 mr-3 tracking-wide">\u2669 NotationApp</span>
 
         {/* Menus */}
-        <MenuDropdown label="File" items={fileMenu} isOpen={openMenu === "file"} onToggle={() => toggleMenu("file")} onClose={closeMenu} />
-        <MenuDropdown label="Edit" items={editMenu} isOpen={openMenu === "edit"} onToggle={() => toggleMenu("edit")} onClose={closeMenu} />
-        <MenuDropdown label="View" items={viewMenu} isOpen={openMenu === "view"} onToggle={() => toggleMenu("view")} onClose={closeMenu} />
-        <MenuDropdown label="Tools" items={toolsMenu} isOpen={openMenu === "tools"} onToggle={() => toggleMenu("tools")} onClose={closeMenu} />
+        <MenuDropdown
+          label="File"
+          items={fileMenu}
+          isOpen={openMenu === "file"}
+          onToggle={() => toggleMenu("file")}
+          onClose={closeMenu}
+          onItemClick={(name) => logEvent({ event: "menu", name: `File>${name}`, scoreType: scoreTypeOf(score) })}
+        />
+        <MenuDropdown
+          label="Edit"
+          items={editMenu}
+          isOpen={openMenu === "edit"}
+          onToggle={() => toggleMenu("edit")}
+          onClose={closeMenu}
+          onItemClick={(name) => logEvent({ event: "menu", name: `Edit>${name}`, scoreType: scoreTypeOf(score) })}
+        />
+        <MenuDropdown
+          label="View"
+          items={viewMenu}
+          isOpen={openMenu === "view"}
+          onToggle={() => toggleMenu("view")}
+          onClose={closeMenu}
+          onItemClick={(name) => logEvent({ event: "menu", name: `View>${name}`, scoreType: scoreTypeOf(score) })}
+        />
+        <MenuDropdown
+          label="Tools"
+          items={toolsMenu}
+          isOpen={openMenu === "tools"}
+          onToggle={() => toggleMenu("tools")}
+          onClose={closeMenu}
+          onItemClick={(name) => logEvent({ event: "menu", name: `Tools>${name}`, scoreType: scoreTypeOf(score) })}
+        />
 
         <CloudSaveIndicator />
 

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useScoreStore } from "@/store/score-store";
+import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
 type Mode = "edit" | "perform" | "annotate";
 
@@ -17,6 +18,9 @@ export default function ModeSelector() {
 
   function selectMode(mode: Mode) {
     if (mode === "perform" && !hasChordChart) return;
+    if (mode !== currentMode) {
+      logEvent({ event: "mode_switch", name: mode, scoreType: scoreTypeOf(score) });
+    }
     setUIState({
       performMode: mode === "perform",
       annotationMode: mode === "annotate",

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -26,6 +26,7 @@ import {
   syncSongbook,
   type SyncStatus as CloudSyncStatus,
 } from "@/lib/song-cloud";
+import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
 type SyncStatus = "idle" | CloudSyncStatus;
 
@@ -35,6 +36,10 @@ type SyncStatus = "idle" | CloudSyncStatus;
 const EMPTY_STRINGS: string[] = [];
 
 export default function MySongsModal({ onClose }: { onClose: () => void }) {
+  // Analytics: log modal open on mount.
+  useEffect(() => {
+    logEvent({ event: "mysongs_open" });
+  }, []);
   const score = useScoreStore(s => s.score);
   const setScore = useScoreStore(s => s.setScore);
   const setUIState = useScoreStore(s => s.setUIState);
@@ -223,10 +228,17 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     }
   };
 
-  const handleSave = () => performSave(false);
-  const handleSaveAs = () => performSave(true);
+  const handleSave = () => {
+    logEvent({ event: "mysongs_save", scoreType: scoreTypeOf(score) });
+    performSave(false);
+  };
+  const handleSaveAs = () => {
+    logEvent({ event: "mysongs_save_as", scoreType: scoreTypeOf(score) });
+    performSave(true);
+  };
 
   const handleLoad = async (entry: SongBankEntry) => {
+    logEvent({ event: "mysongs_load", scoreType: scoreTypeOf(entry.score) });
     // Take an autosave snapshot of the OUTGOING score before replacing it.
     // Recovery from this snapshot is how we get back from accidental Loads
     // that overwrite unsaved work — exactly what bit us before.
@@ -363,6 +375,7 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
   };
 
   const handleDelete = async (id: string) => {
+    logEvent({ event: "mysongs_delete" });
     deleteSong(id);
     refreshLocal();
     if (!CLOUD_ENABLED) return;

--- a/src/components/PasteLyricsModal.tsx
+++ b/src/components/PasteLyricsModal.tsx
@@ -4,12 +4,30 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { useScoreStore } from "@/store/score-store";
 import { ChordSymbol, Note, ScorePatch } from "@/lib/schema";
 import { parseLyricsWithChords, parseToSections } from "@/lib/lyric-parser";
+import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
 export default function PasteLyricsModal({ onClose }: { onClose: () => void }) {
   const score = useScoreStore(s => s.score);
   const applyPatches = useScoreStore(s => s.applyPatches);
   const stepEntry = useScoreStore(s => s.stepEntry);
   const [text, setText] = useState("");
+
+  // Analytics: log open on mount; on unmount, log submit-or-cancel based on
+  // whether handleApply ran. The ref is read in cleanup so the close event
+  // is always paired with the open.
+  const submittedRef = useRef(false);
+  useEffect(() => {
+    logEvent({ event: "paste_lyrics_open", scoreType: scoreTypeOf(score) });
+    return () => {
+      logEvent({
+        event: submittedRef.current ? "paste_lyrics_submit" : "paste_lyrics_cancel",
+        scoreType: scoreTypeOf(score),
+      });
+    };
+    // Open/close are bookended by mount/unmount — we deliberately don't want
+    // re-fires when the score reference changes. eslint: react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Determine staff, voice, sorted notes, and starting index from stepEntry
   const { staffId, voiceId, notes, startIdx } = useMemo((): {
@@ -90,6 +108,7 @@ export default function PasteLyricsModal({ onClose }: { onClose: () => void }) {
       }
       applyPatches(patches);
     }
+    submittedRef.current = true;
     onClose();
   };
 
@@ -129,6 +148,7 @@ export default function PasteLyricsModal({ onClose }: { onClose: () => void }) {
     }
 
     if (allPatches.length > 0) applyPatches(allPatches);
+    submittedRef.current = true;
     onClose();
   };
 

--- a/src/components/PromptPanel.tsx
+++ b/src/components/PromptPanel.tsx
@@ -5,6 +5,7 @@ import { useScoreStore, ChatMessage, RecordedOperation } from "@/store/score-sto
 import { matchBuiltinCommand, BUILTIN_COMMANDS } from "@/lib/transforms";
 import { IS_STATIC_EXPORT, STATIC_FEATURE_DISABLED_MESSAGE } from "@/lib/api-availability";
 import { v4 as uuidv4 } from "uuid";
+import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
 export default function PromptPanel() {
   const [input, setInput] = useState("");
@@ -35,6 +36,8 @@ export default function PromptPanel() {
     if (!input.trim() || isGenerating) return;
 
     const prompt = input.trim();
+    // Analytics: log only that a message was sent — NEVER the prompt content.
+    logEvent({ event: "ai_send", scoreType: scoreTypeOf(score) });
     const userMsg: ChatMessage = {
       id: uuidv4(),
       role: "user",
@@ -173,6 +176,7 @@ export default function PromptPanel() {
         timestamp: Date.now(),
       });
     } catch (err: any) {
+      logEvent({ event: "error", name: "ai_request", scoreType: scoreTypeOf(score) });
       addMessage({
         id: uuidv4(),
         role: "assistant",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,153 @@
+// Lightweight client-side usage instrumentation. Logs anonymized interaction
+// events to a localStorage ring buffer so we can inspect what users do without
+// shipping any of their content. Event payloads are deliberately minimal:
+// names + score type + platform — never lyrics, chord names, annotation text,
+// AI prompts, or any user-typed string.
+//
+// Storage layout:
+//   localStorage["notation-app-analytics"] = JSON array, oldest-first, capped
+//     at MAX_EVENTS. Oldest entries are dropped when full.
+//   sessionStorage["notation-app-session-id"] = UUID generated lazily once per
+//     browser session; cleared when the tab closes.
+
+import { v4 as uuidv4 } from "uuid";
+import packageJson from "../../package.json";
+
+const STORAGE_KEY = "notation-app-analytics";
+const SESSION_KEY = "notation-app-session-id";
+const MAX_EVENTS = 500;
+
+export type ScoreType = "notation" | "chord-chart" | "none";
+
+export interface AnalyticsEvent {
+  event: string;
+  timestamp: number;
+  sessionId: string;
+  appVersion: string;
+  scoreType: ScoreType;
+  platform: string;
+}
+
+// Optional per-event extras — kept tiny on purpose. Callers may pass a
+// `name` (menu item label, mode name, error type, etc.); we never accept
+// freeform user content here. No `text`, `prompt`, `lyric`, or `chord`
+// fields exist by design.
+export interface LogEventInput {
+  event: string;
+  scoreType?: ScoreType;
+  name?: string;
+}
+
+const APP_VERSION = (packageJson as { version?: string }).version ?? "unknown";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function getPlatform(): string {
+  if (!isBrowser()) return "ssr";
+  const nav = window.navigator;
+  // userAgentData is the modern, privacy-conscious surface; fall back to
+  // platform/userAgent for older browsers. We only record the broad bucket
+  // (Mac, Windows, Linux, iOS, Android, Other) — never the full UA.
+  const uaPlatform = (nav as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform
+    ?? nav.platform
+    ?? "";
+  const ua = nav.userAgent || "";
+  const lower = (uaPlatform || ua).toLowerCase();
+  if (lower.includes("iphone") || lower.includes("ipad") || lower.includes("ios")) return "iOS";
+  if (lower.includes("android")) return "Android";
+  if (lower.includes("mac")) return "macOS";
+  if (lower.includes("win")) return "Windows";
+  if (lower.includes("linux")) return "Linux";
+  return "Other";
+}
+
+function getSessionId(): string {
+  if (!isBrowser()) return "ssr";
+  try {
+    const existing = window.sessionStorage.getItem(SESSION_KEY);
+    if (existing) return existing;
+    const fresh = uuidv4();
+    window.sessionStorage.setItem(SESSION_KEY, fresh);
+    return fresh;
+  } catch {
+    // Session storage can throw in privacy modes — fall back to a per-call
+    // id so we still log something coherent within this call.
+    return "no-session";
+  }
+}
+
+function readBuffer(): AnalyticsEvent[] {
+  if (!isBrowser()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeBuffer(events: AnalyticsEvent[]): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+  } catch {
+    // Quota exceeded or storage disabled — drop silently. Analytics must
+    // never break the app.
+  }
+}
+
+export function logEvent(input: LogEventInput | AnalyticsEvent): void {
+  if (!isBrowser()) return;
+  const eventName = input.event;
+  if (!eventName) return;
+  // If the caller passes a fully-formed event (e.g. replaying), respect its
+  // fields; otherwise fill in the contextual ones.
+  const fullEvent: AnalyticsEvent = "sessionId" in input && "timestamp" in input
+    ? input as AnalyticsEvent
+    : {
+        event: input.name ? `${eventName}:${input.name}` : eventName,
+        timestamp: Date.now(),
+        sessionId: getSessionId(),
+        appVersion: APP_VERSION,
+        scoreType: (input as LogEventInput).scoreType ?? "none",
+        platform: getPlatform(),
+      };
+  const buffer = readBuffer();
+  buffer.push(fullEvent);
+  while (buffer.length > MAX_EVENTS) buffer.shift();
+  writeBuffer(buffer);
+  // Notify in-page listeners (the debug overlay polls via this event).
+  try {
+    window.dispatchEvent(new CustomEvent("notation-app-analytics", { detail: fullEvent }));
+  } catch {
+    // CustomEvent unavailable in some environments — non-fatal.
+  }
+}
+
+export function getEvents(): AnalyticsEvent[] {
+  return readBuffer();
+}
+
+export function clearEvents(): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+    window.dispatchEvent(new CustomEvent("notation-app-analytics", { detail: null }));
+  } catch {
+    // ignore
+  }
+}
+
+// Helper: classify a score for the `scoreType` field. Matches the same
+// branching the rest of the app uses (chord-chart when sections are
+// populated, notation otherwise).
+export function scoreTypeOf(score: { sections?: unknown[] } | null | undefined): ScoreType {
+  if (!score) return "none";
+  const sections = score.sections;
+  if (Array.isArray(sections) && sections.length > 0) return "chord-chart";
+  return "notation";
+}


### PR DESCRIPTION
## Summary

Adds anonymized usage instrumentation behind a 500-event localStorage ring buffer (issue #54). Logs *what* the user does (mode switches, menu actions, modal lifecycles, annotation CRUD, AI sends, score new/type-switch, caught errors) — never *what they typed*. No lyrics, chord names, annotation text, or AI prompts are stored.

- `src/lib/analytics.ts`: `logEvent`/`getEvents`/`clearEvents` against `localStorage["notation-app-analytics"]` (max 500, oldest dropped). Per-session UUID in `sessionStorage`. SSR-safe (window/typeof guards).
- Wires `logEvent` in: `ModeSelector`, `MenuBar` (every menu item + import/transcribe/open errors), `PasteLyricsModal` (open/submit/cancel via mount/unmount), `MySongsModal` (open/load/save/save_as/delete), `PromptPanel` (ai_send + ai_request error), `AnnotationLayer` (create/edit/delete), and `page.tsx` (AI drawer toggle, in-page New Score buttons, notation↔chord-chart type switch).
- `src/components/DebugOverlay.tsx`: small fixed bottom-right panel showing the last 20 events, Clear button, toggled via `?debug=1`, `localStorage["notation-app-debug"]="true"`, or **Ctrl+Shift+D**. Mounted in `src/app/page.tsx`.

## Test plan

- [ ] Visit the app with `?debug=1` and confirm the overlay appears and updates as you interact.
- [ ] Press **Ctrl+Shift+D** with the overlay hidden — it should appear; press again to hide.
- [ ] Switch modes (Edit / Perform / Annotate) and confirm `mode_switch:<mode>` events.
- [ ] Open File / Edit / View / Tools menus, click items — confirm `menu:<Menu>>Item` events.
- [ ] Open and cancel the Paste Lyrics modal — confirm `paste_lyrics_open` followed by `paste_lyrics_cancel`. Open and Apply — confirm `paste_lyrics_submit`.
- [ ] Open My Songs, save / load / delete — confirm `mysongs_open`, `mysongs_save`, `mysongs_load`, `mysongs_delete`.
- [ ] Toggle the AI panel drawer — confirm `ai_panel_open` / `ai_panel_close`. Send a message — confirm `ai_send`.
- [ ] Create / edit / delete an annotation — confirm respective events.
- [ ] Click "New Score" / "New Chord Chart" — confirm `score_new:notation` / `score_new:chord-chart`. Switch from one type to the other — confirm `score_type_switch:notation->chord-chart`.
- [ ] Inspect events in DevTools: `JSON.parse(localStorage["notation-app-analytics"])` shows event/timestamp/sessionId/appVersion/scoreType/platform — no user content.
- [ ] Force errors (drop a malformed JSON in Import) and confirm `error:<type>` events with no stack/details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)