### PR TITLE
Sync perform picker with My Songs via SongsUpdatedEvent

### DIFF
--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -7,7 +7,7 @@ import PaginatedPerformChart from "@/components/PaginatedPerformChart";
 import AnnotationLayer from "@/components/AnnotationLayer";
 import AnnotateToggle from "@/components/AnnotateToggle";
 import { useScoreStore } from "@/store/score-store";
-import { getSongs, type SongBankEntry } from "@/lib/song-bank";
+import { getSongs, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
 
 const PREFS_KEY = "notation-app-perform-prefs";
 
@@ -74,11 +74,17 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   const horizScrollRef = useRef<HTMLDivElement | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
 
-  // Song list. We snapshot on mount (so an in-flight cloud sync doesn't
-  // shuffle the picker mid-performance), but ALSO re-read localStorage
-  // every time the picker opens so dedup work done by MySongsModal sync
-  // is reflected here. Newest first matches My Songs modal ordering.
+  // Song list. Subscribe to the SongsUpdatedEvent so any sync, save,
+  // delete, or rename in another surface (My Songs modal especially)
+  // refreshes the picker here. Also re-read on picker-open as a
+  // safety net in case an event was missed during a remount race.
+  // Newest first matches My Songs modal ordering.
   const [songs, setSongs] = useState<SongBankEntry[]>(() => getSongs().slice().reverse());
+  useEffect(() => {
+    const refresh = () => setSongs(getSongs().slice().reverse());
+    window.addEventListener(SongsUpdatedEvent, refresh);
+    return () => window.removeEventListener(SongsUpdatedEvent, refresh);
+  }, []);
   useEffect(() => {
     if (pickerOpen) {
       setSongs(getSongs().slice().reverse());

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -15,6 +15,17 @@ export interface SongBankEntry {
 }
 
 const STORAGE_KEY = "notation-app-songs";
+const SONGS_UPDATED_EVENT = "notation-songs-updated";
+
+/** Event name dispatched on the window every time the song bank in
+ *  localStorage is rewritten. Listen for this to keep secondary views
+ *  (perform-mode song picker, sidebar lists) in sync without polling. */
+export const SongsUpdatedEvent = SONGS_UPDATED_EVENT;
+
+function fireSongsUpdated(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(SONGS_UPDATED_EVENT));
+}
 
 export function getSongs(): SongBankEntry[] {
   try {
@@ -35,6 +46,7 @@ export function saveSong(title: string, score: Score): void {
   });
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(songs));
+    fireSongsUpdated();
   } catch {
     console.warn("[song-bank] localStorage quota exceeded");
   }
@@ -44,6 +56,7 @@ export function deleteSong(id: string): void {
   try {
     const songs = getSongs().filter(s => s.id !== id);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(songs));
+    fireSongsUpdated();
   } catch {
     console.warn("[song-bank] failed to delete song");
   }
@@ -52,6 +65,7 @@ export function deleteSong(id: string): void {
 export function setSongs(songs: SongBankEntry[]): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(songs));
+    fireSongsUpdated();
   } catch {
     console.warn("[song-bank] localStorage quota exceeded");
   }
@@ -65,7 +79,7 @@ export function renameSong(id: string, title: string): SongBankEntry | null {
   if (idx === -1) return null;
   const next: SongBankEntry = { ...songs[idx], title };
   songs[idx] = next;
-  setSongs(songs);
+  setSongs(songs); // dispatches SongsUpdatedEvent
   return next;
 }
 


### PR DESCRIPTION
Picker showed stale mount-time snapshot when My Songs sync de-duped localStorage. Now subscribes to a global event fired on every song-bank write.