### PR TITLE
Cloud-sync test coverage (autosave + sync + tombstone)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@vitest/expect": "^4.1.5",
         "eslint": "^9",
         "eslint-config-next": "16.2.3",
+        "happy-dom": "^20.9.0",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5",
@@ -2493,6 +2494,23 @@
       "integrity": "sha512-bj3If1sm1FYJN0tJMV2BJNrwoeQ6xfrTt+rbmFvUytyxUhklLlW79MR4uwQ+upzrNJLVy012TnC7oZqSpEglSw==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
@@ -4174,6 +4192,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -5361,6 +5392,24 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -9577,6 +9626,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9810,6 +9869,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@vitest/expect": "^4.1.5",
     "eslint": "^9",
     "eslint-config-next": "16.2.3",
+    "happy-dom": "^20.9.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",

--- a/src/lib/__tests__/cloud-autosave.test.ts
+++ b/src/lib/__tests__/cloud-autosave.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Score } from "../schema";
+import type { SongDTO } from "../song-cloud-types";
+
+// ── Score factory ─────────────────────────────────────────────────────
+
+function buildScore(overrides: Partial<Score> = {}): Score {
+  return {
+    id: "test-score",
+    title: "Test",
+    composer: "",
+    tempo: 120,
+    timeSignature: "4/4",
+    keySignature: "C",
+    measures: 4,
+    anacrusis: false,
+    staves: [],
+    chordSymbols: [],
+    rehearsalMarks: [],
+    repeats: [],
+    measureChanges: [],
+    sections: [
+      {
+        id: "v1",
+        label: "Verse 1",
+        lines: [{ chords: "C", lyrics: "hello" }],
+      },
+    ],
+    form: [],
+    annotations: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ── Test setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Each test gets a fresh localStorage and a fresh fetch mock.
+  localStorage.clear();
+  // Stable device id keeps the x-device-id header predictable across calls.
+  localStorage.setItem("notation-app-device-id", "test-device-id");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+/** Build a fetch mock that responds based on URL+method. Each handler
+ *  returns either a parsed body or a tuple [status, body]. */
+function mockFetch(handlers: Record<string, (req: { method: string; body: unknown }) => unknown | [number, unknown]>) {
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    const path = new URL(url).pathname;
+    const key = `${method} ${path}`;
+    const handler = handlers[key];
+    if (!handler) {
+      // Unmatched calls are a test bug — surface explicitly.
+      throw new Error(`unhandled fetch: ${key}`);
+    }
+    const result = handler({ method, body });
+    if (Array.isArray(result) && typeof result[0] === "number") {
+      const [status, payload] = result as [number, unknown];
+      return new Response(JSON.stringify(payload), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+// Helper: build a SongDTO matching a Score, with a fixed version.
+function dto(score: Score, version = "v1", folder?: string): SongDTO {
+  return {
+    id: score.id,
+    title: score.title,
+    savedAt: 1_000,
+    updatedAt: 1_000,
+    version,
+    score,
+    ...(folder ? { folder } : {}),
+  };
+}
+
+// ── autosaveToCloud — happy path ───────────────────────────────────────
+
+describe("autosaveToCloud", () => {
+  it("PUTs the score and updates local entry with new cloudVersion", async () => {
+    const { autosaveToCloud } = await import("../cloud-autosave");
+    const { saveSong, getSongs } = await import("../song-bank");
+
+    const score = buildScore({ id: "abc", title: "Hello" });
+    saveSong("Hello", score);
+    const local = getSongs();
+    expect(local).toHaveLength(1);
+    const songId = local[0].id;
+
+    mockFetch({
+      [`PUT /songs/${songId}`]: () => dto({ ...score, id: songId }, "fresh-version"),
+    });
+
+    const ok = await autosaveToCloud(songId, score);
+    expect(ok).toBe(true);
+
+    const refreshed = getSongs();
+    expect(refreshed[0].cloudVersion).toBe("fresh-version");
+  });
+
+  it("sends expectedVersion when local entry has cloudVersion", async () => {
+    const { autosaveToCloud } = await import("../cloud-autosave");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    const score = buildScore({ id: "v" });
+    saveSong("V", score);
+    const songId = getSongs()[0].id;
+    updateSong(songId, { cloudVersion: "v0" });
+
+    let receivedExpected: string | undefined;
+    mockFetch({
+      [`PUT /songs/${songId}`]: ({ body }) => {
+        receivedExpected = (body as { expectedVersion?: string }).expectedVersion;
+        return dto({ ...score, id: songId }, "v1");
+      },
+    });
+
+    await autosaveToCloud(songId, score);
+    expect(receivedExpected).toBe("v0");
+  });
+});
+
+// ── 409 → auto-merge path ──────────────────────────────────────────────
+
+describe("autosaveToCloud — 409 auto-merge", () => {
+  it("merges and silently re-saves when the conflict is non-overlapping", async () => {
+    const { autosaveToCloud, CloudSaveEvents } = await import("../cloud-autosave");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    const baseScore = buildScore({
+      id: "song",
+      sections: [
+        {
+          id: "v1",
+          label: "Verse 1",
+          lines: [
+            { chords: "C", lyrics: "line a" },
+            { chords: "G", lyrics: "line b" },
+          ],
+        },
+      ],
+    });
+    saveSong("Song", baseScore);
+    const songId = getSongs()[0].id;
+    updateSong(songId, { cloudVersion: "v0" });
+
+    // Mine: edit line 0 chord.
+    const mine = buildScore({
+      ...baseScore,
+      id: songId,
+      sections: [
+        {
+          id: "v1",
+          label: "Verse 1",
+          lines: [
+            { chords: "Am", lyrics: "line a" },
+            { chords: "G", lyrics: "line b" },
+          ],
+        },
+      ],
+    });
+
+    // Theirs (cloud): edit line 1 chord.
+    const theirs = buildScore({
+      ...baseScore,
+      id: songId,
+      sections: [
+        {
+          id: "v1",
+          label: "Verse 1",
+          lines: [
+            { chords: "C", lyrics: "line a" },
+            { chords: "Em", lyrics: "line b" },
+          ],
+        },
+      ],
+    });
+
+    let putCalls = 0;
+    let mergedScoreSent: Score | undefined;
+    mockFetch({
+      [`PUT /songs/${songId}`]: ({ body }) => {
+        putCalls++;
+        if (putCalls === 1) {
+          // First PUT → 409 with theirs as current.
+          return [409, { error: "conflict", current: dto(theirs, "v1") }];
+        }
+        // Second PUT (the merge retry) → success.
+        mergedScoreSent = (body as { score: Score }).score;
+        return dto((body as { score: Score }).score, "v2");
+      },
+    });
+
+    const mergedEvents: Score[] = [];
+    const onMerged = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { score: Score };
+      mergedEvents.push(detail.score);
+    };
+    window.addEventListener(CloudSaveEvents.Merged, onMerged);
+
+    const ok = await autosaveToCloud(songId, mine);
+
+    window.removeEventListener(CloudSaveEvents.Merged, onMerged);
+
+    expect(ok).toBe(true);
+    expect(putCalls).toBe(2);
+    // The merged score sent up should have BOTH edits.
+    expect(mergedScoreSent?.sections[0].lines[0].chords).toBe("Am");
+    expect(mergedScoreSent?.sections[0].lines[1].chords).toBe("Em");
+    // Toast event fired.
+    expect(mergedEvents).toHaveLength(1);
+    // Local cloudVersion advanced to the merge result's version.
+    expect(getSongs()[0].cloudVersion).toBe("v2");
+  });
+
+  it("falls through to the conflict modal when same-line chords disagree", async () => {
+    const { autosaveToCloud, CloudSaveEvents } = await import("../cloud-autosave");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    const base = buildScore({ id: "x" });
+    saveSong("X", base);
+    const songId = getSongs()[0].id;
+    updateSong(songId, { cloudVersion: "v0" });
+
+    const mine = buildScore({
+      ...base,
+      id: songId,
+      sections: [{ id: "v1", label: "Verse 1", lines: [{ chords: "Am", lyrics: "hello" }] }],
+    });
+    const theirs = buildScore({
+      ...base,
+      id: songId,
+      sections: [{ id: "v1", label: "Verse 1", lines: [{ chords: "Em", lyrics: "hello" }] }],
+    });
+
+    mockFetch({
+      [`PUT /songs/${songId}`]: () => [409, { error: "conflict", current: dto(theirs, "v1") }],
+    });
+
+    const conflicts: { current: SongDTO }[] = [];
+    const onConflict = (e: Event) => {
+      conflicts.push((e as CustomEvent).detail);
+    };
+    window.addEventListener(CloudSaveEvents.Conflict, onConflict);
+
+    const ok = await autosaveToCloud(songId, mine);
+
+    window.removeEventListener(CloudSaveEvents.Conflict, onConflict);
+
+    expect(ok).toBe(false);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].current.score.sections[0].lines[0].chords).toBe("Em");
+  });
+});
+
+// ── syncSongbook — tombstone respect ───────────────────────────────────
+
+describe("syncSongbook — tombstone deletion", () => {
+  it("drops a local entry when cloud lists nothing AND cloudVersion is set", async () => {
+    const { syncSongbook } = await import("../song-cloud");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    saveSong("Tombstoned", buildScore({ title: "Tombstoned" }));
+    const id = getSongs()[0].id;
+    updateSong(id, { cloudVersion: "v9" });
+
+    mockFetch({
+      "GET /songs": () => ({ songs: [] }),
+    });
+
+    const merged = await syncSongbook();
+    expect(merged).toHaveLength(0);
+    expect(getSongs()).toHaveLength(0);
+  });
+
+  it("pushes a never-synced local entry up (legacy migration)", async () => {
+    const { syncSongbook } = await import("../song-cloud");
+    const { saveSong, getSongs } = await import("../song-bank");
+
+    saveSong("Legacy", buildScore({ title: "Legacy" }));
+    const id = getSongs()[0].id;
+
+    let pushed: { score: Score } | undefined;
+    mockFetch({
+      "GET /songs": () => ({ songs: [] }),
+      [`PUT /songs/${id}`]: ({ body }) => {
+        pushed = body as { score: Score };
+        return dto(buildScore({ id, title: "Legacy" }), "freshly-pushed");
+      },
+    });
+
+    const merged = await syncSongbook();
+    expect(pushed).toBeTruthy();
+    expect(merged).toHaveLength(1);
+    expect(merged[0].cloudVersion).toBe("freshly-pushed");
+  });
+
+  it("pulls a cloud entry when local doesn't have it", async () => {
+    const { syncSongbook } = await import("../song-cloud");
+    const { getSongs } = await import("../song-bank");
+
+    const cloudScore = buildScore({ id: "remote", title: "Remote" });
+    mockFetch({
+      "GET /songs": () => ({
+        songs: [
+          {
+            id: "remote",
+            title: "Remote",
+            savedAt: 5_000,
+            updatedAt: 5_000,
+            version: "rv1",
+          },
+        ],
+      }),
+      "GET /songs/remote": () => dto(cloudScore, "rv1"),
+    });
+
+    const merged = await syncSongbook();
+    expect(merged).toHaveLength(1);
+    expect(merged[0].title).toBe("Remote");
+    expect(merged[0].cloudVersion).toBe("rv1");
+    // Local mirror also written.
+    expect(getSongs()).toHaveLength(1);
+  });
+
+  it("uses local for entries newer than cloud (push-up path)", async () => {
+    const { syncSongbook } = await import("../song-cloud");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    saveSong("Edited", buildScore({ title: "Edited" }));
+    const id = getSongs()[0].id;
+    updateSong(id, { cloudVersion: "old", savedAt: 9_000 });
+
+    let putBody: { score: Score; expectedVersion?: string } | undefined;
+    mockFetch({
+      "GET /songs": () => ({
+        songs: [
+          {
+            id,
+            title: "Edited",
+            savedAt: 5_000,
+            updatedAt: 5_000,
+            version: "old",
+          },
+        ],
+      }),
+      [`PUT /songs/${id}`]: ({ body }) => {
+        putBody = body as { score: Score; expectedVersion?: string };
+        return dto(buildScore({ id, title: "Edited" }), "new");
+      },
+    });
+
+    const merged = await syncSongbook();
+    expect(putBody?.expectedVersion).toBe("old");
+    expect(merged[0].cloudVersion).toBe("new");
+  });
+});
+
+// ── enqueueOffline / hasPendingOps / flushQueue ────────────────────────
+
+describe("offline queue", () => {
+  it("collapses repeated enqueues for the same id", async () => {
+    const { enqueueOffline, hasPendingOps } = await import("../song-cloud");
+    expect(hasPendingOps()).toBe(false);
+    enqueueOffline({ type: "put", id: "a", title: "A1", score: buildScore() });
+    enqueueOffline({ type: "put", id: "a", title: "A2", score: buildScore() });
+    enqueueOffline({ type: "delete", id: "b" });
+    expect(hasPendingOps()).toBe(true);
+    const raw = JSON.parse(localStorage.getItem("notation-app-cloud-queue") ?? "[]");
+    expect(raw).toHaveLength(2);
+    // Latest 'a' wins
+    expect(raw[0].title).toBe("A2");
+    expect(raw[1].id).toBe("b");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,27 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     include: ["src/**/__tests__/**/*.test.ts", "src/**/__tests__/**/*.test.tsx"],
     // Don't sweep up the Playwright e2e suite — it has a different test
     // runner and would otherwise complain about unsupported describe()
     // calls in the vitest context.
     exclude: ["node_modules", "e2e", ".next", "infra"],
+    // Use happy-dom so window / document / localStorage / dispatchEvent
+    // are available without booting a full browser. Faster than jsdom
+    // for the bits the cloud-sync tests need.
+    environment: "happy-dom",
+    // Cloud env: set NEXT_PUBLIC_API_BASE so CLOUD_ENABLED is true at
+    // module load. The base value doesn't matter for tests because we
+    // mock fetch — it just needs to be non-empty.
+    env: {
+      NEXT_PUBLIC_API_BASE: "https://test.local",
+    },
   },
 });


### PR DESCRIPTION
9 new vitest specs covering autosaveToCloud (happy path, expectedVersion, 409 auto-merge, 409 conflict-modal fallback) and syncSongbook (tombstone, legacy push, pull, push-up) plus offline queue. Uses happy-dom + fetch mocking; <250ms total. CI picks them up automatically.