### PR TITLE
Recover-all button + Revisions UX cleanup

### DIFF
--- a/src/components/AutosaveRecoveryDialog.tsx
+++ b/src/components/AutosaveRecoveryDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { listSnapshots, loadSnapshot, deleteSnapshot, AutosaveSnapshot } from "@/lib/autosave";
 import { useScoreStore } from "@/store/score-store";
 import {
@@ -9,6 +9,7 @@ import {
   cloudListVersions,
 } from "@/lib/song-cloud";
 import type { VersionEntry } from "@/lib/song-cloud-types";
+import { getSongs, saveSong } from "@/lib/song-bank";
 
 interface AutosaveRecoveryDialogProps {
   onClose: () => void;
@@ -122,6 +123,66 @@ export default function AutosaveRecoveryDialog({ onClose, filterTitle, cloudSong
     }
   };
 
+  // Snapshots grouped by title — used by both the rendering pass and
+  // the "Recover all" button. Each title's newest snapshot is the
+  // candidate to materialize into My Songs.
+  const groupedByTitle = useMemo(() => {
+    if (!snapshots) return null;
+    const map = new Map<string, Omit<AutosaveSnapshot, "score">>();
+    for (const s of snapshots) {
+      const key = (s.title || "Untitled").toLowerCase();
+      const existing = map.get(key);
+      if (!existing || s.timestamp > existing.timestamp) map.set(key, s);
+    }
+    return map;
+  }, [snapshots]);
+
+  /** Recover every unique-title snapshot whose title isn't already
+   *  represented in My Songs. The newest snapshot per title wins.
+   *  Used after the save flow loses a song (e.g. silent overwrite via
+   *  the now-fixed currentSongId clobber). One click rescues everything. */
+  const handleRecoverAllUnique = async () => {
+    if (!groupedByTitle || busy) return;
+    setBusy(true);
+    try {
+      const existingTitles = new Set(
+        getSongs().map((s) => (s.title || "").trim().toLowerCase()),
+      );
+      let recovered = 0;
+      const recoveredTitles: string[] = [];
+      for (const [key, snapMeta] of groupedByTitle.entries()) {
+        if (existingTitles.has(key)) continue;
+        if (key === "untitled") continue; // skip the placeholder
+        const full = await loadSnapshot(snapMeta.timestamp);
+        if (!full) continue;
+        saveSong(snapMeta.title, full.score);
+        recovered++;
+        recoveredTitles.push(snapMeta.title);
+      }
+      if (recovered === 0) {
+        addMessage({
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: "Nothing to recover — every snapshotted title is already in My Songs.",
+          timestamp: Date.now(),
+        });
+      } else {
+        addMessage({
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: `Recovered ${recovered} song${recovered === 1 ? "" : "s"} into My Songs: ${recoveredTitles.join(", ")}.`,
+          timestamp: Date.now(),
+        });
+      }
+      onClose();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Failed to recover snapshots";
+      setError(msg);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const handleDelete = async (timestamp: number) => {
     if (busy) return;
     if (!confirm(`Delete this autosave from ${formatTimestamp(timestamp)}?`)) return;
@@ -147,19 +208,32 @@ export default function AutosaveRecoveryDialog({ onClose, filterTitle, cloudSong
         className="bg-white rounded-xl shadow-2xl border border-gray-200 w-[560px] max-h-[70vh] flex flex-col overflow-hidden text-gray-800"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between">
-          <div>
+        <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between gap-3">
+          <div className="min-w-0">
             <h2 className="text-base font-semibold">
               {filterTitle ? `History — ${filterTitle}` : "Recover from Auto-save"}
             </h2>
             <p className="text-xs text-gray-500 mt-0.5">
-              Up to the last 20 snapshots, saved every 30 seconds when there are changes.
+              Up to the last 50 snapshots, saved as you edit. Click any row to load
+              it; click <strong>Recover all</strong> below to bulk-rescue every
+              unique title that isn&rsquo;t already in My Songs.
             </p>
           </div>
+          {!filterTitle && groupedByTitle && groupedByTitle.size > 0 && (
+            <button
+              type="button"
+              onClick={handleRecoverAllUnique}
+              disabled={busy}
+              className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg disabled:opacity-50 whitespace-nowrap shrink-0"
+              title="Bulk-recover every unique-titled snapshot not already in My Songs. The newest snapshot per title wins."
+            >
+              Recover all
+            </button>
+          )}
           <button
             type="button"
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 text-lg px-2"
+            className="text-gray-500 hover:text-gray-700 text-lg px-2 shrink-0"
             aria-label="Close"
           >
             ×

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -499,10 +499,6 @@ export default function PropertiesPanel({ embedded = false }: PropertiesPanelPro
         </section>
       </div>
 
-      {/* Revisions — anchored at bottom */}
-      <div className="mt-auto">
-        <RevisionPanel />
-      </div>
     </div>
   );
 }

--- a/src/components/RevisionPanel.tsx
+++ b/src/components/RevisionPanel.tsx
@@ -3,6 +3,18 @@
 import { useState } from "react";
 import { useScoreStore } from "@/store/score-store";
 
+/**
+ * Named-revision panel. Always renders its contents — the consumer is
+ * responsible for any collapse/expand chrome (PropSection handles that
+ * in the embedded case). Previously RevisionPanel had its own internal
+ * disclosure arrow on top of PropSection's, which forced the user to
+ * click twice to see anything.
+ *
+ * Note: most users get all the recovery they need from File → Recover
+ * from Auto-save (50 snapshots in IndexedDB). Named revisions are
+ * mostly for milestones the user wants to label and never lose. Kept
+ * compact accordingly.
+ */
 export default function RevisionPanel() {
   const {
     score,
@@ -14,7 +26,6 @@ export default function RevisionPanel() {
     historyIndex,
   } = useScoreStore();
   const [saveName, setSaveName] = useState("");
-  const [showPanel, setShowPanel] = useState(false);
 
   if (!score) return null;
 
@@ -40,84 +51,79 @@ export default function RevisionPanel() {
   };
 
   return (
-    <div className="border-t border-gray-200">
-      <button
-        onClick={() => setShowPanel(!showPanel)}
-        className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50"
-      >
-        <span>
-          Revisions ({savedRevisions.length})
-          {history.length > 1 && (
-            <span className="text-gray-400 ml-1">
-              &middot; {historyIndex + 1}/{history.length} undo steps
-            </span>
-          )}
-        </span>
-        <span className="text-[10px]">{showPanel ? "\u25B2" : "\u25BC"}</span>
-      </button>
+    <div className="px-3 py-2 space-y-2">
+      <div className="text-[10px] text-gray-500">
+        {savedRevisions.length} named revision{savedRevisions.length === 1 ? "" : "s"}
+        {history.length > 1 && (
+          <span className="text-gray-400 ml-2">
+            · {historyIndex + 1}/{history.length} undo steps
+          </span>
+        )}
+      </div>
 
-      {showPanel && (
-        <div className="px-3 pb-3 space-y-2">
-          {/* Save form */}
-          <div className="flex gap-1">
-            <input
-              type="text"
-              value={saveName}
-              onChange={(e) => setSaveName(e.target.value)}
-              placeholder="Revision name..."
-              onKeyDown={(e) => e.key === "Enter" && handleSave()}
-              className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 text-gray-800 placeholder-gray-400"
-            />
-            <button
-              onClick={handleSave}
-              className="px-2 py-1 text-xs font-medium text-green-700 bg-green-50 hover:bg-green-100 rounded transition-colors"
+      {/* Name + Save form. The placeholder is explicit: this names a
+       * NEW milestone, it isn't a search box. (Earlier user feedback:
+       * 'the search box doesn't work' — they were typing here expecting
+       * filter behavior.) */}
+      <div className="flex gap-1">
+        <input
+          type="text"
+          value={saveName}
+          onChange={(e) => setSaveName(e.target.value)}
+          placeholder="Name this version (e.g. 'pre-bridge edit')…"
+          aria-label="New revision name"
+          onKeyDown={(e) => e.key === "Enter" && handleSave()}
+          className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 text-gray-800 placeholder-gray-400"
+        />
+        <button
+          onClick={handleSave}
+          className="px-2 py-1 text-xs font-medium text-green-700 bg-green-50 hover:bg-green-100 rounded transition-colors whitespace-nowrap"
+          title="Save the current state as a named milestone"
+        >
+          Save
+        </button>
+      </div>
+
+      <p className="text-[10px] text-gray-400 leading-snug">
+        For ad-hoc recovery, use <strong>File → Recover from Auto-save…</strong>{" "}
+        — the editor snapshots automatically every few seconds.
+      </p>
+
+      {savedRevisions.length === 0 ? null : (
+        <div className="space-y-1 max-h-64 overflow-y-auto">
+          {[...savedRevisions].reverse().map((rev) => (
+            <div
+              key={rev.id}
+              className="flex items-center justify-between bg-white border border-gray-200 rounded px-2 py-1.5"
             >
-              Save
-            </button>
-          </div>
-
-          {/* Revision list */}
-          {savedRevisions.length === 0 ? (
-            <p className="text-[10px] text-gray-400 text-center py-2">
-              No saved revisions yet
-            </p>
-          ) : (
-            <div className="space-y-1 max-h-48 overflow-y-auto">
-              {[...savedRevisions].reverse().map((rev) => (
-                <div
-                  key={rev.id}
-                  className="flex items-center justify-between bg-white border border-gray-200 rounded px-2 py-1.5 group"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="text-xs font-medium text-gray-700 truncate">
-                      {rev.name}
-                    </div>
-                    <div className="text-[10px] text-gray-400">
-                      {formatDate(rev.timestamp)} {formatTime(rev.timestamp)}
-                      {" \u00B7 "}
-                      {rev.score.staves.length} staves, {rev.score.measures} measures
-                    </div>
-                  </div>
-                  <div className="flex gap-1 ml-2 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <button
-                      onClick={() => restoreRevision(rev.id)}
-                      className="px-1.5 py-0.5 text-[10px] text-blue-600 hover:bg-blue-50 rounded"
-                      title="Restore this revision"
-                    >
-                      Restore
-                    </button>
-                    <button
-                      onClick={() => deleteRevision(rev.id)}
-                      className="px-1.5 py-0.5 text-[10px] text-red-500 hover:bg-red-50 rounded"
-                      title="Delete this revision"
-                    >
-                      &times;
-                    </button>
-                  </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-xs font-medium text-gray-700 truncate">
+                  {rev.name}
                 </div>
-              ))}
+                <div className="text-[10px] text-gray-400">
+                  {formatDate(rev.timestamp)} {formatTime(rev.timestamp)}
+                  {" · "}
+                  {rev.score.staves.length} staves, {rev.score.measures} measures
+                </div>
+              </div>
+              <div className="flex gap-1 ml-2 shrink-0">
+                <button
+                  onClick={() => restoreRevision(rev.id)}
+                  className="px-1.5 py-0.5 text-[10px] text-blue-600 hover:bg-blue-50 rounded"
+                  title="Restore this revision"
+                >
+                  Restore
+                </button>
+                <button
+                  onClick={() => deleteRevision(rev.id)}
+                  className="px-1.5 py-0.5 text-[10px] text-red-500 hover:bg-red-50 rounded"
+                  title="Delete this revision"
+                >
+                  ×
+                </button>
+              </div>
             </div>
-          )}
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
**Recover all** in the autosave dialog → bulk-recover every unique-titled snapshot not already in My Songs. Single-tap rescue for orphaned songs.

Revisions UX: kill the double-disclosure (PropSection + RevisionPanel both had arrows), relabel the name input so it can't be mistaken for search, drop the redundant standalone footer, always-show action buttons (touch-friendly), bump scroll height.