### PR TITLE
Unified Unicode-aware title canonicalization

### DIFF
--- a/src/components/AutosaveRecoveryDialog.tsx
+++ b/src/components/AutosaveRecoveryDialog.tsx
@@ -9,7 +9,7 @@ import {
   cloudListVersions,
 } from "@/lib/song-cloud";
 import type { VersionEntry } from "@/lib/song-cloud-types";
-import { getSongs, saveSong } from "@/lib/song-bank";
+import { canonicalSongTitle, getSongs, saveSong } from "@/lib/song-bank";
 
 interface AutosaveRecoveryDialogProps {
   onClose: () => void;
@@ -123,13 +123,11 @@ export default function AutosaveRecoveryDialog({ onClose, filterTitle, cloudSong
     }
   };
 
-  // Aggressively normalize titles so 'San Francisco' / ' san francisco '
-  // / 'san  francisco' all collapse to the same key. Earlier version
-  // only lower-cased — left near-duplicates because the whitespace
-  // differed slightly between the snapshot and an existing My Songs
-  // entry, so the existence check missed.
-  const normalizeTitle = (s: string) =>
-    (s || "").trim().toLowerCase().replace(/\s+/g, " ");
+  // Canonical title equality — shared with My Songs dedup so iPad-
+  // entered smart-quote / NFD-accent variants of the same song get
+  // matched. See canonicalSongTitle in src/lib/song-bank.ts for the
+  // exact normalization steps.
+  const normalizeTitle = canonicalSongTitle;
 
   // Snapshots grouped by normalized title — used by both the rendering
   // pass and the "Recover all" button. Each title's newest snapshot is

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -7,6 +7,7 @@ import AutosaveRecoveryDialog from "@/components/AutosaveRecoveryDialog";
 import SetsPanel from "@/components/SetsPanel";
 import AddToSetSheet from "@/components/AddToSetSheet";
 import {
+  canonicalSongTitle,
   getSongs,
   isAliasTitle,
   saveSong,
@@ -421,7 +422,9 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     const list = getSongs();
     const byTitle = new Map<string, SongBankEntry[]>();
     for (const s of list) {
-      const k = s.title.trim().toLowerCase();
+      // Canonical key folds smart quotes / NFC-NFD / case / whitespace so
+      // iPad-typed and Mac-typed variants of the same song collide.
+      const k = canonicalSongTitle(s.title);
       if (!byTitle.has(k)) byTitle.set(k, []);
       byTitle.get(k)!.push(s);
     }

--- a/src/lib/__tests__/canonical-title.test.ts
+++ b/src/lib/__tests__/canonical-title.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { canonicalSongTitle } from "../song-bank";
+
+describe("canonicalSongTitle", () => {
+  it("collapses case + whitespace + trim", () => {
+    expect(canonicalSongTitle("  Friday GIG  ")).toBe("friday gig");
+  });
+
+  it("collapses internal double-spaces and tabs to single space", () => {
+    expect(canonicalSongTitle("Friday   gig\t!")).toBe("friday gig !");
+  });
+
+  it("collapses non-breaking space (U+00A0) like a regular space", () => {
+    expect(canonicalSongTitle("Friday gig")).toBe("friday gig");
+  });
+
+  it("folds NFD to NFC — precomposed and decomposed accented chars match", () => {
+    const nfc = "Café";              // single precomposed é
+    const nfd = "Café";        // e + combining acute
+    expect(canonicalSongTitle(nfc)).toBe(canonicalSongTitle(nfd));
+    expect(canonicalSongTitle(nfc)).toBe("café");
+  });
+
+  it("folds smart single quotes to straight", () => {
+    expect(canonicalSongTitle("Friday’s gig")).toBe("friday's gig");
+    expect(canonicalSongTitle("‘So it goes’")).toBe("'so it goes'");
+  });
+
+  it("folds smart double quotes to straight", () => {
+    expect(canonicalSongTitle("“Hey”")).toBe('"hey"');
+  });
+
+  it("returns empty string for null/undefined-ish input", () => {
+    // Defensive: any caller passing through an undefined title shouldn't blow up.
+    expect(canonicalSongTitle("")).toBe("");
+    expect(canonicalSongTitle(undefined as unknown as string)).toBe("");
+  });
+
+  it("equates iPad-typed and Mac-typed versions of the same title", () => {
+    // The actual scenario this helper exists for: same song saved on
+    // both devices, one with auto-corrected smart quote + NFD accent.
+    const iPad = "Café’s Anthem";          // NFC + smart apostrophe
+    const mac = "Café's Anthem";              // NFD + straight apostrophe
+    expect(canonicalSongTitle(iPad)).toBe(canonicalSongTitle(mac));
+  });
+});

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -47,6 +47,32 @@ export function isAliasTitle(title: string): boolean {
   return aliasCanonicalTitle(title) !== null;
 }
 
+/**
+ * Canonical form of a song title for equality comparison. Folds the
+ * surprising-divergence sources we've actually hit in user data:
+ *
+ *   - NFC vs NFD: macOS dead-key input ("Cafe" + combining-acute) hashes
+ *     differently from precomposed "Café" without `.normalize("NFC")`.
+ *   - Smart quotes: iOS auto-corrects ' → ’ and " → ”. "Friday's gig"
+ *     from iPad would otherwise miss "Friday's gig" typed elsewhere.
+ *   - Whitespace: nbsp (U+00A0), tabs, double spaces — all collapse to
+ *     a single regular space. `\s` in modern JS already matches Unicode
+ *     whitespace including nbsp, so /\s+/g is enough.
+ *   - Case + leading/trailing whitespace.
+ *
+ * Use for any dedup or membership check that should treat
+ * visually-identical titles as the same song.
+ */
+export function canonicalSongTitle(s: string): string {
+  return (s ?? "")
+    .normalize("NFC")
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
 export function getSongs(): SongBankEntry[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary

Two divergence sources slipped past the dedup/recover flows:

- **NFC vs NFD** — macOS dead-key input (e + combining-acute) hashes differently from precomposed "é", but they render identically.
- **Smart quotes** — iOS auto-corrects `'` → `'`, so "Friday's gig" typed on iPad missed "Friday's gig" elsewhere.

Adds a single `canonicalSongTitle` helper in `src/lib/song-bank.ts` (NFC + smart→straight + trim + lowercase + collapse whitespace). Replaces the inline normalizers in `AutosaveRecoveryDialog` (recover-all grouping) and `MySongsModal` (cleanup-duplicates) so dedup behaves consistently across paths.

## Test plan

- [x] `npx vitest run` — 61 passing (8 new for the canonicalizer, including the iPad↔Mac scenario)
- [x] `npx tsc --noEmit` clean
- [ ] Open My Songs → "Clean up duplicates" → verifies near-identical titles now collapse together

Auto-merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)