### PR TITLE
Annotation fixes: visible textarea + drag-to-move

### DIFF
--- a/src/components/AnnotationLayer.tsx
+++ b/src/components/AnnotationLayer.tsx
@@ -40,6 +40,29 @@ export default function AnnotationLayer() {
   // overlay opens a popover and scrolling on iPad/touch devices breaks.
   const pointerStart = useRef<{ x: number; y: number } | null>(null);
 
+  // Drag-to-move state for repositioning an existing bubble. Live during
+  // the gesture; on pointer-up either commits an update_annotation patch
+  // (if the bubble moved) or falls through to opening the editor (tap).
+  // Ref-not-state because the pointer-event handlers need to read the
+  // current values synchronously without re-render churn.
+  const dragState = useRef<{
+    id: string;
+    startClientX: number;
+    startClientY: number;
+    baseAnchorX: number;
+    baseAnchorY: number;
+    layerRect: DOMRect;
+    moved: boolean;
+  } | null>(null);
+  // Visual feedback during drag — re-rendered when dragOffset changes.
+  // Stored in fraction-of-container-size so it composes with anchorX/Y.
+  const [dragVisual, setDragVisual] = useState<{
+    id: string;
+    dx: number;
+    dy: number;
+  } | null>(null);
+  const layerRef = useRef<HTMLDivElement | null>(null);
+
   const editingAnnotation = editingId
     ? annotations.find((a) => a.id === editingId) ?? null
     : null;
@@ -88,10 +111,67 @@ export default function AnnotationLayer() {
     [annotationMode],
   );
 
-  const handleBubbleClick = (e: React.MouseEvent, ann: Annotation) => {
+  // Bubble pointer handlers — drive both tap-to-edit and drag-to-move.
+  // pointerdown captures pointer so the drag continues even if the finger
+  // slides off the bubble onto another element (critical on iPad).
+  const handleBubblePointerDown = (e: React.PointerEvent, ann: Annotation) => {
     e.stopPropagation();
-    setEditingId(ann.id);
-    setPendingAnchor(null);
+    if (!annotationMode) return;
+    const layer = layerRef.current;
+    if (!layer) return;
+    const rect = layer.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    dragState.current = {
+      id: ann.id,
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      baseAnchorX: ann.anchorX,
+      baseAnchorY: ann.anchorY,
+      layerRect: rect,
+      moved: false,
+    };
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const handleBubblePointerMove = (e: React.PointerEvent) => {
+    const drag = dragState.current;
+    if (!drag) return;
+    const dxPx = e.clientX - drag.startClientX;
+    const dyPx = e.clientY - drag.startClientY;
+    if (!drag.moved && Math.abs(dxPx) <= TAP_THRESHOLD_PX && Math.abs(dyPx) <= TAP_THRESHOLD_PX) {
+      return; // still inside the tap-threshold, no visual movement yet
+    }
+    drag.moved = true;
+    setDragVisual({
+      id: drag.id,
+      dx: dxPx / drag.layerRect.width,
+      dy: dyPx / drag.layerRect.height,
+    });
+  };
+
+  const handleBubblePointerUp = (e: React.PointerEvent, ann: Annotation) => {
+    e.stopPropagation();
+    const drag = dragState.current;
+    dragState.current = null;
+    setDragVisual(null);
+    if (!drag) {
+      // No drag started (e.g. annotationMode was off on pointerdown) —
+      // treat as a plain tap to open the editor.
+      setEditingId(ann.id);
+      setPendingAnchor(null);
+      return;
+    }
+    if (!drag.moved) {
+      // Pure tap inside the threshold — open editor.
+      setEditingId(ann.id);
+      setPendingAnchor(null);
+      return;
+    }
+    // Commit the move. Clamp to [0,1] so the bubble can't end up off-canvas.
+    const newX = Math.max(0, Math.min(1, drag.baseAnchorX + (e.clientX - drag.startClientX) / drag.layerRect.width));
+    const newY = Math.max(0, Math.min(1, drag.baseAnchorY + (e.clientY - drag.startClientY) / drag.layerRect.height));
+    logEvent({ event: "annotation_edit", scoreType: scoreTypeOf(score) });
+    applyPatches([{ op: "update_annotation", id: drag.id, updates: { anchorX: newX, anchorY: newY } }]);
   };
 
   const handleCreate = (data: {
@@ -148,6 +228,7 @@ export default function AnnotationLayer() {
 
   return (
     <div
+      ref={layerRef}
       className={`absolute inset-0 ${annotationMode ? "cursor-crosshair" : ""}`}
       style={layerStyle}
       onPointerDown={handlePointerDown}
@@ -156,19 +237,30 @@ export default function AnnotationLayer() {
       {/* Annotation bubbles */}
       {filteredAnnotations.map((ann) => {
         const cls = COLOR_CLASSES[ann.color] ?? COLOR_CLASSES.yellow;
+        // Visual offset while a drag is in progress for THIS bubble. The
+        // anchor on the model doesn't change until pointer-up; we just
+        // shift the bubble in screen space so the user sees it follow
+        // their finger.
+        const isDragging = dragVisual?.id === ann.id;
+        const dragShiftX = isDragging ? dragVisual.dx * 100 : 0;
+        const dragShiftY = isDragging ? dragVisual.dy * 100 : 0;
         return (
           <div
             key={ann.id}
             data-annotation-bubble="true"
             className="absolute"
             style={{
-              left: `${ann.anchorX * 100}%`,
-              top: `${ann.anchorY * 100}%`,
+              left: `calc(${ann.anchorX * 100}% + ${dragShiftX}%)`,
+              top: `calc(${ann.anchorY * 100}% + ${dragShiftY}%)`,
               transform: "translate(-50%, calc(-100% - 8px))",
               pointerEvents: "auto",
-              zIndex: 10,
+              zIndex: isDragging ? 20 : 10,
+              touchAction: "none",
+              opacity: isDragging ? 0.8 : 1,
             }}
-            onClick={(e) => handleBubbleClick(e, ann)}
+            onPointerDown={(e) => handleBubblePointerDown(e, ann)}
+            onPointerMove={handleBubblePointerMove}
+            onPointerUp={(e) => handleBubblePointerUp(e, ann)}
           >
             <div
               className={`relative rounded-lg border px-2.5 py-1.5 text-xs shadow-md cursor-pointer max-w-[180px] min-w-[44px] min-h-[36px] flex flex-col justify-center ${cls.bg} ${cls.border} ${cls.text}`}

--- a/src/components/AnnotationPopover.tsx
+++ b/src/components/AnnotationPopover.tsx
@@ -150,7 +150,7 @@ export default function AnnotationPopover({
             }}
             rows={3}
             placeholder="Add a note…"
-            className="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            className="w-full text-sm text-gray-900 placeholder-gray-400 border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
           />
         </div>
 

--- a/src/components/AnnotationPopover.tsx
+++ b/src/components/AnnotationPopover.tsx
@@ -76,6 +76,15 @@ export default function AnnotationPopover({
   const topPct = anchorY * 100;
   const above = topPct > 40;
 
+  // The popover lives INSIDE AnnotationLayer's DOM tree. The layer listens
+  // on pointerdown/pointerup (not click) for tap-to-create. Without
+  // stopping pointer events here, clicking Save / Delete / Cancel / a
+  // color swatch — or even tapping the backdrop to dismiss — would also
+  // fire the layer's "create a new annotation here" handler, since
+  // pointer events fire BEFORE click. (Bug: tapping Delete used to spawn
+  // a fresh annotation at the Delete-button position.)
+  const stopPointer = (e: React.PointerEvent | React.MouseEvent) => e.stopPropagation();
+
   return (
     <>
       {/* Backdrop */}
@@ -83,6 +92,8 @@ export default function AnnotationPopover({
         className="absolute inset-0 z-40"
         style={{ pointerEvents: "auto" }}
         onClick={onClose}
+        onPointerDown={stopPointer}
+        onPointerUp={stopPointer}
       />
 
       {/* Popover */}
@@ -97,6 +108,8 @@ export default function AnnotationPopover({
           pointerEvents: "auto",
         }}
         onClick={(e) => e.stopPropagation()}
+        onPointerDown={stopPointer}
+        onPointerUp={stopPointer}
       >
         {/* Color swatches */}
         <div className="flex items-center gap-2 px-4 pt-4 pb-2">

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -520,6 +520,8 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
       color: z.enum(["yellow", "blue", "pink", "green"]).optional(),
       visibility: z.enum(["shared", "personal"]).optional(),
       label: z.string().optional(),
+      anchorX: z.number().min(0).max(1).optional(),
+      anchorY: z.number().min(0).max(1).optional(),
     }),
   }),
   z.object({


### PR DESCRIPTION
## Summary

Three fixes to the annotation system:

1. **Font invisible in the create/edit dialog** — the textarea had no explicit text-color class, so on systems where the default is white-on-white the user couldn't see what they were typing. (The saved bubble has its own color classes via `COLOR_CLASSES`, which is why it looked fine once saved.) Fix: `text-gray-900` + `placeholder-gray-400`.

2. **No way to move an annotation** — adds drag-to-move on existing bubbles when annotation mode is on:
   - Pointer-capture on pointerdown so dragging keeps working when the finger slides off the bubble.
   - Live visual offset during drag (semi-transparent, lifted z-index).
   - Tap (movement < `TAP_THRESHOLD_PX`) still opens the editor — same threshold the tap-to-create flow uses.
   - Commit on pointer-up clamps to `[0,1]` so the bubble can't end up off-canvas.

3. **Patch schema** — `update_annotation` now allows optional `anchorX` / `anchorY`. The runtime applier already spreads `updates` so no behavior change for existing callers.

Edit and delete already worked via the popover (Save / Delete buttons in `AnnotationPopover.tsx:206–224`); they just weren't discoverable because the dialog looked broken.

## Test plan

- [ ] Open a chord chart with annotations enabled → tap the Annotate toggle → tap an empty spot → see the popover with **visible text** as you type.
- [ ] Tap an existing bubble (in annotation mode) → editor opens with current text visible → edit / change color / Save → updates apply.
- [ ] Tap an existing bubble → Delete → bubble removed.
- [ ] Drag an existing bubble (annotation mode on) → ghost preview follows finger → release → bubble lands at new position.
- [ ] Drag less than ~10px → editor opens instead (tap not drag).
- [ ] `npx tsc --noEmit` clean.
- [ ] `npx vitest run` (53 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)