### PR TITLE
UI guidelines doc + Sets/My Songs redesign (multi-select)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+# UI work
+
+Before designing or modifying UI components, read `docs/ui-guidelines.md`. It codifies the patterns already in use (modal sizing, button styles, list rows, empty states, multi-select). Match what's there before inventing anything new.

--- a/docs/ui-guidelines.md
+++ b/docs/ui-guidelines.md
@@ -1,0 +1,112 @@
+# UI guidelines
+
+This file codifies UI conventions for NotationApp. The app is **tablet-first**
+(iPad portrait is the design target) and **keyboard-first** (every modal and
+list must work with Esc / Enter / arrows). Most of what's here describes
+patterns already in the codebase — read a similar existing component before
+designing a new one. Coherence beats novelty.
+
+> Update this file when you add a pattern that other components should follow.
+
+## Principles
+
+1. **Tablet-first.** Every control must work with a finger. Touch targets ≥ 44px.
+   No hover-only affordances.
+2. **Keyboard-first for power users.** Esc closes, Enter commits, ⌘⏎ saves.
+   Arrow keys navigate lists when applicable.
+3. **Match what's already there.** Before designing, grep `src/components/` for
+   a similar pattern and copy its sizing/colors.
+4. **One primary action per surface.** Filled blue. Everything else is gray or
+   ghost. Two filled-blue buttons in the same view is a smell.
+5. **Empty states teach the next move.** "No X yet. Type Y above…" — never
+   just "Empty."
+6. **Multi-select beats per-row buttons when users act on >5 items.** Don't
+   make them tap N times.
+7. **No scroll-jail in modals.** Footer actions must be reachable without
+   scrolling the body.
+
+## Sizing tokens (from real usage)
+
+- **Modal widths**: small `w-[440px]`, default `w-[560px]`, wide `w-[800px]`.
+  Always cap with `max-w-[92vw]`. Don't invent new widths without a reason.
+- **Row padding**: top-level `px-5 py-3` (~44–48px tall — meets touch target);
+  sub-rows `px-5 py-2`.
+- **Modal chrome**: `px-5` on header/footer/body; backdrop `bg-black/40`; z-50
+  for primary, z-100 for stacked / nested.
+- **Focus ring**: `focus:outline-none focus:ring-2 focus:ring-blue-500` on
+  every interactive element.
+
+## Buttons (four styles, no more)
+
+- **Primary (blue, filled)** — main action.
+  `px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg`
+- **Secondary (gray, ghost)** — Cancel, Close, side actions.
+  `px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg`
+- **Destructive (red)** — Delete and similar. Always confirm with a preview
+  of what's affected.
+  `text-red-600 hover:bg-red-50 active:bg-red-100`
+- **Ghost / icon-only** — Rename, kebab, close X.
+  `p-1.5 text-gray-500 hover:text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg`
+  (or `w-11 h-11` for prominent icon buttons; matches the 44px target).
+
+## Empty states
+
+Three lines or fewer. `text-gray-500`. Include the next action inline:
+
+- ✅ "No sets yet. Type a name above to create one — useful for grouping songs you play together at a gig or rehearsal."
+- ❌ "No sets found." / "Empty."
+
+## Lists
+
+- One primary tap per row (loads / opens). Secondary actions inline on the
+  right (Load button, kebab menu), `shrink-0`.
+- Hover: `hover:bg-gray-50`. Active: blue text accent on the title.
+- Kebab menus must use `fixed`-positioned popovers — `absolute` popovers
+  get clipped by the modal's `overflow-y-auto`.
+
+## Modals
+
+- `fixed inset-0` overlay with `bg-black/40` backdrop. `z-50` for primary;
+  stacked sheets at `z-[100]` or `z-[110]`.
+- Esc closes (mandatory). Backdrop click closes unless busy/disabled.
+- Header pattern: title + ghost X button on the right.
+- One filled-blue primary action in the footer; ghost Cancel / Close to its
+  left.
+
+## Multi-select mode
+
+When introducing multi-select to a list:
+
+1. Add a `[Select]` toggle ghost button in the header. On = select mode;
+   the button label flips to `[Cancel]`.
+2. In select mode, rows render with a leading checkbox; the primary tap
+   toggles selection instead of loading/opening.
+3. Per-row secondary actions (Load button, kebab) hide while in select mode
+   so the row is purely selection-focused.
+4. A bulk-action bar appears at the bottom of the modal when ≥1 item is
+   selected: `"N selected"` on the left; action buttons on the right
+   (primary filled-blue for the most common action, ghost for the rest,
+   destructive-red for Delete).
+5. Esc or `[Cancel]` exits select mode and clears the selection.
+
+## Sheets (modals stacked on modals)
+
+When a sub-action needs a focused decision sheet (e.g. "Add to set"):
+
+- Render at `z-[110]` so it sits above the parent modal's `z-50`.
+- Reuse the small-modal styling from `AutosaveRecoveryDialog.tsx` —
+  `w-[440px]` to `w-[560px]`, centred near the top of the viewport
+  (`pt-[12vh]`).
+- Same Esc / backdrop dismissal rules. Body click does NOT close the parent.
+
+## Pre-flight checklist (run BEFORE designing any new component)
+
+1. **Is there an existing component I can extend?** Grep `src/components/`
+   for a similar pattern; copy its skeleton.
+2. **Does the empty state teach the next action?**
+3. **What does keyboard nav look like?** Esc, Enter, arrows where applicable.
+4. **Is the primary action visible without scrolling?**
+5. **Are touch targets ≥ 44px?**
+6. **For lists >5 items, do users need multi-select?**
+7. **Does it look right at iPad portrait (≈810×1080)?** Open DevTools at
+   that viewport before merging.

--- a/src/components/AddToSetSheet.tsx
+++ b/src/components/AddToSetSheet.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  addSongToSet,
+  createSet,
+  getSets,
+  SetsUpdatedEvent,
+  type SongSet,
+} from "@/lib/song-sets";
+import { getSongs, isAliasTitle, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
+import { scoreTypeOf } from "@/lib/analytics";
+
+/**
+ * Stacked sheet (z-[110], above MySongsModal's z-50) used for two
+ * complementary flows:
+ *
+ *  - `pickSet`  → caller pre-selected songs; user picks which set
+ *                 (existing or "+ New set") to add them to.
+ *  - `pickSongs` → caller pre-selected a set; user picks which songs
+ *                 (multi-select with search) to add.
+ *
+ * Adds happen in one batch with `addSongToSet` per id (dedup is handled
+ * inside song-sets.ts already). Closes on success.
+ *
+ * Follows the small-modal styling from AutosaveRecoveryDialog.tsx
+ * (560px, pt-[12vh], black/40 backdrop, Esc + backdrop-click dismiss).
+ */
+interface AddToSetSheetProps {
+  onClose: () => void;
+}
+
+interface PickSetProps extends AddToSetSheetProps {
+  mode: "pickSet";
+  /** Song ids already chosen by the caller. The sheet picks the target set. */
+  songIds: string[];
+}
+
+interface PickSongsProps extends AddToSetSheetProps {
+  mode: "pickSongs";
+  /** Target set pre-chosen by the caller. The sheet picks the songs. */
+  targetSetId: string;
+}
+
+type Props = PickSetProps | PickSongsProps;
+
+export default function AddToSetSheet(props: Props) {
+  const { onClose } = props;
+
+  // Sets + songs lists. Subscribed so renames/edits elsewhere reflect.
+  const [sets, setSetsState] = useState<SongSet[]>(() => getSets());
+  const [songs, setSongsState] = useState<SongBankEntry[]>(() => getSongs());
+
+  useEffect(() => {
+    const refresh = () => {
+      setSetsState(getSets());
+      setSongsState(getSongs());
+    };
+    window.addEventListener(SetsUpdatedEvent, refresh);
+    window.addEventListener(SongsUpdatedEvent, refresh);
+    return () => {
+      window.removeEventListener(SetsUpdatedEvent, refresh);
+      window.removeEventListener(SongsUpdatedEvent, refresh);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-start justify-center pt-[12vh] bg-black/40"
+      // Stop the bubble so clicking the backdrop doesn't ALSO trigger the
+      // parent MySongsModal's onClose (its outer div uses the same
+      // backdrop-click-to-close pattern).
+      onClick={(e) => {
+        e.stopPropagation();
+        onClose();
+      }}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl border border-gray-200 w-[560px] max-w-[92vw] max-h-[70vh] flex flex-col overflow-hidden text-gray-800"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {props.mode === "pickSet" ? (
+          <PickSetBody
+            sets={sets}
+            songIds={props.songIds}
+            onClose={onClose}
+          />
+        ) : (
+          <PickSongsBody
+            sets={sets}
+            songs={songs}
+            targetSetId={props.targetSetId}
+            onClose={onClose}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── pickSet mode ───────────────────────────────────────────────────
+
+function PickSetBody({
+  sets,
+  songIds,
+  onClose,
+}: {
+  sets: SongSet[];
+  songIds: string[];
+  onClose: () => void;
+}) {
+  // Radio choice across existing sets + a synthetic "__new__" option
+  // that reveals a name input on the right.
+  const [chosen, setChosen] = useState<string>(sets[0]?.id ?? "__new__");
+  const [newName, setNewName] = useState("");
+
+  const handleAdd = () => {
+    if (songIds.length === 0) {
+      onClose();
+      return;
+    }
+    let setId: string | null = null;
+    if (chosen === "__new__") {
+      const trimmed = newName.trim();
+      if (!trimmed) return;
+      const fresh = createSet(trimmed);
+      setId = fresh.id;
+    } else {
+      setId = chosen;
+    }
+    if (!setId) return;
+    for (const id of songIds) addSongToSet(setId, id);
+    onClose();
+  };
+
+  const disabled =
+    songIds.length === 0 ||
+    (chosen === "__new__" && !newName.trim());
+
+  return (
+    <>
+      <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-gray-900">
+            Add {songIds.length} {songIds.length === 1 ? "song" : "songs"} to a set
+          </h2>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Pick an existing set or create a new one.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-700 text-lg px-2 shrink-0"
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {sets.length === 0 ? (
+          <div className="px-5 py-6 text-sm text-gray-500 text-center">
+            No sets yet. Name a new one below to create your first set.
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-100">
+            {sets.map((s) => (
+              <li key={s.id}>
+                <label className="flex items-center gap-3 px-5 py-3 hover:bg-gray-50 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="target-set"
+                    checked={chosen === s.id}
+                    onChange={() => setChosen(s.id)}
+                    className="w-4 h-4 text-blue-600"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-gray-900 truncate">{s.name}</div>
+                    <div className="text-xs text-gray-400">
+                      {s.songIds.length} song{s.songIds.length === 1 ? "" : "s"}
+                    </div>
+                  </div>
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+        {/* + New set row, always present at the bottom */}
+        <label className="flex items-center gap-3 px-5 py-3 hover:bg-gray-50 cursor-pointer border-t border-gray-100">
+          <input
+            type="radio"
+            name="target-set"
+            checked={chosen === "__new__"}
+            onChange={() => setChosen("__new__")}
+            className="w-4 h-4 text-blue-600"
+          />
+          <div className="flex-1">
+            <div className="text-sm font-medium text-gray-900 mb-1">+ New set</div>
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onFocus={() => setChosen("__new__")}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleAdd();
+                }
+              }}
+              placeholder="Set name (e.g. 'Friday gig')"
+              className="w-full text-sm text-gray-900 placeholder-gray-400 border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </label>
+      </div>
+      <div className="px-5 py-3 border-t border-gray-200 flex items-center justify-end gap-2">
+        <button
+          onClick={onClose}
+          className="px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleAdd}
+          disabled={disabled}
+          className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:bg-gray-300 disabled:cursor-not-allowed rounded-lg"
+        >
+          Add
+        </button>
+      </div>
+    </>
+  );
+}
+
+// ── pickSongs mode ────────────────────────────────────────────────
+
+function PickSongsBody({
+  sets,
+  songs,
+  targetSetId,
+  onClose,
+}: {
+  sets: SongSet[];
+  songs: SongBankEntry[];
+  targetSetId: string;
+  onClose: () => void;
+}) {
+  const target = sets.find((s) => s.id === targetSetId) ?? null;
+  const inSet = new Set(target?.songIds ?? []);
+
+  // Candidate list: songs not already in the set, with alias artifacts
+  // ("(snapped)" / "(recovered …)" / "(latest …)") filtered out so the
+  // user only sees real songs.
+  const candidates = useMemo(
+    () =>
+      songs
+        .filter((s) => !inSet.has(s.id))
+        .filter((s) => !isAliasTitle(s.title)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [songs, target?.songIds.join("|")],
+  );
+
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return candidates;
+    return candidates.filter((s) => s.title.toLowerCase().includes(q));
+  }, [candidates, query]);
+
+  const togglePicked = (id: string) => {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleAdd = () => {
+    if (picked.size === 0 || !target) {
+      onClose();
+      return;
+    }
+    for (const id of picked) addSongToSet(target.id, id);
+    onClose();
+  };
+
+  if (!target) {
+    return (
+      <>
+        <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-gray-900">Set not found</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 text-lg px-2"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="px-5 py-6 text-sm text-gray-500 text-center">
+          The set may have been deleted in another tab.
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-gray-900 truncate">
+            Add songs to {target.name}
+          </h2>
+          <p className="text-xs text-gray-500 mt-0.5">
+            {target.songIds.length} already in set
+          </p>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-700 text-lg px-2 shrink-0"
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+      <div className="px-5 py-2 border-b border-gray-100">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search songs…"
+          className="w-full text-sm text-gray-900 placeholder-gray-400 border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <div className="px-5 py-6 text-sm text-gray-500 text-center">
+            {candidates.length === 0
+              ? "Every song is already in this set."
+              : "No songs match that search."}
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-100">
+            {filtered.map((entry) => {
+              const t = scoreTypeOf(entry.score);
+              return (
+                <li key={entry.id}>
+                  <label className="flex items-center gap-3 px-5 py-3 hover:bg-gray-50 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={picked.has(entry.id)}
+                      onChange={() => togglePicked(entry.id)}
+                      className="w-4 h-4 text-blue-600"
+                    />
+                    <span className="flex-1 min-w-0 text-sm text-gray-900 truncate">
+                      {entry.title}
+                      {t === "chord-chart" && (
+                        <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-pink-100 text-pink-700 ml-2">
+                          Chart
+                        </span>
+                      )}
+                      {t === "notation" && (
+                        <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 ml-2">
+                          Score
+                        </span>
+                      )}
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+      <div className="px-5 py-3 border-t border-gray-200 flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-500">
+          {picked.size > 0 ? `${picked.size} selected` : "Pick at least one"}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleAdd}
+            disabled={picked.size === 0}
+            className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:bg-gray-300 disabled:cursor-not-allowed rounded-lg"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -5,6 +5,7 @@ import { useScoreStore } from "@/store/score-store";
 import { saveSnapshot } from "@/lib/autosave";
 import AutosaveRecoveryDialog from "@/components/AutosaveRecoveryDialog";
 import SetsPanel from "@/components/SetsPanel";
+import AddToSetSheet from "@/components/AddToSetSheet";
 import {
   getSongs,
   isAliasTitle,
@@ -78,6 +79,42 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
   const [menuAnchor, setMenuAnchor] = useState<Anchor | null>(null);
   const [pickerAnchor, setPickerAnchor] = useState<Anchor | null>(null);
   const [historyForTitle, setHistoryForTitle] = useState<string | null>(null);
+  // Multi-select state for bulk operations (#73 follow-up). When
+  // selectMode is on, rows render with leading checkboxes; the title
+  // toggles selection instead of starting a rename; Load + kebab hide.
+  // Esc exits.
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Stacked sheet for "Add to set…" bulk action. Pre-fills with the
+  // current selection; the sheet picks the target set (existing or new).
+  const [addToSetOpen, setAddToSetOpen] = useState(false);
+  // Centered "pick a folder" picker for the bulk Move action.
+  const [bulkFolderOpen, setBulkFolderOpen] = useState(false);
+
+  const exitSelectMode = () => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  };
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    if (!selectMode) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        exitSelectMode();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [selectMode]);
 
   const openKebab = (entry: SongBankEntry, e: React.MouseEvent<HTMLButtonElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -486,6 +523,70 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     }
   };
 
+  // Bulk delete of the currently-selected songs. Confirms with a count
+  // + preview. Queues all deletes first (local + cloud) and runs ONE
+  // sync at the end — same pattern as handleCleanupAliases. Exits
+  // select mode on success.
+  const handleBulkDelete = async () => {
+    if (selectedIds.size === 0) return;
+    const all = getSongs();
+    const targets = all.filter((s) => selectedIds.has(s.id));
+    if (targets.length === 0) {
+      exitSelectMode();
+      return;
+    }
+    const preview = targets.slice(0, 8).map((s) => `• "${s.title}"`).join("\n");
+    const more = targets.length > 8 ? `\n…and ${targets.length - 8} more` : "";
+    const ok = window.confirm(
+      `Delete ${targets.length} ${targets.length === 1 ? "song" : "songs"}?\n\n${preview}${more}`,
+    );
+    if (!ok) return;
+    for (const t of targets) {
+      deleteSong(t.id);
+      if (CLOUD_ENABLED) {
+        try { await cloudDeleteSong(t.id); } catch { /* best-effort */ }
+      }
+    }
+    refreshLocal();
+    exitSelectMode();
+    if (CLOUD_ENABLED) {
+      await runSync();
+    }
+  };
+
+  // Bulk move-to-folder. Called from the centered folder picker once
+  // the user picks a target folder (or creates a new one). All selected
+  // ids land in that folder; one sync at the end.
+  const handleBulkMoveToFolder = async (folder: string | null) => {
+    if (selectedIds.size === 0) return;
+    const ids = Array.from(selectedIds);
+    for (const id of ids) {
+      setSongFolder(id, folder && folder.trim() ? folder.trim() : null);
+    }
+    refreshLocal();
+    setBulkFolderOpen(false);
+    exitSelectMode();
+    if (CLOUD_ENABLED) {
+      // Push each updated entry so the new folder propagates. Re-read
+      // post-update so cloudVersion bumps land on the latest snapshot.
+      const updated = getSongs().filter((s) => ids.includes(s.id));
+      for (const entry of updated) {
+        try {
+          const dto = await cloudPutSong({
+            id: entry.id,
+            title: entry.title,
+            score: entry.score,
+            savedAt: entry.savedAt,
+            folder: entry.folder ?? null,
+            ...(entry.cloudVersion !== undefined && { expectedVersion: entry.cloudVersion }),
+          });
+          updateSong(entry.id, { cloudVersion: dto.version });
+        } catch { /* best-effort */ }
+      }
+      await runSync();
+    }
+  };
+
   const handleDelete = async (id: string) => {
     logEvent({ event: "mysongs_delete" });
     deleteSong(id);
@@ -527,7 +628,7 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-lg flex flex-col max-h-[80vh]"
+        className="bg-white rounded-xl shadow-2xl w-[800px] max-w-[92vw] flex flex-col max-h-[80vh]"
         onClick={e => e.stopPropagation()}
       >
         <div className="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
@@ -549,14 +650,17 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
         {/* Songs / Sets tab switcher (#73). Sets is a thin slice today —
          * per-device only, no cloud sync until #74 lands. The Songs tab
          * is the existing My Songs view; Sets renders SetsPanel. */}
-        <div className="px-5 pt-2 bg-white border-b border-gray-200 flex gap-1">
+        <div className="px-5 pt-2 bg-white border-b border-gray-200 flex items-end gap-1">
           {(["songs", "sets"] as const).map((t) => {
             const active = activeTab === t;
             return (
               <button
                 key={t}
                 type="button"
-                onClick={() => setActiveTab(t)}
+                onClick={() => {
+                  setActiveTab(t);
+                  if (t !== "songs") exitSelectMode();
+                }}
                 className={`px-3 py-1.5 text-xs font-medium rounded-t-lg transition-colors ${
                   active
                     ? "bg-blue-50 text-blue-700 border border-blue-200 border-b-transparent"
@@ -567,6 +671,23 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
               </button>
             );
           })}
+          {/* Select-mode toggle, Songs tab only. Per docs/ui-guidelines.md
+              §"Multi-select" — ghost button in the header that flips to
+              Cancel when active. */}
+          {activeTab === "songs" && songs.length > 0 && (
+            <button
+              type="button"
+              onClick={() => (selectMode ? exitSelectMode() : setSelectMode(true))}
+              className={`ml-auto mb-1 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                selectMode
+                  ? "text-gray-700 hover:bg-gray-100 active:bg-gray-200"
+                  : "text-gray-500 hover:text-gray-700 hover:bg-gray-50"
+              }`}
+              title={selectMode ? "Exit select mode (Esc)" : "Select multiple songs for bulk actions"}
+            >
+              {selectMode ? "Cancel" : "Select"}
+            </button>
+          )}
         </div>
 
         {activeTab === "sets" ? (
@@ -703,10 +824,33 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
                   )}
                   {!collapsed && (
                   <ul className="divide-y divide-gray-100">
-                    {group.entries.map(entry => (
-                      <li key={entry.id} className="flex items-center px-5 py-3 hover:bg-gray-50 gap-3 relative">
+                    {group.entries.map(entry => {
+                      const isSelected = selectedIds.has(entry.id);
+                      const rowClick = selectMode ? () => toggleSelected(entry.id) : undefined;
+                      return (
+                      <li
+                        key={entry.id}
+                        className={`flex items-center px-5 py-3 hover:bg-gray-50 gap-3 relative ${
+                          selectMode && isSelected ? "bg-blue-50/40" : ""
+                        } ${selectMode ? "cursor-pointer" : ""}`}
+                        onClick={rowClick}
+                      >
+                        {/* Leading checkbox in select mode. Clicking the
+                            checkbox or anywhere else on the row toggles
+                            selection. The Load/kebab buttons and rename
+                            affordance hide so the row is purely
+                            selection-focused. */}
+                        {selectMode && (
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => toggleSelected(entry.id)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="w-4 h-4 text-blue-600 shrink-0"
+                          />
+                        )}
                         <div className="flex-1 min-w-0">
-                          {renamingId === entry.id ? (
+                          {!selectMode && renamingId === entry.id ? (
                             <input
                               type="text"
                               autoFocus
@@ -719,6 +863,28 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
                               onBlur={() => commitRename(entry)}
                               className="w-full px-2 py-1 text-sm border border-blue-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                             />
+                          ) : selectMode ? (
+                            <div className="text-sm font-medium text-gray-900 truncate inline-flex items-center gap-2">
+                              <span className="truncate">{entry.title}</span>
+                              {(() => {
+                                const t = scoreTypeOf(entry.score);
+                                if (t === "chord-chart") {
+                                  return (
+                                    <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-pink-100 text-pink-700 shrink-0">
+                                      Chart
+                                    </span>
+                                  );
+                                }
+                                if (t === "notation") {
+                                  return (
+                                    <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 shrink-0">
+                                      Score
+                                    </span>
+                                  );
+                                }
+                                return null;
+                              })()}
+                            </div>
                           ) : (
                             <button
                               type="button"
@@ -751,26 +917,31 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
                             {new Date(entry.savedAt).toLocaleString()}
                           </div>
                         </div>
-                        <button
-                          onClick={() => handleLoad(entry)}
-                          className="px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-50 active:bg-blue-100 border border-blue-200 rounded-lg transition-colors shrink-0"
-                        >
-                          Load
-                        </button>
-                        <button
-                          onClick={(e) => openKebab(entry, e)}
-                          className="p-1.5 text-gray-400 hover:text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors shrink-0"
-                          title="More"
-                          aria-label="More actions"
-                        >
-                          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                            <circle cx="5" cy="12" r="2" />
-                            <circle cx="12" cy="12" r="2" />
-                            <circle cx="19" cy="12" r="2" />
-                          </svg>
-                        </button>
+                        {!selectMode && (
+                          <>
+                            <button
+                              onClick={() => handleLoad(entry)}
+                              className="px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-50 active:bg-blue-100 border border-blue-200 rounded-lg transition-colors shrink-0"
+                            >
+                              Load
+                            </button>
+                            <button
+                              onClick={(e) => openKebab(entry, e)}
+                              className="p-1.5 text-gray-400 hover:text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors shrink-0"
+                              title="More"
+                              aria-label="More actions"
+                            >
+                              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                                <circle cx="5" cy="12" r="2" />
+                                <circle cx="12" cy="12" r="2" />
+                                <circle cx="19" cy="12" r="2" />
+                              </svg>
+                            </button>
+                          </>
+                        )}
                       </li>
-                    ))}
+                      );
+                    })}
                   </ul>
                   )}
                 </div>
@@ -865,6 +1036,38 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           </div>
         )}
 
+        {/* Bulk-action bar — appears in select mode whenever ≥1 song is
+            picked. Per docs/ui-guidelines.md §"Multi-select" — "N selected"
+            on the left, action buttons on the right (primary blue = the
+            common action; ghost for the rest; red for Delete). */}
+        {selectMode && selectedIds.size > 0 && (
+          <div className="px-5 py-3 border-t border-gray-200 bg-blue-50/40 flex items-center justify-between gap-2">
+            <span className="text-sm font-medium text-gray-700">
+              {selectedIds.size} selected
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setAddToSetOpen(true)}
+                className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg"
+              >
+                Add to set…
+              </button>
+              <button
+                onClick={() => setBulkFolderOpen(true)}
+                className="px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg"
+              >
+                Move to folder…
+              </button>
+              <button
+                onClick={handleBulkDelete}
+                className="px-4 py-1.5 text-sm text-red-600 hover:bg-red-50 active:bg-red-100 rounded-lg"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        )}
+
         <div className="px-5 py-4 border-t border-gray-200 flex justify-between items-center gap-2">
           <div className="flex items-center gap-1">
             <button
@@ -890,6 +1093,30 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           </button>
         </div>
       </div>
+
+      {/* Stacked sheet for "Add to set…" — z-[110] sits above this modal's
+          z-50, matching the kebab-menu z-stack pattern. */}
+      {addToSetOpen && (
+        <AddToSetSheet
+          mode="pickSet"
+          songIds={Array.from(selectedIds)}
+          onClose={() => {
+            setAddToSetOpen(false);
+            exitSelectMode();
+          }}
+        />
+      )}
+
+      {/* Centered bulk folder picker — one picker for the entire selection
+          (vs. the per-row picker reached via the kebab menu). */}
+      {bulkFolderOpen && (
+        <BulkFolderPicker
+          folderNames={folderNames}
+          count={selectedIds.size}
+          onCancel={() => setBulkFolderOpen(false)}
+          onPick={(folder) => handleBulkMoveToFolder(folder)}
+        />
+      )}
 
       {/* Kebab menu — fixed-positioned at the button anchor so it isn't
           clipped by the modal's overflow-y-auto song list (the bug that
@@ -989,4 +1216,136 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
 
 function truncate(s: string, max: number): string {
   return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+/**
+ * Centered folder picker for the bulk Move action. Lists existing
+ * folder names + "(Unfiled)" + "+ New folder" inline create. Pops over
+ * the entire selection at once (vs. the kebab's per-row anchored
+ * picker). Renders at z-[110] above MySongsModal's z-50.
+ */
+function BulkFolderPicker({
+  folderNames,
+  count,
+  onCancel,
+  onPick,
+}: {
+  folderNames: string[];
+  count: number;
+  onCancel: () => void;
+  onPick: (folder: string | null) => void;
+}) {
+  const [newFolder, setNewFolder] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-start justify-center pt-[12vh] bg-black/40"
+      onClick={(e) => {
+        e.stopPropagation();
+        onCancel();
+      }}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl border border-gray-200 w-[440px] max-w-[92vw] max-h-[70vh] flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-gray-900">
+              Move {count} {count === 1 ? "song" : "songs"} to a folder
+            </h2>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Pick an existing folder or name a new one.
+            </p>
+          </div>
+          <button
+            onClick={onCancel}
+            className="text-gray-500 hover:text-gray-700 text-lg px-2 shrink-0"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <ul className="divide-y divide-gray-100">
+            <li>
+              <button
+                type="button"
+                onClick={() => onPick(null)}
+                className="w-full text-left px-5 py-3 text-sm hover:bg-gray-50 active:bg-gray-100 text-gray-900"
+              >
+                (Unfiled)
+              </button>
+            </li>
+            {folderNames.map((f) => (
+              <li key={f}>
+                <button
+                  type="button"
+                  onClick={() => onPick(f)}
+                  className="w-full text-left px-5 py-3 text-sm hover:bg-gray-50 active:bg-gray-100 text-gray-900"
+                >
+                  {f}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="border-t border-gray-100 px-5 py-3">
+            {creating ? (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  autoFocus
+                  value={newFolder}
+                  onChange={(e) => setNewFolder(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const t = newFolder.trim();
+                      if (t) onPick(t);
+                    }
+                    if (e.key === "Escape") {
+                      setCreating(false);
+                      setNewFolder("");
+                    }
+                  }}
+                  placeholder="Folder name"
+                  className="flex-1 text-sm text-gray-900 placeholder-gray-400 border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    const t = newFolder.trim();
+                    if (t) onPick(t);
+                  }}
+                  disabled={!newFolder.trim()}
+                  className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:bg-gray-300 rounded-lg"
+                >
+                  Move
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setCreating(true)}
+                className="w-full text-left text-sm text-blue-700 hover:underline"
+              >
+                + New folder…
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
-  addSongToSet,
   createSet,
   deleteSet,
   getSets,
@@ -12,7 +11,8 @@ import {
   SetsUpdatedEvent,
   type SongSet,
 } from "@/lib/song-sets";
-import { getSongs, isAliasTitle, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
+import { getSongs, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
+import AddToSetSheet from "@/components/AddToSetSheet";
 import { useScoreStore } from "@/store/score-store";
 import { saveSnapshot } from "@/lib/autosave";
 import { scoreTypeOf } from "@/lib/analytics";
@@ -30,6 +30,14 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
   const [newName, setNewName] = useState("");
   const [renameOpen, setRenameOpen] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  // Stacked sheet for "+ Add songs…" entry path. AddToSetSheet in
+  // pickSongs mode lets the user multi-select songs to add at once,
+  // with a search field — replaces the per-row "Add" buttons that
+  // made the original detail view feel cramped.
+  const [addOpen, setAddOpen] = useState(false);
+  // Live search filter for the songs-in-set list. Critical once a set
+  // gets above ~10 songs.
+  const [setQuery, setSetQuery] = useState("");
   const setScore = useScoreStore((s) => s.setScore);
   const setUIState = useScoreStore((s) => s.setUIState);
   const score = useScoreStore((s) => s.score);
@@ -209,15 +217,16 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
 
   // ── Detail view: songs inside the open set ──────────────────────────
 
-  const allSongs = Array.from(songsById.values());
-  const inSet = new Set(openSet.songIds);
-  // Hide alias entries (titles like "Foo (snapped)" / "(recovered 9:06 PM)"
-  // / "(latest 10:37 PM)") from the candidate list — they're stale
-  // autosave/recovery artifacts the user almost never wants to add to a
-  // set. They remain in My Songs and can be removed via "Clean up aliases".
-  const candidatesAll = allSongs.filter((s) => !inSet.has(s.id));
-  const candidates = candidatesAll.filter((s) => !isAliasTitle(s.title));
-  const hiddenAliasCount = candidatesAll.length - candidates.length;
+  // Filter songs-in-set by search query (case-insensitive, title only).
+  // Empty query passes everything through. Reordering controls only show
+  // when no query is active — moving rows in a filtered view would be
+  // confusing (you'd move "song 2 of 3 visible" to a position that means
+  // nothing in the unfiltered list).
+  const setQueryLc = setQuery.trim().toLowerCase();
+  const filterMatch = (entry: SongBankEntry | undefined) => {
+    if (!setQueryLc) return true;
+    return !!entry && entry.title.toLowerCase().includes(setQueryLc);
+  };
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -235,18 +244,42 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
         <span className="text-xs text-gray-400">
           {openSet.songIds.length} song{openSet.songIds.length === 1 ? "" : "s"}
         </span>
+        <button
+          type="button"
+          onClick={() => setAddOpen(true)}
+          className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg"
+          title="Add multiple songs to this set"
+        >
+          + Add songs…
+        </button>
       </div>
+
+      {/* Search field — only useful once the set has >1 song. Hides for
+          empty sets to avoid clutter. */}
+      {openSet.songIds.length > 1 && (
+        <div className="px-5 py-2 border-b border-gray-100">
+          <input
+            type="text"
+            value={setQuery}
+            onChange={(e) => setSetQuery(e.target.value)}
+            placeholder="Search this set…"
+            className="w-full text-sm text-gray-900 placeholder-gray-400 border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      )}
+
       <div className="flex-1 overflow-y-auto">
         {/* Songs in the set, in order, with up/down/remove controls. */}
         {openSet.songIds.length === 0 ? (
           <div className="px-5 py-6 text-sm text-gray-500 text-center">
-            Empty set. Pick songs to add from the list below.
+            Empty set. Tap <strong>+ Add songs…</strong> above to pick songs to add.
           </div>
         ) : (
           <ul className="divide-y divide-gray-100">
             {openSet.songIds.map((songId, idx) => {
               const entry = songsById.get(songId);
               if (!entry) {
+                if (setQueryLc) return null;
                 return (
                   <li key={songId} className="px-5 py-2 flex items-center text-amber-700 bg-amber-50">
                     <span className="text-xs italic flex-1">
@@ -262,6 +295,7 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
                   </li>
                 );
               }
+              if (!filterMatch(entry)) return null;
               return (
                 <li key={songId} className="flex items-center px-5 py-2 hover:bg-gray-50 gap-2">
                   <span className="text-xs text-gray-400 w-6">{idx + 1}.</span>
@@ -273,24 +307,28 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
                     {entry.title}
                     <SongTypeBadge entry={entry} />
                   </button>
-                  <button
-                    type="button"
-                    onClick={() => reorderSong(openSet.id, idx, idx - 1)}
-                    disabled={idx === 0}
-                    className="px-1.5 py-1 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-30"
-                    aria-label="Move up"
-                  >
-                    ↑
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => reorderSong(openSet.id, idx, idx + 1)}
-                    disabled={idx === openSet.songIds.length - 1}
-                    className="px-1.5 py-1 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-30"
-                    aria-label="Move down"
-                  >
-                    ↓
-                  </button>
+                  {!setQueryLc && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => reorderSong(openSet.id, idx, idx - 1)}
+                        disabled={idx === 0}
+                        className="px-1.5 py-1 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-30"
+                        aria-label="Move up"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => reorderSong(openSet.id, idx, idx + 1)}
+                        disabled={idx === openSet.songIds.length - 1}
+                        className="px-1.5 py-1 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-30"
+                        aria-label="Move down"
+                      >
+                        ↓
+                      </button>
+                    </>
+                  )}
                   <button
                     type="button"
                     onClick={() => removeSongFromSet(openSet.id, songId)}
@@ -303,39 +341,15 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
             })}
           </ul>
         )}
-
-        {/* Add-songs picker — shows everything not already in the set, with
-            alias artifacts hidden so the list stays scannable. */}
-        {candidates.length > 0 && (
-          <>
-            <div className="px-5 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 bg-gray-50 border-y border-gray-100 mt-2 flex items-center justify-between">
-              <span>Add to this set</span>
-              {hiddenAliasCount > 0 && (
-                <span className="text-[10px] normal-case tracking-normal text-gray-400">
-                  {hiddenAliasCount} alias{hiddenAliasCount === 1 ? "" : "es"} hidden — clean up in My Songs
-                </span>
-              )}
-            </div>
-            <ul className="divide-y divide-gray-100">
-              {candidates.map((entry) => (
-                <li key={entry.id} className="flex items-center px-5 py-2 hover:bg-gray-50 gap-2">
-                  <div className="flex-1 min-w-0 text-sm text-gray-700 truncate">
-                    {entry.title}
-                    <SongTypeBadge entry={entry} />
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => addSongToSet(openSet.id, entry.id)}
-                    className="px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 rounded"
-                  >
-                    Add
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
       </div>
+
+      {addOpen && (
+        <AddToSetSheet
+          mode="pickSongs"
+          targetSetId={openSet.id}
+          onClose={() => setAddOpen(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes the loop on the rough first-version Sets UX. Two things in one slice — the codified guidelines so the *next* component starts better, and the redesign of My Songs / Sets through that doc.

### Phase 1 — `docs/ui-guidelines.md` + `AGENTS.md`
Short, practical, ~80 lines. Captures the patterns already in the codebase (4 button styles, modal sizing tokens, list-row density, empty-state tone, multi-select pattern) plus a 7-item pre-flight checklist to run before designing any new component. `AGENTS.md` now points at it so future sessions can't miss it.

### Phase 2 — My Songs multi-select + widen
- Modal widens to **800px** (`max-w-[92vw]`) — the cramped 512px was the actual reason Sets detail felt small.
- New `[Select]` toggle next to the Songs / Sets tabs. In select mode: rows show leading checkboxes, primary tap toggles selection, Load/kebab hide. Esc exits.
- **Bulk-action bar** when ≥1 selected: `N selected · Add to set… / Move to folder… / Delete`.
- Bulk Delete runs local + cloud deletes and ONE final sync (not N).
- New `BulkFolderPicker` — one centred picker for the whole selection with inline "+ New folder…".

### Phase 3 — Sets detail redesign
- Inherits the wider modal.
- Replaces the inline candidate list with a primary `[+ Add songs…]` button that opens the same `AddToSetSheet` (in `pickSongs` mode).
- Live "Search this set…" filter once the set has >1 song. Reorder controls hide while filtered.

### Shared component — `AddToSetSheet`
One stacked sheet, two modes driven by props:
- `pickSet` (from My Songs bulk bar) — radio list of existing sets + inline `+ New set` with Enter-to-create-and-add.
- `pickSongs` (from Sets detail) — search + checkbox list of candidate songs (alias titles filtered out), pre-fills the target set.

Both call `addSongToSet` per id (dedup handled in `src/lib/song-sets.ts`). z-[110], small-modal styling matching `AutosaveRecoveryDialog.tsx`, Esc + backdrop-click dismiss with pointer-stopPropagation so it doesn't accidentally close `MySongsModal`.

## Test plan

- [ ] My Songs opens at the wider 800px size; folders / sync settings panes still render correctly.
- [ ] Tap `[Select]` → rows show checkboxes; Load/kebab hidden.
- [ ] Pick 3 songs → bulk bar shows "3 selected · Add to set… / Move… / Delete".
- [ ] `Add to set…` → pick an existing set → confirm 3 land in the set under Sets tab.
- [ ] `Add to set…` → "+ New set: Friday gig" → Enter → set created, songs added.
- [ ] `Move to folder…` → pick existing folder, then "+ New folder: Tonight" → both apply to all selected.
- [ ] `Delete` with 2 selected → preview confirm → both gone (local + cloud).
- [ ] Esc exits select mode without other side effects.
- [ ] Open a set → tap `[+ Add songs…]` → multi-select 2 songs → confirm they appear in the set.
- [ ] Type into the "Search this set…" filter — list filters live; reorder ↑/↓ hide while filtered.
- [ ] iPad portrait (≈810×1080 viewport) — all controls reachable.
- [ ] `npx tsc --noEmit` clean. `npx vitest run` (53 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)