### PR TITLE
Mid-score tempo / time-sig / key-sig changes (#42)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -801,6 +801,7 @@ export default function Home() {
                       keySignature: "C",
                       measures: 16,
                       anacrusis: false,
+      measureChanges: [],
                       staves: [{
                         id: uuidv4(),
                         name: "Staff 1",
@@ -835,6 +836,7 @@ export default function Home() {
                       keySignature: "C",
                       measures: 1,
                       anacrusis: false,
+      measureChanges: [],
                       staves: [],
                       chordSymbols: [],
                       rehearsalMarks: [],

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -156,6 +156,7 @@ export default function MenuBar({
       keySignature: "C",
       measures: 16,
       anacrusis: false,
+      measureChanges: [],
       staves: [{
         id: uuidv4(),
         name: "Staff 1",
@@ -188,6 +189,7 @@ export default function MenuBar({
       keySignature: "C",
       measures: 1,
       anacrusis: false,
+      measureChanges: [],
       staves: [],
       chordSymbols: [],
       rehearsalMarks: [],

--- a/src/components/NewScoreDialog.tsx
+++ b/src/components/NewScoreDialog.tsx
@@ -57,6 +57,7 @@ export default function NewScoreDialog({ onClose }: { onClose: () => void }) {
       keySignature: keySignature as Score["keySignature"],
       measures,
       anacrusis: false,
+      measureChanges: [],
       staves: staves.map((s, i) => ({
         id: `staff_${i + 1}`,
         name: s.name,

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useScoreStore, DEFAULT_LAYOUT, PRINT_LAYOUT, REALBOOK_LAYOUT, STYLE_PRESETS, StylePreset, LayoutSettings, MusicFont, TextFont, PageSize } from "@/store/score-store";
 import { downloadScoreAsMidi } from "@/lib/midi-export";
-import { KeySignature, Clef } from "@/lib/schema";
+import { KeySignature, Clef, Score, ScorePatch } from "@/lib/schema";
 import { v4 as uuidv4 } from "uuid";
 import RevisionPanel from "./RevisionPanel";
 
@@ -51,6 +51,7 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
                 {score.anacrusis ? "On" : "Off"}
               </button>
             </div>
+            <MidScoreChangesEditor score={score} applyPatches={applyPatches} />
           </div>
         </PropSection>
 
@@ -653,6 +654,160 @@ function PropSection({ title, defaultOpen = true, action, children }: {
           {children}
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Mid-score change editor (#42). Lists every measureChange and provides
+ * an "+ Add" button. Each row lets the user pick the measure number plus
+ * any combination of tempo / time-signature / key-signature override.
+ */
+function MidScoreChangesEditor({
+  score,
+  applyPatches,
+}: {
+  score: Score;
+  applyPatches: (patches: ScorePatch[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const changes = score.measureChanges ?? [];
+
+  const addChange = () => {
+    const used = new Set(changes.map((c) => c.measure));
+    let target = 2;
+    while (used.has(target) && target <= score.measures) target++;
+    if (target > score.measures) return;
+    applyPatches([{ op: "set_measure_change", measure: target, tempo: score.tempo }]);
+    setOpen(true);
+  };
+
+  const updateChange = (
+    measure: number,
+    patch: { measure?: number; tempo?: number | undefined; timeSignature?: string | undefined; keySignature?: KeySignature | undefined },
+  ) => {
+    const existing = changes.find((c) => c.measure === measure);
+    if (!existing) return;
+    const merged = { ...existing, ...patch };
+    if (patch.measure !== undefined && patch.measure !== measure) {
+      // Renumbering: remove old, insert new.
+      applyPatches([
+        { op: "remove_measure_change", measure },
+        { op: "set_measure_change", ...merged, measure: patch.measure },
+      ]);
+    } else {
+      applyPatches([{ op: "set_measure_change", ...merged }]);
+    }
+  };
+
+  const removeChange = (measure: number) => {
+    applyPatches([{ op: "remove_measure_change", measure }]);
+  };
+
+  return (
+    <div className="border-t border-white/5 pt-2 mt-1">
+      <div className="flex items-center justify-between mb-1">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="text-[10px] uppercase tracking-wider text-gray-500 hover:text-gray-300 inline-flex items-center gap-1"
+        >
+          <svg className={`w-2.5 h-2.5 transition-transform ${open ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+          <span>Mid-score changes ({changes.length})</span>
+        </button>
+        <button
+          type="button"
+          onClick={addChange}
+          className="text-[10px] text-blue-400 hover:text-blue-300 font-medium"
+          title="Insert a tempo / time / key change at a specific measure"
+        >
+          + Add
+        </button>
+      </div>
+      {open && (
+        <div className="space-y-1.5">
+          {changes.length === 0 && (
+            <p className="text-[10px] text-gray-500 italic">No mid-score changes. Click + Add to insert one.</p>
+          )}
+          {changes.map((c) => (
+            <div key={c.measure} className="bg-white/5 rounded-lg p-2 space-y-1 border border-white/10">
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] text-gray-400 w-10">Bar</span>
+                <input
+                  type="number"
+                  min={2}
+                  max={score.measures}
+                  value={c.measure}
+                  onChange={(e) => {
+                    const n = parseInt(e.target.value, 10);
+                    if (!isNaN(n) && n >= 2 && n <= score.measures) {
+                      updateChange(c.measure, { measure: n });
+                    }
+                  }}
+                  className="flex-1 bg-black/20 border border-white/10 rounded px-2 py-0.5 text-[11px] text-gray-200 focus:outline-none focus:border-blue-400"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeChange(c.measure)}
+                  className="text-[10px] text-red-400/60 hover:text-red-400"
+                  title="Remove this change"
+                >
+                  ✕
+                </button>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] text-gray-400 w-10">Tempo</span>
+                <input
+                  type="number"
+                  min={20}
+                  max={300}
+                  placeholder="—"
+                  value={c.tempo ?? ""}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    const n = v === "" ? undefined : parseInt(v, 10);
+                    updateChange(c.measure, { tempo: n });
+                  }}
+                  className="flex-1 bg-black/20 border border-white/10 rounded px-2 py-0.5 text-[11px] text-gray-200 focus:outline-none focus:border-blue-400"
+                />
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] text-gray-400 w-10">Time</span>
+                <input
+                  type="text"
+                  placeholder="—"
+                  value={c.timeSignature ?? ""}
+                  onChange={(e) => {
+                    const v = e.target.value.trim();
+                    if (v === "" || /^\d+\/\d+$/.test(v)) {
+                      updateChange(c.measure, { timeSignature: v === "" ? undefined : v });
+                    }
+                  }}
+                  className="flex-1 bg-black/20 border border-white/10 rounded px-2 py-0.5 text-[11px] text-gray-200 focus:outline-none focus:border-blue-400"
+                />
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] text-gray-400 w-10">Key</span>
+                <select
+                  value={c.keySignature ?? ""}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    updateChange(c.measure, { keySignature: v === "" ? undefined : (v as KeySignature) });
+                  }}
+                  className="flex-1 bg-black/20 border border-white/10 rounded px-2 py-0.5 text-[11px] text-gray-200 focus:outline-none focus:border-blue-400"
+                >
+                  <option value="">—</option>
+                  {(["C","G","D","A","E","B","F","Bb","Eb","Ab","Db","Am","Em","Bm","Dm","Gm","Cm","Fm"] as const).map((k) => (
+                    <option key={k} value={k}>{k}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -30,6 +30,7 @@ export default function Toolbar({ zoom, onZoomChange, onPrint }: ToolbarProps) {
       keySignature: "C",
       measures: 16,
       anacrusis: false,
+      measureChanges: [],
       staves: [{
         id: uuidv4(),
         name: "Staff 1",

--- a/src/lib/chordpro-import.ts
+++ b/src/lib/chordpro-import.ts
@@ -179,6 +179,7 @@ export function parseChordPro(text: string): ChordProImportResult {
     keySignature: key,
     measures: 1,
     anacrusis: false,
+      measureChanges: [],
     staves: [],
     chordSymbols: [],
     rehearsalMarks: [],

--- a/src/lib/importers/midi-import.ts
+++ b/src/lib/importers/midi-import.ts
@@ -355,6 +355,7 @@ export function parseMidi(
     keySignature: keySignature as Score["keySignature"],
     measures: totalMeasures,
     anacrusis: false,
+      measureChanges: [],
     staves,
     chordSymbols: [],
     rehearsalMarks: [],

--- a/src/lib/importers/musicxml-import.ts
+++ b/src/lib/importers/musicxml-import.ts
@@ -222,6 +222,7 @@ export function parseMusicXML(xmlString: string): Score {
     keySignature: keySignature as any,
     measures: maxMeasure,
     anacrusis: false,
+      measureChanges: [],
     staves,
     chordSymbols,
     rehearsalMarks: [],

--- a/src/lib/importers/staffpad.ts
+++ b/src/lib/importers/staffpad.ts
@@ -282,6 +282,7 @@ class SNTParser {
       keySignature: keySignature as any,
       measures: barCount,
       anacrusis: false,
+      measureChanges: [],
       staves,
       chordSymbols: allChordSymbols,
       rehearsalMarks: [],

--- a/src/lib/musicxml.ts
+++ b/src/lib/musicxml.ts
@@ -1,4 +1,4 @@
-import { Score, Note, Clef, KeySignature, ChordSymbol, Articulation } from "./schema";
+import { Score, Note, Clef, KeySignature, ChordSymbol, Articulation, MeasureChange } from "./schema";
 
 // ── Key signature fifths map ───────────────────────────────────────────────
 
@@ -206,20 +206,27 @@ export function scoreToMusicXML(score: Score): string {
   }
   lines.push("  </part-list>");
 
-  // Time signature parsing
+  // Time signature parsing — initial values; mid-score changes override
+  // per measure inside the loop.
   const [beatsStr, beatTypeStr] = score.timeSignature.split("/");
-  const beats = parseInt(beatsStr, 10);
-  const beatType = parseInt(beatTypeStr, 10);
+  const initialBeats = parseInt(beatsStr, 10);
+  const initialBeatType = parseInt(beatTypeStr, 10);
 
   // Key
-  const fifths = KEY_FIFTHS[score.keySignature] ?? 0;
-  const mode = score.keySignature.endsWith("m") ? "minor" : "major";
+  const initialFifths = KEY_FIFTHS[score.keySignature] ?? 0;
+  const initialMode = score.keySignature.endsWith("m") ? "minor" : "major";
 
   // Chord lookup
   const chordLookup = buildChordLookup(score.chordSymbols);
 
-  // Measure duration in divisions
-  const measureDivisions = beats * (64 / beatType);
+  // Mid-score override lookup: measure → MeasureChange. Used inside the
+  // per-measure loop to emit <attributes> + <sound tempo> at the change
+  // boundary and to keep beats/beatType/divisions in sync for subsequent
+  // measures so rest-filling math still adds up.
+  const changeAt = new Map<number, MeasureChange>();
+  for (const c of score.measureChanges ?? []) {
+    changeAt.set(c.measure, c);
+  }
 
   // Parts — iterate visibleStaves so isFirstPart correctly identifies the
   // first emitted part (used to attach time/key signature attributes).
@@ -227,6 +234,14 @@ export function scoreToMusicXML(score: Score): string {
     const staff = visibleStaves[si];
     const clef = clefToMusicXML(staff.clef);
     const isFirstPart = si === 0;
+
+    // Per-staff mutable signature state — gets overwritten by mid-score
+    // changes inside the per-measure loop. Reset to score defaults at the
+    // start of each staff so every part stays in sync.
+    let beats = initialBeats;
+    let beatType = initialBeatType;
+    let fifths = initialFifths;
+    let mode = initialMode;
 
     lines.push(`  <part id="${esc(staff.id)}">`);
 
@@ -258,6 +273,34 @@ export function scoreToMusicXML(score: Score): string {
       const displayNumber = score.anacrusis ? m - 1 : m;
       lines.push(`    <measure number="${displayNumber}">`);
 
+      // Mid-score change at this measure (#42). On m===1 the change folds
+      // into the initial attributes block below; on m>1 we emit a fresh
+      // <attributes> + tempo direction.
+      const change = changeAt.get(m);
+      let timeChanged = false;
+      let keyChanged = false;
+      let tempoChanged = false;
+      if (change) {
+        if (change.timeSignature) {
+          const [tb, tbt] = change.timeSignature.split("/").map(Number);
+          if (tb !== beats || tbt !== beatType) {
+            beats = tb;
+            beatType = tbt;
+            timeChanged = true;
+          }
+        }
+        if (change.keySignature) {
+          const newFifths = KEY_FIFTHS[change.keySignature] ?? 0;
+          const newMode = change.keySignature.endsWith("m") ? "minor" : "major";
+          if (newFifths !== fifths || newMode !== mode) {
+            fifths = newFifths;
+            mode = newMode;
+            keyChanged = true;
+          }
+        }
+        if (change.tempo) tempoChanged = true;
+      }
+
       // Attributes on first measure
       if (m === 1) {
         lines.push("      <attributes>");
@@ -287,6 +330,38 @@ export function scoreToMusicXML(score: Score): string {
           lines.push("        <sound tempo=\"" + score.tempo + "\"/>");
           lines.push("      </direction>");
         }
+      } else if (timeChanged || keyChanged) {
+        // Mid-score key / time-signature change. Emit only the changed
+        // sub-elements; OSMD draws a key/time change marker at the start
+        // of this measure on every staff.
+        lines.push("      <attributes>");
+        if (keyChanged) {
+          lines.push("        <key>");
+          lines.push(`          <fifths>${fifths}</fifths>`);
+          lines.push(`          <mode>${mode}</mode>`);
+          lines.push("        </key>");
+        }
+        if (timeChanged) {
+          lines.push("        <time>");
+          lines.push(`          <beats>${beats}</beats>`);
+          lines.push(`          <beat-type>${beatType}</beat-type>`);
+          lines.push("        </time>");
+        }
+        lines.push("      </attributes>");
+      }
+
+      // Mid-score tempo change. Renders as a metronome direction above
+      // this measure on the first part only (avoids stacking on every
+      // staff).
+      if (m > 1 && tempoChanged && isFirstPart && change?.tempo) {
+        lines.push("      <direction placement=\"above\">");
+        lines.push("        <direction-type>");
+        lines.push(
+          `          <metronome><beat-unit>quarter</beat-unit><per-minute>${change.tempo}</per-minute></metronome>`
+        );
+        lines.push("        </direction-type>");
+        lines.push(`        <sound tempo="${change.tempo}"/>`);
+        lines.push("      </direction>");
       }
 
       // Chord symbols (only on first part typically, but we attach to first)

--- a/src/lib/patches.ts
+++ b/src/lib/patches.ts
@@ -43,6 +43,27 @@ export function applyPatch(score: Score, patch: ScorePatch): Score {
     case "set_anacrusis":
       return { ...score, anacrusis: patch.value };
 
+    case "set_measure_change": {
+      const existing = score.measureChanges ?? [];
+      const others = existing.filter((c) => c.measure !== patch.measure);
+      const change = {
+        measure: patch.measure,
+        ...(patch.tempo !== undefined && { tempo: patch.tempo }),
+        ...(patch.timeSignature !== undefined && { timeSignature: patch.timeSignature }),
+        ...(patch.keySignature !== undefined && { keySignature: patch.keySignature }),
+      };
+      return {
+        ...score,
+        measureChanges: [...others, change].sort((a, b) => a.measure - b.measure),
+      };
+    }
+
+    case "remove_measure_change":
+      return {
+        ...score,
+        measureChanges: (score.measureChanges ?? []).filter((c) => c.measure !== patch.measure),
+      };
+
     case "update_staff":
       return {
         ...score,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -235,6 +235,23 @@ export const AnnotationSchema = z.object({
 });
 export type Annotation = z.infer<typeof AnnotationSchema>;
 
+// ── Mid-score changes ─────────────────────────────────────────────────────
+//
+// At a given measure, override the score's tempo / time signature / key
+// signature. Multiple changes at the same measure stack into one (later
+// fields win). Renderer reads these as MusicXML <sound tempo>, <time>,
+// and <key> elements emitted at the measure boundary. Playback honors
+// the tempo override starting at that measure.
+
+export const MeasureChangeSchema = z.object({
+  /** 1-indexed bar number where the change takes effect. */
+  measure: z.number().int().min(1),
+  tempo: z.number().int().min(20).max(300).optional(),
+  timeSignature: z.string().regex(/^\d+\/\d+$/).optional(),
+  keySignature: KeySignature.optional(),
+});
+export type MeasureChange = z.infer<typeof MeasureChangeSchema>;
+
 // ── Score (top-level) ──────────────────────────────────────────────────────
 
 export const ScoreSchema = z.object({
@@ -256,6 +273,10 @@ export const ScoreSchema = z.object({
   chordSymbols: z.array(ChordSymbolSchema).default([]),
   rehearsalMarks: z.array(RehearsalMarkSchema).default([]),
   repeats: z.array(RepeatSchema).default([]),
+  /** Mid-score overrides for tempo / time signature / key signature.
+   *  Each entry takes effect at its `measure` and stays until the next
+   *  override of the same field (or the end of the score). */
+  measureChanges: z.array(MeasureChangeSchema).default([]),
   // Songbook / chord-chart structure. When `form` is non-empty, the app
   // renders a chord chart instead of staff notation. `form` is the ordered
   // sequence of section IDs that play (e.g. ["intro","V","V","C","V","C","B","V","C","C"]);
@@ -335,6 +356,21 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
   z.object({
     op: z.literal("set_anacrusis"),
     value: z.boolean(),
+  }),
+  /** Insert or update the mid-score change at `measure`. Fields that are
+   *  undefined are cleared (so passing only `tempo` produces a
+   *  tempo-only change at that measure). */
+  z.object({
+    op: z.literal("set_measure_change"),
+    measure: z.number().int().min(1),
+    tempo: z.number().int().min(20).max(300).optional(),
+    timeSignature: z.string().regex(/^\d+\/\d+$/).optional(),
+    keySignature: KeySignature.optional(),
+  }),
+  /** Remove every change at the given measure. */
+  z.object({
+    op: z.literal("remove_measure_change"),
+    measure: z.number().int().min(1),
   }),
   z.object({
     op: z.literal("update_staff"),

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -186,6 +186,7 @@ export function expandIntentToScore(intent: ScoreIntent): Score {
     keySignature,
     measures,
     anacrusis: false,
+      measureChanges: [],
     staves,
     chordSymbols: intent.chordSymbols ?? [],
     rehearsalMarks: intent.rehearsalMarks ?? [],


### PR DESCRIPTION
Schema + patches + MusicXML emission + UI editor in PropertiesPanel for inserting tempo / time-sig / key-sig overrides at any measure past 1.