### PR TITLE
Hide alias artifacts from Sets picker + 'Clean up aliases' action

### DIFF
--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -7,6 +7,7 @@ import AutosaveRecoveryDialog from "@/components/AutosaveRecoveryDialog";
 import SetsPanel from "@/components/SetsPanel";
 import {
   getSongs,
+  isAliasTitle,
   saveSong,
   deleteSong,
   renameSong,
@@ -456,6 +457,35 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     }
   };
 
+  // Bulk-delete autosave/recovery alias entries — titles like
+  // "Foo (snapped)", "(recovered 9:06 PM)", "(latest 10:37 PM)" — that
+  // earlier sync/recovery flows used to disambiguate duplicates. They
+  // pile up over time and clutter the Sets candidate picker. Removes
+  // both local and cloud copies, with a transparent confirm.
+  const handleCleanupAliases = async () => {
+    const aliases = getSongs().filter((s) => isAliasTitle(s.title));
+    if (aliases.length === 0) {
+      window.alert("No alias entries found.");
+      return;
+    }
+    const preview = aliases.slice(0, 8).map((s) => `• "${s.title}"`).join("\n");
+    const more = aliases.length > 8 ? `\n…and ${aliases.length - 8} more` : "";
+    const ok = window.confirm(
+      `Delete ${aliases.length} alias ${aliases.length === 1 ? "entry" : "entries"}? These are autosave/recovery copies whose titles end in (snapped), (recovered …), or (latest …).\n\n${preview}${more}`,
+    );
+    if (!ok) return;
+    for (const entry of aliases) {
+      deleteSong(entry.id);
+      if (CLOUD_ENABLED) {
+        try { await cloudDeleteSong(entry.id); } catch { /* best-effort */ }
+      }
+    }
+    refreshLocal();
+    if (CLOUD_ENABLED) {
+      await runSync();
+    }
+  };
+
   const handleDelete = async (id: string) => {
     logEvent({ event: "mysongs_delete" });
     deleteSong(id);
@@ -835,14 +865,23 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           </div>
         )}
 
-        <div className="px-5 py-4 border-t border-gray-200 flex justify-between items-center">
-          <button
-            onClick={handleCleanupDuplicates}
-            className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors"
-            title="Delete duplicate-titled songs, keeping the newest of each"
-          >
-            Clean up duplicates
-          </button>
+        <div className="px-5 py-4 border-t border-gray-200 flex justify-between items-center gap-2">
+          <div className="flex items-center gap-1">
+            <button
+              onClick={handleCleanupDuplicates}
+              className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors"
+              title="Delete duplicate-titled songs, keeping the newest of each"
+            >
+              Clean up duplicates
+            </button>
+            <button
+              onClick={handleCleanupAliases}
+              className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors"
+              title="Delete autosave/recovery alias copies (titles ending in (snapped), (recovered …), (latest …))"
+            >
+              Clean up aliases
+            </button>
+          </div>
           <button
             onClick={onClose}
             className="px-5 py-2 text-sm text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors"

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -12,7 +12,7 @@ import {
   SetsUpdatedEvent,
   type SongSet,
 } from "@/lib/song-sets";
-import { getSongs, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
+import { getSongs, isAliasTitle, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
 import { useScoreStore } from "@/store/score-store";
 import { saveSnapshot } from "@/lib/autosave";
 import { scoreTypeOf } from "@/lib/analytics";
@@ -211,7 +211,13 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
 
   const allSongs = Array.from(songsById.values());
   const inSet = new Set(openSet.songIds);
-  const candidates = allSongs.filter((s) => !inSet.has(s.id));
+  // Hide alias entries (titles like "Foo (snapped)" / "(recovered 9:06 PM)"
+  // / "(latest 10:37 PM)") from the candidate list — they're stale
+  // autosave/recovery artifacts the user almost never wants to add to a
+  // set. They remain in My Songs and can be removed via "Clean up aliases".
+  const candidatesAll = allSongs.filter((s) => !inSet.has(s.id));
+  const candidates = candidatesAll.filter((s) => !isAliasTitle(s.title));
+  const hiddenAliasCount = candidatesAll.length - candidates.length;
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -298,11 +304,17 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
           </ul>
         )}
 
-        {/* Add-songs picker — shows everything not already in the set. */}
+        {/* Add-songs picker — shows everything not already in the set, with
+            alias artifacts hidden so the list stays scannable. */}
         {candidates.length > 0 && (
           <>
-            <div className="px-5 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 bg-gray-50 border-y border-gray-100 mt-2">
-              Add to this set
+            <div className="px-5 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 bg-gray-50 border-y border-gray-100 mt-2 flex items-center justify-between">
+              <span>Add to this set</span>
+              {hiddenAliasCount > 0 && (
+                <span className="text-[10px] normal-case tracking-normal text-gray-400">
+                  {hiddenAliasCount} alias{hiddenAliasCount === 1 ? "" : "es"} hidden — clean up in My Songs
+                </span>
+              )}
             </div>
             <ul className="divide-y divide-gray-100">
               {candidates.map((entry) => (

--- a/src/lib/__tests__/song-bank-aliases.test.ts
+++ b/src/lib/__tests__/song-bank-aliases.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { aliasCanonicalTitle, isAliasTitle } from "../song-bank";
+
+describe("aliasCanonicalTitle", () => {
+  it("strips (snapped)", () => {
+    expect(aliasCanonicalTitle("Anywhere (snapped)")).toBe("Anywhere");
+  });
+  it("strips (recovered 9:06 PM)", () => {
+    expect(aliasCanonicalTitle("Foggy Night (recovered 9:06 PM)")).toBe("Foggy Night");
+  });
+  it("strips (latest 10:37 PM)", () => {
+    expect(aliasCanonicalTitle("Star to Star (latest 10:37 PM)")).toBe("Star to Star");
+  });
+  it("strips (snapped) with trailing whitespace", () => {
+    expect(aliasCanonicalTitle("Foo (snapped)   ")).toBe("Foo");
+  });
+  it("is case-insensitive on the keyword", () => {
+    expect(aliasCanonicalTitle("Foo (Snapped)")).toBe("Foo");
+    expect(aliasCanonicalTitle("Foo (RECOVERED 1:00 AM)")).toBe("Foo");
+  });
+  it("returns null for plain titles", () => {
+    expect(aliasCanonicalTitle("Hurricane Larry")).toBeNull();
+    expect(aliasCanonicalTitle("Untitled")).toBeNull();
+  });
+  it("does not match unrelated parens", () => {
+    expect(aliasCanonicalTitle("Song (live version)")).toBeNull();
+    expect(aliasCanonicalTitle("Take 2 (rehearsal)")).toBeNull();
+  });
+});
+
+describe("isAliasTitle", () => {
+  it("matches alias titles", () => {
+    expect(isAliasTitle("Anywhere (snapped)")).toBe(true);
+    expect(isAliasTitle("Foo (recovered 9:06 PM)")).toBe(true);
+    expect(isAliasTitle("Bar (latest 10:37 PM)")).toBe(true);
+  });
+  it("rejects plain titles", () => {
+    expect(isAliasTitle("Anywhere")).toBe(false);
+    expect(isAliasTitle("Song (live)")).toBe(false);
+  });
+});

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -27,6 +27,26 @@ function fireSongsUpdated(): void {
   window.dispatchEvent(new CustomEvent(SONGS_UPDATED_EVENT));
 }
 
+/**
+ * Recognises titles that past autosave-recovery / dedup-cleanup runs
+ * suffixed to disambiguate copies, e.g.
+ *   "Anywhere (snapped)"
+ *   "Foggy Night (recovered 9:06 PM)"
+ *   "Star to Star (latest 10:37 PM)"
+ * These are alias entries — we hide them from the Sets candidate
+ * picker and offer a one-click cleanup. Returns the canonical title
+ * (suffix stripped) if matched, else null.
+ */
+export function aliasCanonicalTitle(title: string): string | null {
+  const m = title.match(/^(.*?)\s*\((snapped|recovered|latest)(?:\s[^)]*)?\)\s*$/i);
+  return m ? m[1].trim() : null;
+}
+
+/** True if the title looks like an autosave-/recovery-/sync-generated alias. */
+export function isAliasTitle(title: string): boolean {
+  return aliasCanonicalTitle(title) !== null;
+}
+
 export function getSongs(): SongBankEntry[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary

Fixes the immediate complaint that the Sets "Add to this set" picker is unscannable — `Anywhere` and `Anywhere (snapped)` look identical in the list, ditto for Foggy Night / Star to Star and the various `(recovered HH:MM PM)` and `(latest HH:MM PM)` entries.

These are stale autosave/recovery suffix titles left behind by old sync/dedup runs. The existing "Clean up duplicates" button can't touch them because it matches on exact title.

- New `aliasCanonicalTitle` / `isAliasTitle` helpers in `src/lib/song-bank.ts` recognise `(snapped)` / `(recovered …)` / `(latest …)` suffixes (case-insensitive, suffix-only — won't false-match `Song (live version)`)
- Sets candidate picker filters them out, with a small "N aliases hidden — clean up in My Songs" hint
- New **"Clean up aliases"** button next to "Clean up duplicates" — bulk-deletes alias entries from local + cloud with a transparent preview confirm

## Test plan

- [ ] Open My Songs → Sets → an existing set → verify "Add to this set" no longer shows the `(snapped)` / `(recovered …)` / `(latest …)` entries
- [ ] Confirm the "N aliases hidden" hint appears
- [ ] Click "Clean up aliases" in the modal footer → see preview, confirm, verify they disappear from My Songs
- [ ] `npx vitest run` (53 passing, 9 new for the matcher)
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)