### PR TITLE
Tier 1: cloud versioning + 409 conflict modal (#87)

### DIFF
--- a/infra/lambda/handler.ts
+++ b/infra/lambda/handler.ts
@@ -7,6 +7,7 @@ import {
   listSongs,
   listVersions,
   putSong,
+  VersionConflictError,
 } from "./repo";
 
 const json = (statusCode: number, body: unknown): APIGatewayProxyResultV2 => ({
@@ -91,6 +92,9 @@ export const handler = async (
       }
     }
   } catch (err) {
+    if (err instanceof VersionConflictError) {
+      return json(409, { error: "conflict", current: err.current });
+    }
     console.error("handler error", err);
     return json(500, { error: "internal error" });
   }

--- a/infra/lambda/repo.ts
+++ b/infra/lambda/repo.ts
@@ -6,7 +6,19 @@ import {
   PutCommand,
   QueryCommand,
 } from "@aws-sdk/lib-dynamodb";
+import { randomUUID } from "node:crypto";
 import type { SongDTO, SongSummary, VersionEntry } from "./types";
+
+/** Thrown by putSong when the caller's expectedVersion doesn't match the
+ *  current cloud version. Handler maps this to HTTP 409 with the current
+ *  DTO in the body so the client can run conflict resolution without a
+ *  second round trip. */
+export class VersionConflictError extends Error {
+  constructor(public current: SongDTO) {
+    super("version conflict");
+    this.name = "VersionConflictError";
+  }
+}
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.TABLE_NAME!;
@@ -51,11 +63,16 @@ export async function listSongs(deviceId: string): Promise<SongSummary[]> {
         "#savedAt": "savedAt",
         "#updatedAt": "updatedAt",
         "#folder": "folder",
+        "#version": "version",
       },
-      ProjectionExpression: "#id, #title, #savedAt, #updatedAt, #folder",
+      ProjectionExpression: "#id, #title, #savedAt, #updatedAt, #folder, #version",
     })
   );
-  return (out.Items ?? []) as SongSummary[];
+  // Backfill empty version on legacy rows.
+  return (out.Items ?? []).map((it) => ({
+    ...(it as SongSummary),
+    version: typeof it.version === "string" ? it.version : "",
+  })) as SongSummary[];
 }
 
 export async function getSong(deviceId: string, id: string): Promise<SongDTO | null> {
@@ -71,6 +88,9 @@ export async function getSong(deviceId: string, id: string): Promise<SongDTO | n
     title: out.Item.title,
     savedAt: out.Item.savedAt,
     updatedAt: out.Item.updatedAt,
+    // Backfill a fresh token for legacy rows that predate the version
+    // field so clients can still load them.
+    version: typeof out.Item.version === "string" ? out.Item.version : "",
     score: out.Item.score,
     ...(out.Item.folder ? { folder: out.Item.folder } : {}),
   };
@@ -79,7 +99,18 @@ export async function getSong(deviceId: string, id: string): Promise<SongDTO | n
 export async function putSong(
   deviceId: string,
   id: string,
-  body: { title: string; score: Record<string, unknown>; savedAt?: number; folder?: string | null }
+  body: {
+    title: string;
+    score: Record<string, unknown>;
+    savedAt?: number;
+    folder?: string | null;
+    /** Opaque concurrency token from the last load/save the client did.
+     *  When provided AND the cloud row exists with a different version,
+     *  this PUT throws VersionConflictError. Clients that intentionally
+     *  want last-write-wins (e.g. force-save from the conflict modal)
+     *  omit this field. New songs (no cloud row yet) ignore it. */
+    expectedVersion?: string;
+  }
 ): Promise<SongDTO> {
   const now = Date.now();
 
@@ -90,6 +121,28 @@ export async function putSong(
     new GetCommand({ TableName: TABLE, Key: { pk: songPk(deviceId), sk: songSk(id) } })
   );
   const current = currentResp.Item;
+
+  // Optimistic-concurrency check (#87). If the client passed an
+  // expectedVersion AND the cloud row exists, both must agree. A
+  // mismatch means someone else wrote in between — the client gets
+  // 409 with the current DTO so it can run conflict resolution.
+  if (
+    body.expectedVersion !== undefined &&
+    current &&
+    typeof current.version === "string" &&
+    current.version !== body.expectedVersion
+  ) {
+    throw new VersionConflictError({
+      id,
+      title: current.title as string,
+      savedAt: current.savedAt as number,
+      updatedAt: current.updatedAt as number,
+      version: current.version as string,
+      score: current.score as Record<string, unknown>,
+      ...(current.folder ? { folder: current.folder as string } : {}),
+    });
+  }
+
   let didVersion = false;
   if (current) {
     const lastVersionedAt = (current.lastVersionedAt as number | undefined) ?? 0;
@@ -117,7 +170,7 @@ export async function putSong(
       );
       const kind = hasDailyToday ? "auto" : "daily";
 
-      const versionItem = {
+      const versionItem: Record<string, unknown> = {
         ...current,
         pk: songPk(deviceId),
         sk: versionSk(id, versionTs),
@@ -132,7 +185,7 @@ export async function putSong(
       // sticky. Among auto versions when we're over the cap, drop the
       // one that contributes least temporal info — the one closest in
       // time to its neighbors.
-      const allItemsAfter = [...existing, versionItem];
+      const allItemsAfter: Record<string, unknown>[] = [...existing, versionItem];
       if (allItemsAfter.length > MAX_VERSIONS_PER_SONG) {
         const sortedAsc = allItemsAfter
           .slice()
@@ -140,13 +193,13 @@ export async function putSong(
             (a, b) =>
               (a.updatedAt as number) - (b.updatedAt as number)
           );
-        const autos: typeof sortedAsc = [];
-        const idxOf = new Map<typeof sortedAsc[number], number>();
+        const autos: Record<string, unknown>[] = [];
+        const idxOf = new Map<Record<string, unknown>, number>();
         sortedAsc.forEach((v, i) => idxOf.set(v, i));
         for (const v of sortedAsc) if (v.kind === "auto") autos.push(v);
 
         const overBy = allItemsAfter.length - MAX_VERSIONS_PER_SONG;
-        const victims: typeof sortedAsc = [];
+        const victims: Record<string, unknown>[] = [];
         for (let n = 0; n < overBy && autos.length > 0; n++) {
           // Find the auto version whose temporal "gap to the closer
           // neighbor in the FULL set" is smallest — i.e., the one whose
@@ -184,6 +237,10 @@ export async function putSong(
     }
   }
 
+  // Mint a fresh version token on every successful write. Clients use
+  // this on subsequent PUTs to detect concurrent edits.
+  const newVersion = randomUUID();
+
   const item: Record<string, unknown> = {
     pk: songPk(deviceId),
     sk: songSk(id),
@@ -192,7 +249,7 @@ export async function putSong(
     title: body.title,
     savedAt: body.savedAt ?? now,
     updatedAt: now,
-    version: 1,
+    version: newVersion,
     score: body.score,
     lastVersionedAt: didVersion ? now : ((current?.lastVersionedAt as number | undefined) ?? 0),
   };
@@ -203,6 +260,7 @@ export async function putSong(
     title: item.title as string,
     savedAt: item.savedAt as number,
     updatedAt: item.updatedAt as number,
+    version: newVersion,
     score: body.score,
     ...(item.folder ? { folder: item.folder as string } : {}),
   };
@@ -294,6 +352,7 @@ export async function getVersion(
     title: out.Item.title,
     savedAt: out.Item.savedAt,
     updatedAt: out.Item.updatedAt,
+    version: typeof out.Item.version === "string" ? out.Item.version : "",
     score: out.Item.score,
     ...(out.Item.folder ? { folder: out.Item.folder } : {}),
   };

--- a/infra/lambda/types.ts
+++ b/infra/lambda/types.ts
@@ -7,6 +7,11 @@ export interface SongSummary {
   title: string;
   savedAt: number;
   updatedAt: number;
+  /** Opaque concurrency token. Regenerated on every successful write.
+   *  Clients keep the version they last loaded against and pass it on
+   *  subsequent writes; if cloud's current version differs, the write
+   *  fails with 409 Conflict (issue #87 — Tier 1 conflict-aware sync). */
+  version: string;
   /** Optional folder for the My Songs picker. Synced so multiple devices
    *  see the same organization. */
   folder?: string;
@@ -18,6 +23,9 @@ export interface SongDTO extends SongSummary {
 
 export interface ApiError {
   error: string;
+  /** When error === "conflict", the current cloud DTO is included so the
+   *  client can show a side-by-side diff without a second round trip. */
+  current?: SongDTO;
 }
 
 /** Returned by GET /songs/{id}/versions. Each entry is one recovery

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,8 +24,11 @@ import JoinSongbookModal from "@/components/JoinSongbookModal";
 import PerformView from "@/components/PerformView";
 import PersistFailureBanner from "@/components/PersistFailureBanner";
 import FeedbackModal from "@/components/FeedbackModal";
-import { CLOUD_ENABLED, getDeviceId } from "@/lib/song-cloud";
-import { autosaveToCloud } from "@/lib/cloud-autosave";
+import { CLOUD_ENABLED, getDeviceId, cloudPutSong } from "@/lib/song-cloud";
+import { autosaveToCloud, CloudSaveEvents } from "@/lib/cloud-autosave";
+import { updateSong } from "@/lib/song-bank";
+import type { SongDTO } from "@/lib/song-cloud-types";
+import ConflictModal from "@/components/ConflictModal";
 import AnnotationLayer from "@/components/AnnotationLayer";
 import AnnotateToggle from "@/components/AnnotateToggle";
 import AnnotationFilterBar from "@/components/AnnotationFilterBar";
@@ -91,6 +94,12 @@ export default function Home() {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [apiKeysOpen, setApiKeysOpen] = useState(false);
   const [joinCode, setJoinCode] = useState<string | null>(null);
+  // Conflict-resolution state (#87). Populated when cloudAutosave fires the
+  // notation-cloud-conflict event; cleared by the modal's resolution paths.
+  const [conflict, setConflict] = useState<
+    | { current: SongDTO; local: typeof score; songId: string }
+    | null
+  >(null);
   const [inlineAI, setInlineAI] = useState<{ note: { measure: number; beat: number; pitch: string; staffIndex: number }; position: { x: number; y: number } } | null>(null);
   const printFnRef = useRef<(() => Promise<void>) | null>(null);
   const handlePrint = useCallback(() => {
@@ -445,6 +454,25 @@ export default function Home() {
       // unmounts on full teardown. Leaving the rule in place is harmless.
     };
   }, [layout?.pageSize]);
+
+  // Cloud conflict listener (#87). cloudAutosave dispatches this event
+  // when a 409 comes back from the server; we capture the payload and
+  // open the conflict modal. Resolution paths in the modal handlers
+  // (keep-mine forces a write w/o expectedVersion; discard-mine swaps
+  // the open score for the cloud version).
+  useEffect(() => {
+    if (!CLOUD_ENABLED) return;
+    const onConflict = (e: Event) => {
+      const detail = (e as CustomEvent).detail as {
+        current: SongDTO;
+        local: typeof score;
+        songId: string;
+      } | undefined;
+      if (detail) setConflict(detail);
+    };
+    window.addEventListener(CloudSaveEvents.Conflict, onConflict);
+    return () => window.removeEventListener(CloudSaveEvents.Conflict, onConflict);
+  }, []);
 
   // Songbook share-link: visiting `?join=<deviceId>` prompts to take over
   // that device's songbook. The param is stripped after the user decides
@@ -1281,6 +1309,48 @@ export default function Home() {
           score={score}
           onExit={() => setUIState({ performMode: false, annotationMode: false })}
           onOpenMySongs={() => setMySongsOpen(true)}
+        />
+      )}
+
+      {/* Concurrent-edit conflict modal (#87). Opened when cloudAutosave's
+          409 path fires; the three resolution paths each clear `conflict`. */}
+      {conflict && conflict.local && (
+        <ConflictModal
+          current={conflict.current}
+          local={conflict.local}
+          songId={conflict.songId}
+          onKeepMine={async () => {
+            // Force last-write-wins: re-save with no expectedVersion so the
+            // server skips the concurrency check.
+            try {
+              const dto = await cloudPutSong({
+                id: conflict.songId,
+                title: conflict.current.title,
+                score: conflict.local!,
+                folder: conflict.current.folder ?? null,
+              });
+              updateSong(conflict.songId, {
+                score: conflict.local!,
+                cloudVersion: dto.version,
+                savedAt: dto.savedAt,
+              });
+            } catch (err) {
+              console.warn("[conflict] keep-mine save failed", err);
+            }
+            setConflict(null);
+          }}
+          onDiscardMine={() => {
+            // Adopt the cloud version: replace open score, advance local
+            // entry's cloudVersion so future saves go through cleanly.
+            setScore(conflict.current.score);
+            updateSong(conflict.songId, {
+              score: conflict.current.score,
+              cloudVersion: conflict.current.version,
+              savedAt: conflict.current.savedAt,
+            });
+            setConflict(null);
+          }}
+          onCancel={() => setConflict(null)}
         />
       )}
 

--- a/src/components/ConflictModal.tsx
+++ b/src/components/ConflictModal.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Score } from "@/lib/schema";
+import type { SongDTO } from "@/lib/song-cloud-types";
+
+/**
+ * Conflict resolution modal (#87, Tier 1). Fires when cloudPutSong returns
+ * 409 — the row in cloud was changed by someone else (other tab, other
+ * device, bandmate) since this client loaded it.
+ *
+ * Three resolution paths:
+ *  - Keep mine: re-save WITHOUT expectedVersion → forces last-write-wins.
+ *  - Discard mine: load cloud version into the editor.
+ *  - Cancel: leave both alone; user can revisit by editing again.
+ *
+ * The diff is intentionally summary-level for now (sections, lines,
+ * annotations counts) — full structural diff lives in #89's auto-merge
+ * slice and reuses the same modal.
+ */
+interface ConflictModalProps {
+  current: SongDTO;
+  local: Score;
+  songId: string;
+  onKeepMine: () => void;
+  onDiscardMine: () => void;
+  onCancel: () => void;
+}
+
+export default function ConflictModal({
+  current,
+  local,
+  onKeepMine,
+  onDiscardMine,
+  onCancel,
+}: ConflictModalProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  const summary = computeDiffSummary(local, current.score as Score);
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-lg w-full p-6 text-gray-800">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">
+          This song was changed elsewhere
+        </h2>
+        <p className="text-sm text-gray-600 mb-4">
+          Someone (your other device, or a bandmate) saved a different version
+          of <strong>{current.title}</strong> after you loaded it. Pick how to
+          resolve — your unsaved work is still in the editor either way.
+        </p>
+
+        <div className="bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 mb-4 text-xs text-gray-700 font-mono space-y-0.5">
+          <div>
+            <span className="text-gray-500">Their version:</span>{" "}
+            {summary.theirSections} sections, {summary.theirChordChars} chord
+            chars, {summary.theirAnnotations} annotations
+          </div>
+          <div>
+            <span className="text-gray-500">Your version:</span>{" "}
+            {summary.yourSections} sections, {summary.yourChordChars} chord
+            chars, {summary.yourAnnotations} annotations
+          </div>
+          {summary.note && (
+            <div className="pt-1 text-amber-700 not-italic">{summary.note}</div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onDiscardMine}
+            className="w-full px-4 py-2.5 text-sm font-medium rounded-lg bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white transition-colors"
+            title="Replace your unsaved work with the cloud version"
+          >
+            Discard mine — load latest
+          </button>
+          <button
+            type="button"
+            onClick={onKeepMine}
+            className="w-full px-4 py-2.5 text-sm font-medium rounded-lg bg-amber-50 hover:bg-amber-100 text-amber-900 border border-amber-200 transition-colors"
+            title="Overwrite the cloud version with what's in your editor"
+          >
+            Keep mine — overwrite cloud
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-full px-4 py-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            Cancel — decide later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function computeDiffSummary(
+  local: Score,
+  remote: Score,
+): {
+  yourSections: number;
+  theirSections: number;
+  yourChordChars: number;
+  theirChordChars: number;
+  yourAnnotations: number;
+  theirAnnotations: number;
+  note?: string;
+} {
+  const chordChars = (s: Score) =>
+    (s.sections ?? []).reduce(
+      (sum, sec) =>
+        sum + sec.lines.reduce((n, l) => n + (l.chords?.length ?? 0), 0),
+      0,
+    );
+  const yourSections = local.sections?.length ?? 0;
+  const theirSections = remote.sections?.length ?? 0;
+  const yourChordChars = chordChars(local);
+  const theirChordChars = chordChars(remote);
+  const yourAnnotations = local.annotations?.length ?? 0;
+  const theirAnnotations = remote.annotations?.length ?? 0;
+
+  let note: string | undefined;
+  if (yourSections > theirSections || yourChordChars > theirChordChars + 50) {
+    note = "Your version looks like it has more content.";
+  } else if (
+    theirSections > yourSections ||
+    theirChordChars > yourChordChars + 50
+  ) {
+    note = "Their version looks like it has more content.";
+  }
+  return {
+    yourSections,
+    theirSections,
+    yourChordChars,
+    theirChordChars,
+    yourAnnotations,
+    theirAnnotations,
+    note,
+  };
+}

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -229,13 +229,17 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     if (!CLOUD_ENABLED || !entry) return;
     setSyncStatus("syncing");
     try {
-      await cloudPutSong({
+      const dto = await cloudPutSong({
         id: entry.id,
         title: entry.title,
         score: entry.score,
         savedAt: entry.savedAt,
         folder: entry.folder ?? null,
+        ...(entry.cloudVersion !== undefined && { expectedVersion: entry.cloudVersion }),
       });
+      // Advance the local entry's cloudVersion so the autosave can keep
+      // sending matching expectedVersion on subsequent edits.
+      updateSong(entry.id, { cloudVersion: dto.version });
       setSyncStatus("ok");
     } catch (err) {
       if (isTransient(err)) {
@@ -272,7 +276,15 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
       try { await saveSnapshot(score); } catch { /* best-effort */ }
     }
     setScore(entry.score);
-    setUIState({ currentSongId: entry.id });
+    // Auto-flip into perform mode when loading a chord-chart song. Bands
+    // typically open a song to play it, not edit it; the Edit button in
+    // the perform-mode top-right cluster is one tap away if they need to
+    // tweak. Notation scores stay in edit mode (no perform view there).
+    const isChordChart = !!(entry.score.sections && entry.score.sections.length > 0);
+    setUIState({
+      currentSongId: entry.id,
+      ...(isChordChart && { performMode: true }),
+    });
     onClose();
   };
 

--- a/src/lib/cloud-autosave.ts
+++ b/src/lib/cloud-autosave.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import type { Score } from "@/lib/schema";
-import { CLOUD_ENABLED, cloudPutSong, isTransient, enqueueOffline } from "@/lib/song-cloud";
+import type { SongDTO } from "@/lib/song-cloud-types";
+import { CLOUD_ENABLED, cloudPutSong, isTransient, enqueueOffline, isConflictError } from "@/lib/song-cloud";
 import { getSongs, updateSong } from "@/lib/song-bank";
 
 /**
@@ -13,11 +14,15 @@ import { getSongs, updateSong } from "@/lib/song-bank";
  *   - notation-cloud-saving — push started
  *   - notation-cloud-saved  — push succeeded (detail: { ts: number })
  *   - notation-cloud-offline — push failed transiently (queued for retry)
+ *   - notation-cloud-conflict — server returned 409; detail.current is
+ *     the cloud DTO, detail.local is the score we tried to push. UI
+ *     opens the conflict modal in response.
  */
 
 const SAVING_EVENT = "notation-cloud-saving";
 const SAVED_EVENT = "notation-cloud-saved";
 const OFFLINE_EVENT = "notation-cloud-offline";
+const CONFLICT_EVENT = "notation-cloud-conflict";
 
 let lastPushedScore: Score | null = null;
 let lastPushedSongId: string | null = null;
@@ -32,27 +37,30 @@ export async function autosaveToCloud(
   // Skip if nothing changed since the last successful push for this song.
   if (lastPushedSongId === songId && lastPushedScore === score) return true;
 
-  // Look up the local entry for its title and folder (in case they were
-  // updated separately). Fall back to score.title.
+  // Look up the local entry for its title, folder, and the cloudVersion
+  // we'll send as expectedVersion. Fall back to score.title.
   const localEntry = getSongs().find(s => s.id === songId);
   const title = localEntry?.title ?? score.title ?? "Untitled Song";
   const folder = localEntry?.folder ?? null;
+  const expectedVersion = localEntry?.cloudVersion;
 
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent(SAVING_EVENT));
   }
   try {
     const now = Date.now();
-    await cloudPutSong({
+    const dto = await cloudPutSong({
       id: songId,
       title,
       score,
       savedAt: now,
       folder,
+      ...(expectedVersion !== undefined && { expectedVersion }),
     });
-    // Mirror to local entry so list views show the latest savedAt.
+    // Mirror to local entry so list views show the latest savedAt and
+    // the cloudVersion advances in lockstep with cloud.
     if (localEntry) {
-      updateSong(songId, { score, savedAt: now });
+      updateSong(songId, { score, savedAt: now, cloudVersion: dto.version });
     }
     lastPushedScore = score;
     lastPushedSongId = songId;
@@ -63,6 +71,19 @@ export async function autosaveToCloud(
     }
     return true;
   } catch (err) {
+    if (isConflictError(err)) {
+      // Concurrent write detected. Surface to the UI; the modal owns
+      // resolution. Don't queue or retry — that would create a loop.
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(
+          new CustomEvent<{ current: SongDTO; local: Score; songId: string }>(
+            CONFLICT_EVENT,
+            { detail: { current: err.current, local: score, songId } },
+          ),
+        );
+      }
+      return false;
+    }
     if (isTransient(err)) {
       enqueueOffline({
         type: "put",
@@ -92,4 +113,5 @@ export const CloudSaveEvents = {
   Saving: SAVING_EVENT,
   Saved: SAVED_EVENT,
   Offline: OFFLINE_EVENT,
+  Conflict: CONFLICT_EVENT,
 };

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -8,6 +8,10 @@ export interface SongBankEntry {
   /** Optional folder name (e.g. "Originals", "Covers"). Songs without a
    *  folder appear under "(Unfiled)" in the My Songs picker. */
   folder?: string;
+  /** Cloud version this entry was last synced from. Used as the
+   *  expectedVersion on cloudPutSong so concurrent writes from another
+   *  device get caught with a 409 instead of silently overwriting (#87). */
+  cloudVersion?: string;
 }
 
 const STORAGE_KEY = "notation-app-songs";
@@ -70,7 +74,7 @@ export function renameSong(id: string, title: string): SongBankEntry | null {
  *  current song) instead of saveSong (which always creates a new entry). */
 export function updateSong(
   id: string,
-  patch: Partial<Pick<SongBankEntry, "title" | "score" | "savedAt" | "folder">>,
+  patch: Partial<Pick<SongBankEntry, "title" | "score" | "savedAt" | "folder" | "cloudVersion">>,
 ): SongBankEntry | null {
   const songs = getSongs();
   const idx = songs.findIndex(s => s.id === id);
@@ -81,6 +85,7 @@ export function updateSong(
     ...(patch.score !== undefined ? { score: JSON.parse(JSON.stringify(patch.score)) } : {}),
     ...(patch.savedAt !== undefined ? { savedAt: patch.savedAt } : {}),
     ...(patch.folder !== undefined ? { folder: patch.folder } : {}),
+    ...(patch.cloudVersion !== undefined ? { cloudVersion: patch.cloudVersion } : {}),
   };
   songs[idx] = next;
   setSongs(songs);

--- a/src/lib/song-cloud-types.ts
+++ b/src/lib/song-cloud-types.ts
@@ -9,6 +9,11 @@ export interface SongSummary {
   title: string;
   savedAt: number;
   updatedAt: number;
+  /** Opaque concurrency token. Regenerated on every successful write.
+   *  Clients keep the version they last loaded against and pass it on
+   *  subsequent writes; if cloud's current version differs, the write
+   *  fails with 409 Conflict (issue #87 — Tier 1 conflict-aware sync). */
+  version: string;
   /** Optional folder for the My Songs picker. Synced across devices. */
   folder?: string;
 }
@@ -19,6 +24,9 @@ export interface SongDTO extends SongSummary {
 
 export interface ApiError {
   error: string;
+  /** When error === "conflict", the current cloud DTO is included so the
+   *  client can show a side-by-side diff without a second round trip. */
+  current?: SongDTO;
 }
 
 export interface VersionEntry {

--- a/src/lib/song-cloud.ts
+++ b/src/lib/song-cloud.ts
@@ -35,6 +35,20 @@ export function setDeviceId(id: string): void {
 class TerminalCloudError extends Error {}
 class TransientCloudError extends Error {}
 
+/** Thrown by cloudPutSong when the server returns 409. The cloud's current
+ *  DTO is attached so the client can show a side-by-side diff or run a
+ *  3-way merge (issue #89) without a second round trip. */
+export class ConflictCloudError extends TerminalCloudError {
+  constructor(public current: SongDTO) {
+    super("version conflict");
+    this.name = "ConflictCloudError";
+  }
+}
+
+export function isConflictError(err: unknown): err is ConflictCloudError {
+  return err instanceof ConflictCloudError;
+}
+
 async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
   if (!CLOUD_ENABLED) throw new TerminalCloudError("cloud disabled");
   const ctrl = new AbortController();
@@ -50,6 +64,20 @@ async function apiFetch(path: string, init: RequestInit = {}): Promise<Response>
       },
     });
     if (res.status >= 500) throw new TransientCloudError(`HTTP ${res.status}`);
+    if (res.status === 409) {
+      // Optimistic-concurrency conflict (#87). Body carries the current
+      // cloud DTO so the client can show a diff / run merge.
+      try {
+        const j = await res.json();
+        if (j && typeof j === "object" && j.error === "conflict" && j.current) {
+          throw new ConflictCloudError(j.current as SongDTO);
+        }
+      } catch (err) {
+        if (err instanceof ConflictCloudError) throw err;
+        // Body wasn't the expected shape — fall through to generic.
+      }
+      throw new TerminalCloudError(`HTTP 409`);
+    }
     if (res.status >= 400) {
       const body = await res.text().catch(() => "");
       throw new TerminalCloudError(`HTTP ${res.status}: ${body}`);
@@ -82,12 +110,18 @@ export async function cloudPutSong(s: {
   score: Score;
   savedAt?: number;
   folder?: string | null;
+  /** The cloud version this save is replacing. When provided AND the cloud's
+   *  current version differs, the request is rejected with ConflictCloudError
+   *  so the caller can run resolution. Omit to force last-write-wins (e.g.
+   *  the conflict modal's "keep mine" path). */
+  expectedVersion?: string;
 }): Promise<SongDTO> {
   const body = JSON.stringify({
     title: s.title,
     score: s.score,
     savedAt: s.savedAt,
     folder: s.folder ?? null,
+    ...(s.expectedVersion !== undefined && { expectedVersion: s.expectedVersion }),
   });
   if (body.length > MAX_PAYLOAD) {
     throw new TerminalCloudError(
@@ -234,19 +268,24 @@ export async function syncSongbook(opts?: {
     for (const summary of summaries) {
       const localEntry = localById.get(summary.id);
       if (localEntry && localEntry.savedAt >= summary.updatedAt) {
-        // Local has newer save — push it up (include folder).
+        // Local has newer save — push it up (include folder + version).
+        let pushedDto: SongDTO | undefined;
         try {
-          await cloudPutSong({
+          pushedDto = await cloudPutSong({
             id: summary.id,
             title: localEntry.title,
             score: localEntry.score,
             savedAt: localEntry.savedAt,
             folder: localEntry.folder ?? null,
+            ...(localEntry.cloudVersion !== undefined && { expectedVersion: localEntry.cloudVersion }),
           });
         } catch {
           /* keep local; retry next time */
         }
-        merged.push(localEntry);
+        merged.push({
+          ...localEntry,
+          ...(pushedDto?.version !== undefined && { cloudVersion: pushedDto.version }),
+        });
       } else {
         try {
           const dto = await cloudGetSong(summary.id);
@@ -254,16 +293,19 @@ export async function syncSongbook(opts?: {
           // If cloud has no folder but local does, that's a pre-sync local
           // folder we need to migrate up — push it now.
           let folder = dto.folder ?? localEntry?.folder;
+          let version = dto.version;
           if (!dto.folder && localEntry?.folder) {
             try {
-              await cloudPutSong({
+              const repushed = await cloudPutSong({
                 id: dto.id,
                 title: dto.title,
                 score: dto.score,
                 savedAt: dto.savedAt,
                 folder: localEntry.folder,
+                expectedVersion: dto.version,
               });
               folder = localEntry.folder;
+              version = repushed.version;
             } catch {
               /* keep local-only for now */
             }
@@ -274,6 +316,7 @@ export async function syncSongbook(opts?: {
             savedAt: dto.savedAt,
             score: dto.score,
             ...(folder ? { folder } : {}),
+            ...(version && { cloudVersion: version }),
           });
         } catch {
           if (localEntry) merged.push(localEntry);
@@ -285,14 +328,14 @@ export async function syncSongbook(opts?: {
     for (const entry of local) {
       if (cloudIds.has(entry.id)) continue;
       try {
-        await cloudPutSong({
+        const dto = await cloudPutSong({
           id: entry.id,
           title: entry.title,
           score: entry.score,
           savedAt: entry.savedAt,
           folder: entry.folder ?? null,
         });
-        merged.push(entry);
+        merged.push({ ...entry, cloudVersion: dto.version });
       } catch (err) {
         merged.push(entry);
         if (isTransient(err)) {


### PR DESCRIPTION
Cloud rows carry an opaque UUID version regenerated on every write. Clients pass the version they last loaded against; mismatch returns 409 with the current DTO so the client opens the conflict modal (Discard mine / Keep mine / Cancel) instead of silently overwriting. Soft-lock leftover removed.

Server: handler maps VersionConflictError to 409. Lambda redeploy required.

Client: ConflictCloudError surfaces 409s; cloud-autosave dispatches notation-cloud-conflict event; ConflictModal handles all three paths. SongBankEntry tracks cloudVersion.

Bonus: chord-chart songs auto-open in perform mode from My Songs (rehearsal-flow tweak).

Type-check clean. **Lambda not yet deployed** — eyeball the diff first then say go.