### PR TITLE
Pack chord-chart columns by line — kill overflow cutoff

### DIFF
--- a/src/components/PaginatedPerformChart.tsx
+++ b/src/components/PaginatedPerformChart.tsx
@@ -1,14 +1,28 @@
 "use client";
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { ChordChartSection, Score } from "@/lib/schema";
+import type { ChordChartSection, ChordChartLine, Score } from "@/lib/schema";
 
 const MONO_FONT_STACK =
   "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
 
+/**
+ * Each block is either a section header or a single line. The packer
+ * treats them independently so a section never bleeds past the bottom of
+ * a column — the worst case is a clean break between two of its lines.
+ * Continuation columns get a "(Section Label …)" label so the user
+ * doesn't lose context.
+ */
+type Block =
+  | { kind: "header"; sectionId: string; section: ChordChartSection }
+  | { kind: "line"; sectionId: string; lineIdx: number; line: ChordChartLine };
+
+interface ColumnContent {
+  blocks: Block[];
+}
 interface Page {
-  col1: ChordChartSection[];
-  col2: ChordChartSection[];
+  col1: ColumnContent;
+  col2: ColumnContent;
 }
 
 interface PerformPrefsLike {
@@ -21,17 +35,15 @@ interface PaginatedPerformChartProps {
   score: Score;
   prefs: PerformPrefsLike;
   /** Forwarded ref to the horizontally-scrolling pages strip; PerformView
-   *  uses it to drive the top/bottom tap zones. */
+   *  uses it to drive the bottom pager. */
   scrollRef: React.RefObject<HTMLDivElement | null>;
   onPageChange?: (current: number, total: number) => void;
 }
 
 /**
- * Quark-XPress-style 2-column performance layout. Treats each section as
- * an atomic block, measures its rendered height, then bin-packs sections
- * into a chain of (page, column) slots — col1 of page 1, then col2 of
- * page 1, then col1 of page 2, etc. Pages are laid out horizontally and
- * scroll-snap so each tap-zone advance lands on a clean page.
+ * Quark-XPress-style 2-column performance layout. Bin-packs by individual
+ * line (and section header) so columns always end on a clean line boundary
+ * — content can't bleed past the column edge regardless of section size.
  *
  * Reflow is automatic: font/leading/kerning change, ResizeObserver, or
  * score change all retrigger measurement and re-pack.
@@ -49,9 +61,20 @@ export default function PaginatedPerformChart({
   const [pages, setPages] = useState<Page[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
 
-  // Re-pack: read rendered section heights from the hidden measure column,
-  // walk in order, and assign each section to the current slot. Move to
-  // the next slot when a section won't fit in the remaining column space.
+  // Flatten the score into per-line blocks. Headers are their own block so
+  // we can measure them and decide whether to keep the header attached to
+  // its first line at column boundaries.
+  const blocks: Block[] = [];
+  for (const section of score.sections) {
+    blocks.push({ kind: "header", sectionId: section.id, section });
+    section.lines.forEach((line, lineIdx) => {
+      blocks.push({ kind: "line", sectionId: section.id, lineIdx, line });
+    });
+  }
+
+  const blockKey = (b: Block) =>
+    b.kind === "header" ? `h:${b.sectionId}` : `l:${b.sectionId}:${b.lineIdx}`;
+
   const recompute = useCallback(() => {
     const outer = outerRef.current;
     if (!outer) return;
@@ -59,27 +82,26 @@ export default function PaginatedPerformChart({
     const pageH = outer.clientHeight;
     if (pageW === 0 || pageH === 0) return;
 
-    // Visible-page padding. Mirrors the .perform-page class below.
-    const PAD_X = 16; // px
-    const PAD_Y = 8; // px
-    const COL_GAP = 32; // px (matches gap-8)
-
+    const PAD_Y = 8; // px — matches .py-2 on each visible page
     const colHeight = pageH - 2 * PAD_Y;
 
     const heights = new Map<string, number>();
-    score.sections.forEach((s) => {
-      const el = measureRefs.current.get(s.id);
-      if (el) heights.set(s.id, el.getBoundingClientRect().height);
-    });
+    for (const b of blocks) {
+      const key = blockKey(b);
+      const el = measureRefs.current.get(key);
+      if (el) heights.set(key, el.getBoundingClientRect().height);
+    }
 
     const result: Page[] = [];
-    let curPage: Page = { col1: [], col2: [] };
+    let curPage: Page = { col1: { blocks: [] }, col2: { blocks: [] } };
     let curCol: "col1" | "col2" = "col1";
     let used = 0;
 
     const flushPage = () => {
-      if (curPage.col1.length || curPage.col2.length) result.push(curPage);
-      curPage = { col1: [], col2: [] };
+      const hasContent =
+        curPage.col1.blocks.length > 0 || curPage.col2.blocks.length > 0;
+      if (hasContent) result.push(curPage);
+      curPage = { col1: { blocks: [] }, col2: { blocks: [] } };
       curCol = "col1";
       used = 0;
     };
@@ -92,33 +114,33 @@ export default function PaginatedPerformChart({
       }
     };
 
-    for (const section of score.sections) {
-      const h = heights.get(section.id) ?? 0;
-      // If this section is too tall for an empty column, just place it on
-      // its own column and let it bleed; the alternative (skipping it) is
-      // worse. The user can shrink the font to fit.
-      if (h > colHeight && curPage[curCol].length > 0) {
+    for (let i = 0; i < blocks.length; i++) {
+      const b = blocks[i];
+      const h = heights.get(blockKey(b)) ?? 0;
+
+      // If a header lands at the bottom of a column with no room for at
+      // least its first line, push the header to the next column so the
+      // user never sees an orphan title.
+      if (b.kind === "header" && curPage[curCol].blocks.length > 0) {
+        const next = blocks[i + 1];
+        const nextH = next ? (heights.get(blockKey(next)) ?? 0) : 0;
+        if (used + h + nextH > colHeight) {
+          advanceCol();
+        }
+      } else if (used + h > colHeight && curPage[curCol].blocks.length > 0) {
         advanceCol();
       }
-      // If it doesn't fit in the remaining column space, move to next.
-      if (used + h > colHeight && curPage[curCol].length > 0) {
-        advanceCol();
-      }
-      curPage[curCol].push(section);
+
+      curPage[curCol].blocks.push(b);
       used += h;
     }
     flushPage();
 
     setPages(result);
-    // Suppress unused vars
     void pageW;
-    void PAD_X;
-    void COL_GAP;
-  }, [score]);
+  }, [blocks]);
 
   // Measure-then-pack on mount, when score or prefs change, and on resize.
-  // useLayoutEffect runs synchronously after DOM mutation so the measurement
-  // pass is in the DOM before we read sizes.
   useLayoutEffect(() => {
     recompute();
   }, [recompute, prefs.fontSize, prefs.lineHeight, prefs.letterSpacing]);
@@ -145,32 +167,89 @@ export default function PaginatedPerformChart({
     return () => el.removeEventListener("scroll", onScroll);
   }, [scrollRef, pages.length, onPageChange]);
 
+  // Render a column from a list of blocks. Consecutive line blocks that
+  // share a section are grouped under a continuation label when no header
+  // block is at the start of the run.
+  const renderColumn = (col: ColumnContent) => {
+    const out: React.ReactElement[] = [];
+    let runSectionId: string | null = null;
+    let runStartedWithHeader = false;
+    let runLines: { line: ChordChartLine; lineIdx: number }[] = [];
+    let runHeaderSection: ChordChartSection | null = null;
+
+    const flushRun = (key: string) => {
+      if (!runSectionId) return;
+      out.push(
+        <PerformSectionGroup
+          key={key}
+          section={runHeaderSection /* may be null = continuation */}
+          continuation={!runStartedWithHeader}
+          continuationLabel={
+            !runStartedWithHeader
+              ? score.sections.find((s) => s.id === runSectionId)?.label
+              : undefined
+          }
+          lines={runLines}
+        />,
+      );
+      runSectionId = null;
+      runStartedWithHeader = false;
+      runLines = [];
+      runHeaderSection = null;
+    };
+
+    col.blocks.forEach((b, i) => {
+      if (b.kind === "header") {
+        flushRun(`r-${i}`);
+        runSectionId = b.sectionId;
+        runStartedWithHeader = true;
+        runHeaderSection = b.section;
+      } else {
+        if (b.sectionId !== runSectionId) {
+          flushRun(`r-${i}`);
+          runSectionId = b.sectionId;
+          runStartedWithHeader = false;
+        }
+        runLines.push({ line: b.line, lineIdx: b.lineIdx });
+      }
+    });
+    flushRun(`r-end`);
+    return out;
+  };
+
   return (
     <div
       ref={outerRef}
-      className="absolute inset-0 pt-[7vh] pb-[9vh] overflow-hidden"
+      className="absolute inset-0 pt-[7vh] pb-16 overflow-hidden"
     >
-      {/* Hidden measurement column. Width matches a real visible column so
-          height measurements correspond to what'll be rendered. Also pulls
-          in the same CSS variables (font-size, line-height, letter-spacing)
-          as the visible columns via inheritance from PerformView. */}
+      {/* Hidden measurement column. Width matches a real visible column
+          (page px-4 + grid gap-8 = 64px non-column overhead per page).
+          Each block — section header and individual line — is measured
+          independently so the packer can fit them per column. */}
       <div
         ref={measureContainerRef}
         aria-hidden
         className="absolute opacity-0 pointer-events-none top-0 left-0"
-        style={{ width: "calc((100% - 32px) / 2 - 32px)" }}
+        style={{ width: "calc((100% - 64px) / 2)" }}
       >
-        {score.sections.map((s) => (
-          <div
-            key={s.id}
-            ref={(el) => { measureRefs.current.set(s.id, el); }}
-          >
-            <PerformSection section={s} />
-          </div>
-        ))}
+        {blocks.map((b) => {
+          const key = blockKey(b);
+          return (
+            <div
+              key={key}
+              ref={(el) => { measureRefs.current.set(key, el); }}
+            >
+              {b.kind === "header" ? (
+                <PerformSectionHeader section={b.section} />
+              ) : (
+                <PerformLine line={b.line} />
+              )}
+            </div>
+          );
+        })}
       </div>
 
-      {/* Visible pages strip — horizontal scroll-snap so the tap zones advance
+      {/* Visible pages strip — horizontal scroll-snap so the pager advances
           one page per click. */}
       <div
         ref={scrollRef}
@@ -182,15 +261,8 @@ export default function PaginatedPerformChart({
             key={i}
             className="shrink-0 w-full h-full snap-start grid grid-cols-2 gap-8 px-4 py-2"
           >
-            {/* overflow-y-auto so a section taller than the column doesn't
-                get clipped — user can scroll within the column. Beats the
-                previous overflow-hidden which silently cut content off. */}
-            <div className="overflow-y-auto overflow-x-hidden">
-              {page.col1.map((s) => <PerformSection key={s.id} section={s} />)}
-            </div>
-            <div className="overflow-y-auto overflow-x-hidden">
-              {page.col2.map((s) => <PerformSection key={s.id} section={s} />)}
-            </div>
+            <div className="overflow-hidden">{renderColumn(page.col1)}</div>
+            <div className="overflow-hidden">{renderColumn(page.col2)}</div>
           </div>
         ))}
         {pages.length === 0 && (
@@ -210,12 +282,6 @@ export default function PaginatedPerformChart({
   );
 }
 
-/**
- * Read-only section renderer for paginated perform mode. Mirrors the look
- * of the editor's SectionBlock but without any click handlers, edit inputs,
- * or "Add line" affordance — and crucially each section is structurally
- * isolated so the bin-packer can measure it as one unit.
- */
 /** Read-only renderer for a lyric line with per-character highlight/
  *  underline ranges. Mirrors MarkedLyricText in ChordChartView. */
 function PerformMarkedLyric({
@@ -273,61 +339,88 @@ const PERFORM_NAV_LABELS: Record<string, string> = {
   "d.s. al coda": "D.S. al Coda",
 };
 
-function PerformSection({ section }: { section: ChordChartSection }) {
+function PerformSectionHeader({ section }: { section: ChordChartSection }) {
+  return (
+    <h3 className="text-pink-300 italic font-semibold text-base mb-1 inline-flex items-baseline flex-wrap gap-2">
+      <span>{section.label}</span>
+      {section.endingNumber && (
+        <span className="text-xs font-mono text-amber-300 border-2 border-b-0 border-amber-300/80 px-1.5 pt-0.5 leading-tight">
+          {section.endingNumber}.
+        </span>
+      )}
+      {section.repeatStart && <span className="text-pink-200">𝄆</span>}
+      {section.repeatEnd && <span className="text-pink-200">𝄇</span>}
+      {section.navMark && (
+        <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-purple-500/30 text-purple-100 not-italic">
+          {PERFORM_NAV_LABELS[section.navMark] ?? section.navMark}
+        </span>
+      )}
+    </h3>
+  );
+}
+
+function PerformLine({ line }: { line: ChordChartLine }) {
+  const markerClasses = [
+    line.highlight ? "bg-yellow-300/20 rounded px-1" : "",
+    line.underline ? "border-b-2 border-yellow-400/80" : "",
+  ].filter(Boolean).join(" ");
+  return (
+    <div
+      className={`mb-2 ${markerClasses}`}
+      style={{
+        fontFamily: MONO_FONT_STACK,
+        fontSize: "var(--perf-font-size, 0.875rem)",
+        lineHeight: "var(--perf-line-height, 1.25)",
+        letterSpacing: "var(--perf-letter-spacing, normal)",
+      }}
+    >
+      {line.chords && (
+        <div className="text-yellow-300 whitespace-pre min-h-[1em]">
+          {line.chords}
+        </div>
+      )}
+      {line.lyrics && (
+        <div className="text-gray-100 whitespace-pre">
+          <PerformMarkedLyric
+            text={line.lyrics}
+            highlightRanges={line.highlightRanges}
+            underlineRanges={line.underlineRanges}
+          />
+        </div>
+      )}
+      {!line.chords && !line.lyrics && (
+        <div className="text-gray-500 whitespace-pre min-h-[1em]">&nbsp;</div>
+      )}
+    </div>
+  );
+}
+
+/** A run of one or more consecutive lines from the same section — either
+ *  starting with the section's real header, or (when the run starts mid-
+ *  section after a column break) prefixed with a faint continuation label
+ *  so the user keeps context. */
+function PerformSectionGroup({
+  section,
+  continuation,
+  continuationLabel,
+  lines,
+}: {
+  section: ChordChartSection | null;
+  continuation: boolean;
+  continuationLabel?: string;
+  lines: { line: ChordChartLine; lineIdx: number }[];
+}) {
   return (
     <section className="mb-3">
-      <h3 className="text-pink-300 italic font-semibold text-base mb-1 inline-flex items-baseline flex-wrap gap-2">
-        <span>{section.label}</span>
-        {section.endingNumber && (
-          <span className="text-xs font-mono text-amber-300 border-2 border-b-0 border-amber-300/80 px-1.5 pt-0.5 leading-tight">
-            {section.endingNumber}.
-          </span>
-        )}
-        {section.repeatStart && <span className="text-pink-200">𝄆</span>}
-        {section.repeatEnd && <span className="text-pink-200">𝄇</span>}
-        {section.navMark && (
-          <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-purple-500/30 text-purple-100 not-italic">
-            {PERFORM_NAV_LABELS[section.navMark] ?? section.navMark}
-          </span>
-        )}
-      </h3>
-      <div
-        className="chord-chart-line-body whitespace-pre"
-        style={{
-          fontFamily: MONO_FONT_STACK,
-          fontSize: "var(--perf-font-size, 0.875rem)",
-          lineHeight: "var(--perf-line-height, 1.25)",
-          letterSpacing: "var(--perf-letter-spacing, normal)",
-        }}
-      >
-        {section.lines.map((line, i) => {
-          const markerClasses = [
-            line.highlight ? "bg-yellow-300/20 -mx-2 px-2 rounded" : "",
-            line.underline ? "border-b-2 border-yellow-400/80" : "",
-          ].filter(Boolean).join(" ");
-          return (
-            <div key={i} className={`mb-2 ${markerClasses}`}>
-              {line.chords && (
-                <div className="text-yellow-300 whitespace-pre min-h-[1em]">
-                  {line.chords}
-                </div>
-              )}
-              {line.lyrics && (
-                <div className="text-gray-100 whitespace-pre">
-                  <PerformMarkedLyric
-                    text={line.lyrics}
-                    highlightRanges={line.highlightRanges}
-                    underlineRanges={line.underlineRanges}
-                  />
-                </div>
-              )}
-              {!line.chords && !line.lyrics && (
-                <div className="text-gray-500 whitespace-pre min-h-[1em]">&nbsp;</div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {!continuation && section && <PerformSectionHeader section={section} />}
+      {continuation && continuationLabel && (
+        <div className="text-pink-300/60 italic text-xs mb-1">
+          {continuationLabel} (cont’d)
+        </div>
+      )}
+      {lines.map(({ line, lineIdx }) => (
+        <PerformLine key={lineIdx} line={line} />
+      ))}
     </section>
   );
 }


### PR DESCRIPTION
Bin-packer now treats each section header and line as independent blocks. Columns always break on a clean line boundary; sections that span columns get a 'Section (cont'd)' label so context isn't lost.