### PR TITLE
Kill white border around edit screen

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -717,7 +717,7 @@ export default function Home() {
         )}
 
         {/* Center: Score View — chord chart if `sections` is populated, else notation */}
-        <div className="flex-1 overflow-auto p-4 print-full bg-[#f8f9fa]">
+        <div className="flex-1 overflow-auto print-full bg-[#f8f9fa]">
           {score ? (
             score.sections && score.sections.length > 0 ? (
               <div className="score-container h-full relative">

--- a/src/components/ScoreRenderer.tsx
+++ b/src/components/ScoreRenderer.tsx
@@ -1121,7 +1121,7 @@ export default function ScoreRenderer({
   }, []);
 
   return (
-    <div className="relative w-full h-full overflow-auto bg-white rounded-lg">
+    <div className="relative w-full h-full overflow-auto bg-white">
       {loading && (
         <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-10">
           <div className="flex items-center gap-2 text-gray-500">


### PR DESCRIPTION
Removes p-4 padding on the outer score view and the rounded-lg corner on ScoreRenderer's container so the score area sits edge-to-edge.