### PR TITLE
Print: Legal + Tabloid; @page size honors layout choice (#5)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"3c7c65d4-a5e9-4ad8-8a29-b0c1278a0b5e","pid":21521,"procStart":"Fri May  1 15:26:44 2026","acquiredAt":1778109852177}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -419,6 +419,33 @@ export default function Home() {
     }
   }, [score]);
 
+  // Inject a `@page { size: ... }` rule so the browser print dialog
+  // defaults to the layout's chosen paper size (Letter / A4 / Legal /
+  // Tabloid). Without this the print dialog uses the OS default and the
+  // user has to change it manually every time. Runs as an effect so it
+  // re-applies whenever the page size pref changes.
+  useEffect(() => {
+    const pageSize = layout?.pageSize ?? "letter";
+    const cssSize = pageSize === "a4"
+      ? "A4"
+      : pageSize === "legal"
+        ? "legal"
+        : pageSize === "tabloid"
+          ? "ledger"
+          : "letter";
+    let el = document.getElementById("notation-page-size") as HTMLStyleElement | null;
+    if (!el) {
+      el = document.createElement("style");
+      el.id = "notation-page-size";
+      document.head.appendChild(el);
+    }
+    el.textContent = `@media print { @page { size: ${cssSize}; } }`;
+    return () => {
+      // Don't remove on unmount — the page is the app root, this only
+      // unmounts on full teardown. Leaving the rule in place is harmless.
+    };
+  }, [layout?.pageSize]);
+
   // Songbook share-link: visiting `?join=<deviceId>` prompts to take over
   // that device's songbook. The param is stripped after the user decides
   // (Join or Cancel) so a refresh doesn't re-prompt.

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useScoreStore, DEFAULT_LAYOUT, PRINT_LAYOUT, REALBOOK_LAYOUT, STYLE_PRESETS, StylePreset, LayoutSettings, MusicFont, TextFont, PageSize } from "@/store/score-store";
+import { useScoreStore, DEFAULT_LAYOUT, PRINT_LAYOUT, REALBOOK_LAYOUT, STYLE_PRESETS, StylePreset, LayoutSettings, MusicFont, TextFont, PageSize, PAGE_DIMENSIONS } from "@/store/score-store";
 import { downloadScoreAsMidi } from "@/lib/midi-export";
 import { KeySignature, Clef, Score, ScorePatch } from "@/lib/schema";
 import { v4 as uuidv4 } from "uuid";
@@ -456,7 +456,7 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
               />
               <span className="text-[10px] text-gray-400">
                 {layout.pageBreaks
-                  ? layout.pageSize === "a4" ? "A4 pages" : "Letter pages"
+                  ? `${PAGE_DIMENSIONS[layout.pageSize].label} pages`
                   : "Endless scroll"}
               </span>
             </div>
@@ -469,6 +469,8 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
               >
                 <option value="letter">US Letter (8.5 &times; 11&quot;)</option>
                 <option value="a4">A4 (210 &times; 297mm)</option>
+                <option value="legal">US Legal (8.5 &times; 14&quot;)</option>
+                <option value="tabloid">Tabloid (11 &times; 17&quot;)</option>
               </select>
             </div>
             <div className="flex items-center gap-2">

--- a/src/store/score-store.ts
+++ b/src/store/score-store.ts
@@ -27,11 +27,13 @@ export interface RecordedOperation {
 
 export type MusicFont = "bravura" | "petaluma" | "gonville";
 export type TextFont = "georgia" | "palatino" | "garamond" | "times" | "helvetica" | "noto" | "handwritten";
-export type PageSize = "letter" | "a4";
+export type PageSize = "letter" | "a4" | "legal" | "tabloid";
 
-export const PAGE_DIMENSIONS: Record<PageSize, { width: number; height: number; label: string }> = {
-  letter: { width: 8.5, height: 11.0, label: "US Letter" },
-  a4: { width: 8.27, height: 11.69, label: "A4" },
+export const PAGE_DIMENSIONS: Record<PageSize, { width: number; height: number; label: string; cssSize: string }> = {
+  letter:  { width: 8.5,  height: 11.0,  label: "US Letter", cssSize: "letter" },
+  a4:      { width: 8.27, height: 11.69, label: "A4",        cssSize: "A4" },
+  legal:   { width: 8.5,  height: 14.0,  label: "US Legal",  cssSize: "legal" },
+  tabloid: { width: 11.0, height: 17.0,  label: "Tabloid",   cssSize: "ledger" },
 };
 
 export const TEXT_FONT_STACKS: Record<TextFont, string> = {


### PR DESCRIPTION
Adds Legal + Tabloid alongside Letter / A4. Injects @page size CSS at print time so the browser dialog defaults to the chosen paper.