### PR TITLE
Ledger line width: multiply OSMD default, not staff width

### DIFF
--- a/src/components/ScoreRenderer.tsx
+++ b/src/components/ScoreRenderer.tsx
@@ -177,7 +177,13 @@ function applyLayout(osmd: any, layout: LayoutSettings, zoomLevel: number) {
     rules.TieHeightMaximum = 1.4;
     rules.BeamSlopeMaxAngle = 10;
   }
-  rules.LedgerLineWidth = rules.StaffLineWidth * layout.ledgerLineWeight;
+  // OSMD's default LedgerLineWidth is 1.0 in its own units (about 10× the
+  // 0.1 StaffLineWidth — yes, the units are different scales). Multiplying
+  // staff-width by the weight produced ledger lines a fifth as thick as
+  // OSMD's own default, which is why weight=2.0 still rendered a hairline.
+  // Use the weight as a direct multiplier on the OSMD default instead, so
+  // 1.0 = OSMD default, 2.0 = twice as bold, etc.
+  rules.LedgerLineWidth = 1.0 * layout.ledgerLineWeight;
 
   rules.SlurPlacementUseSkyBottomLine = true;
 

--- a/src/store/score-store.ts
+++ b/src/store/score-store.ts
@@ -58,7 +58,7 @@ export interface LayoutSettings {
   pageBreaks: boolean;      // enable page-height pagination
   pageSize: PageSize;       // page dimensions for print/pagination
   noteSize: number;         // notation scale factor (1.0 = default, 0.7 = smaller)
-  ledgerLineWeight: number; // multiplier on the staff line stroke width used for ledger lines (1.0 = match staff lines)
+  ledgerLineWeight: number; // multiplier on OSMD's native LedgerLineWidth default (1.0 = OSMD default; >1 = bolder)
   musicFont: MusicFont;     // VexFlow music notation font
   textFont: TextFont;       // CSS text font for lyrics, titles, etc.
   printPageNumbers: boolean; // show page numbers in print output


### PR DESCRIPTION
Previous formula StaffLineWidth × weight produced ~0.2 — a fifth of OSMD's native default of 1.0. Slider at 3.5 still rendered hairlines. Now weight directly multiplies OSMD's 1.0 baseline.