### PR TITLE
fix: apply basePath to MenuBar docs links so they resolve on Pages

### DIFF
--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -11,6 +11,10 @@ import { IS_STATIC_EXPORT, STATIC_FEATURE_DISABLED_MESSAGE } from "@/lib/api-ava
 import { v4 as uuidv4 } from "uuid";
 import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
+// On the GitHub Pages static export, the app is served from /NotationApp/.
+// next/link auto-applies basePath, but raw <a href> and window.open() do not.
+const DOCS_HREF = IS_STATIC_EXPORT ? "/NotationApp/docs/" : "/docs";
+
 interface MenuBarProps {
   zoom: number;
   onZoomChange: (zoom: number) => void;
@@ -391,7 +395,7 @@ export default function MenuBar({
   ];
 
   const toolsMenu: MenuItem[] = [
-    { label: "User Guide", action: () => { if (typeof window !== "undefined") window.open("/docs", "_blank"); } },
+    { label: "User Guide", action: () => { if (typeof window !== "undefined") window.open(DOCS_HREF, "_blank"); } },
   ];
 
   return (
@@ -482,7 +486,7 @@ export default function MenuBar({
           </button>
           <span className="text-gray-700 mx-1">|</span>
           <a
-            href="/docs"
+            href={DOCS_HREF}
             target="_blank"
             rel="noopener noreferrer"
             className="w-5 h-5 flex items-center justify-center text-[11px] font-bold text-gray-400 hover:bg-white/10 hover:text-gray-200 rounded-full border border-white/15"


### PR DESCRIPTION
## Summary
- Fix the **Tools → User Guide** menu entry and the menu-bar **?** anchor — they currently 404 on the GitHub Pages deploy.
- Cause: app is served from `/NotationApp/` on Pages (`basePath` in `next.config.ts:14`). `next/link` auto-prepends basePath, but the raw `window.open("/docs")` (`MenuBar.tsx:394`) and `<a href="/docs">` (`MenuBar.tsx:485`) bypass it, landing on `https://gibsonds.github.io/docs` → 404.
- Fix: compute `DOCS_HREF` once from `IS_STATIC_EXPORT` (`/NotationApp/docs/` on Pages, `/docs` in dev) and use it in both spots.

## Test plan
- [ ] Static-export build (`STATIC_EXPORT=1 npm run build`) — Tools → User Guide and the `?` button both open `/NotationApp/docs/` in a new tab.
- [ ] Dev (`npm run dev`) — same actions open `/docs`.
- [ ] After deploy, click Tools → User Guide on `https://gibsonds.github.io/NotationApp/` and confirm the docs page loads (no 404).

https://claude.ai/code/session_01DjCP1AyKrCuEg36AFeCR3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjCP1AyKrCuEg36AFeCR3A)_