### PR TITLE
Annotate button stays in upper-right across modes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ import PersistFailureBanner from "@/components/PersistFailureBanner";
 import { CLOUD_ENABLED, getDeviceId } from "@/lib/song-cloud";
 import { autosaveToCloud } from "@/lib/cloud-autosave";
 import AnnotationLayer from "@/components/AnnotationLayer";
+import AnnotateToggle from "@/components/AnnotateToggle";
 import AnnotationFilterBar from "@/components/AnnotationFilterBar";
 import { cleanScoreOverflow } from "@/lib/score-cleanup";
 
@@ -1218,6 +1219,18 @@ export default function Home() {
           onExit={() => setUIState({ performMode: false })}
           onOpenMySongs={() => setMySongsOpen(true)}
         />
+      )}
+
+      {/* Annotate sub-mode toggle — pinned to the top-right of the
+          viewport in edit mode (PerformView renders its own at the same
+          screen position when active, so this one is hidden behind it).
+          Putting it in a fixed wrapper guarantees it lives in the SAME
+          screen location whether the user is in Edit or Perform — no
+          button-shuffling between modes. */}
+      {!uiState.performMode && score && (
+        <div className="fixed top-3 right-3 z-40 flex items-center gap-1 rounded-xl bg-gray-900/80 backdrop-blur-sm shadow border border-white/10 p-1 print-hide">
+          <AnnotateToggle />
+        </div>
       )}
     </div>
   );

--- a/src/components/AnnotateToggle.tsx
+++ b/src/components/AnnotateToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useScoreStore } from "@/store/score-store";
+
+/**
+ * Annotate sub-mode toggle. Pinned to the top-right of the viewport in
+ * the SAME screen position whether the user is in Edit or Perform — that
+ * consistency is the whole point. Toggles uiState.annotationMode without
+ * touching performMode.
+ *
+ * In PerformView this is rendered next to an Edit button (which exits
+ * perform); in edit-mode page.tsx it's rendered alone.
+ */
+export default function AnnotateToggle() {
+  const annotationMode = useScoreStore((s) => s.uiState.annotationMode);
+  const setUIState = useScoreStore((s) => s.setUIState);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setUIState({ annotationMode: !annotationMode })}
+      aria-pressed={annotationMode}
+      aria-label={annotationMode ? "Stop annotating" : "Annotate"}
+      title={
+        annotationMode
+          ? "Tap the chart to add a sticky note. Tap Annotating to stop."
+          : "Annotate — drop sticky notes on the chart"
+      }
+      className={`px-3 h-11 rounded-lg text-sm font-medium transition-colors ${
+        annotationMode
+          ? "bg-yellow-400 text-gray-900 hover:bg-yellow-300"
+          : "text-gray-100 hover:bg-gray-800 active:bg-gray-700"
+      }`}
+    >
+      {annotationMode ? "Annotating" : "Annotate"}
+    </button>
+  );
+}

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -5,12 +5,10 @@ import { useScoreStore } from "@/store/score-store";
 type Mode = "edit" | "perform";
 
 /**
- * Top-level mode selector — Edit | Perform — plus an Annotate toggle next
- * to it. Annotate is a sub-mode that overlays either Edit or Perform: the
- * button toggles uiState.annotationMode without touching performMode, so
- * the user can drop sticky notes from whichever top-level view they're in
- * and the behavior is identical in both. Mirrors the Annotate button in
- * PerformView's top-right cluster.
+ * Top-level mode selector — Edit | Perform. Annotate is a sub-mode that
+ * lives in the upper-right of the viewport (rendered separately by
+ * AnnotateToggle) and overlays either Edit or Perform without changing
+ * which top-level mode is active.
  */
 export default function ModeSelector() {
   const { uiState, setUIState, score } = useScoreStore();
@@ -29,66 +27,43 @@ export default function ModeSelector() {
     { id: "perform", label: "Perform", disabled: !hasChordChart },
   ];
 
-  const annotating = uiState.annotationMode;
-
   return (
-    <div className="inline-flex items-center gap-2">
-      <div
-        className="inline-flex items-center rounded-md bg-white/8 border border-white/15 overflow-hidden"
-        style={{ minHeight: 44 }}
-        role="tablist"
-        aria-label="Editor mode"
-      >
-        {segments.map((seg, i) => {
-          const isActive = currentMode === seg.id;
-          const isDisabled = seg.disabled;
-          return (
-            <button
-              key={seg.id}
-              role="tab"
-              aria-selected={isActive}
-              disabled={isDisabled}
-              onClick={() => selectMode(seg.id)}
-              className={[
-                "px-4 text-sm font-medium h-full transition-colors",
-                i > 0 ? "border-l border-white/15" : "",
-                isActive
-                  ? "bg-white text-gray-900"
-                  : isDisabled
-                  ? "text-gray-600 cursor-not-allowed"
-                  : "text-gray-300 hover:bg-white/10 cursor-pointer",
-              ].join(" ")}
-              style={{ minHeight: 44 }}
-              title={
-                seg.id === "perform" && isDisabled
-                  ? "Perform mode requires a chord-chart score"
-                  : undefined
-              }
-            >
-              {seg.label}
-            </button>
-          );
-        })}
-      </div>
-      <button
-        type="button"
-        onClick={() => setUIState({ annotationMode: !annotating })}
-        aria-pressed={annotating}
-        aria-label={annotating ? "Stop annotating" : "Annotate"}
-        title={annotating
-          ? "Tap the chart to add a sticky note. Tap Annotating to stop."
-          : "Annotate — drop sticky notes on the chart (works in Edit and Perform)"
-        }
-        className={[
-          "px-4 text-sm font-medium rounded-md border transition-colors",
-          annotating
-            ? "bg-yellow-300 text-gray-900 border-yellow-400 hover:bg-yellow-200"
-            : "bg-white/8 text-gray-300 border-white/15 hover:bg-white/15",
-        ].join(" ")}
-        style={{ minHeight: 44 }}
-      >
-        {annotating ? "Annotating" : "Annotate"}
-      </button>
+    <div
+      className="inline-flex items-center rounded-md bg-white/8 border border-white/15 overflow-hidden"
+      style={{ minHeight: 44 }}
+      role="tablist"
+      aria-label="Editor mode"
+    >
+      {segments.map((seg, i) => {
+        const isActive = currentMode === seg.id;
+        const isDisabled = seg.disabled;
+        return (
+          <button
+            key={seg.id}
+            role="tab"
+            aria-selected={isActive}
+            disabled={isDisabled}
+            onClick={() => selectMode(seg.id)}
+            className={[
+              "px-4 text-sm font-medium h-full transition-colors",
+              i > 0 ? "border-l border-white/15" : "",
+              isActive
+                ? "bg-white text-gray-900"
+                : isDisabled
+                ? "text-gray-600 cursor-not-allowed"
+                : "text-gray-300 hover:bg-white/10 cursor-pointer",
+            ].join(" ")}
+            style={{ minHeight: 44 }}
+            title={
+              seg.id === "perform" && isDisabled
+                ? "Perform mode requires a chord-chart score"
+                : undefined
+            }
+          >
+            {seg.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -5,6 +5,7 @@ import type { Score } from "@/lib/schema";
 import ChordChartView from "@/components/ChordChartView";
 import PaginatedPerformChart from "@/components/PaginatedPerformChart";
 import AnnotationLayer from "@/components/AnnotationLayer";
+import AnnotateToggle from "@/components/AnnotateToggle";
 import { useScoreStore } from "@/store/score-store";
 import { getSongs, type SongBankEntry } from "@/lib/song-bank";
 
@@ -361,31 +362,15 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
         </>
       )}
 
-      {/* Mode buttons — pinned to the top-right, never wrap off-screen.
-          Annotate toggles annotationMode while staying in perform (same
-          scroll position, same chrome) so the user can drop a sticky
-          note where they're already looking. Edit exits perform back to
-          the full editor. */}
+      {/* Mode cluster — pinned top-right in the SAME screen position used
+          in edit mode (see <AnnotateToggle /> rendered from page.tsx).
+          Annotate stays in place whether you're in Edit or Perform; only
+          the neighbor changes (Perform shows an Edit-out button here). */}
       <div className="absolute top-3 right-3 z-30 flex items-center gap-1 rounded-xl bg-gray-900/80 backdrop-blur-sm shadow border border-white/10 p-1">
-        <button
-          type="button"
-          onClick={() => setUIState({ annotationMode: !annotationMode })}
-          className={`px-3 h-11 rounded-lg text-sm font-medium transition-colors ${
-            annotationMode
-              ? "bg-yellow-400 text-gray-900 hover:bg-yellow-300"
-              : "text-gray-100 hover:bg-gray-800 active:bg-gray-700"
-          }`}
-          aria-pressed={annotationMode}
-          aria-label={annotationMode ? "Stop annotating" : "Annotate"}
-          title={annotationMode ? "Tap the chart to add a note. Tap Annotating to stop." : "Annotate — drop sticky notes on the chart"}
-        >
-          {annotationMode ? "Annotating" : "Annotate"}
-        </button>
+        <AnnotateToggle />
         <button
           type="button"
           onClick={() => {
-            // Leaving perform also clears annotate so the editor opens in
-            // its normal edit state, not in annotate-while-edit.
             if (annotationMode) setUIState({ annotationMode: false });
             onExit();
           }}


### PR DESCRIPTION
Same button, same screen position whether you're in Edit or Perform — no shuffling. Single AnnotateToggle component used by both call sites; ModeSelector reverts to Edit | Perform only.