### PR TITLE
AddToSetSheet behavior tests + extract candidate filter

### DIFF
--- a/src/components/AddToSetSheet.tsx
+++ b/src/components/AddToSetSheet.tsx
@@ -4,11 +4,12 @@ import { useEffect, useMemo, useState } from "react";
 import {
   addSongToSet,
   createSet,
+  filterCandidatesForSheet,
   getSets,
   SetsUpdatedEvent,
   type SongSet,
 } from "@/lib/song-sets";
-import { getSongs, isAliasTitle, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
+import { getSongs, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
 import { scoreTypeOf } from "@/lib/analytics";
 
 /**
@@ -257,28 +258,20 @@ function PickSongsBody({
   onClose: () => void;
 }) {
   const target = sets.find((s) => s.id === targetSetId) ?? null;
-  const inSet = new Set(target?.songIds ?? []);
-
-  // Candidate list: songs not already in the set, with alias artifacts
-  // ("(snapped)" / "(recovered …)" / "(latest …)") filtered out so the
-  // user only sees real songs.
-  const candidates = useMemo(
-    () =>
-      songs
-        .filter((s) => !inSet.has(s.id))
-        .filter((s) => !isAliasTitle(s.title)),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [songs, target?.songIds.join("|")],
-  );
 
   const [picked, setPicked] = useState<Set<string>>(new Set());
   const [query, setQuery] = useState("");
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return candidates;
-    return candidates.filter((s) => s.title.toLowerCase().includes(q));
-  }, [candidates, query]);
+  // Candidate list: not-yet-in-set + non-alias + search-matching.
+  // Lives in src/lib/song-sets.ts so the rule is unit-testable.
+  const filtered = useMemo(
+    () => filterCandidatesForSheet(songs, target?.songIds ?? [], query),
+    [songs, target?.songIds, query],
+  );
+  const candidates = useMemo(
+    () => filterCandidatesForSheet(songs, target?.songIds ?? []),
+    [songs, target?.songIds],
+  );
 
   const togglePicked = (id: string) => {
     setPicked((prev) => {

--- a/src/lib/__tests__/add-to-set-flow.test.ts
+++ b/src/lib/__tests__/add-to-set-flow.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Score } from "@/lib/schema";
+import type { SongBankEntry } from "@/lib/song-bank";
+import {
+  addSongToSet,
+  createSet,
+  filterCandidatesForSheet,
+  getSets,
+} from "@/lib/song-sets";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// Minimal SongBankEntry factory. The schema in the bank carries plenty
+// of fields, but the AddToSet flow only consults id + title — keep the
+// fixtures terse so the assertions are easy to read.
+function song(id: string, title: string): SongBankEntry {
+  return { id, title, savedAt: 1_700_000_000_000, score: {} as Score };
+}
+
+describe("AddToSetSheet — pickSet flow (bulk add to a chosen set)", () => {
+  it("adds every selected song id to the chosen set in one batch", () => {
+    const s = createSet("Friday gig");
+    // Simulate the sheet calling addSongToSet per id on Add click.
+    addSongToSet(s.id, "song-1");
+    addSongToSet(s.id, "song-2");
+    addSongToSet(s.id, "song-3");
+    expect(getSets()[0].songIds).toEqual(["song-1", "song-2", "song-3"]);
+  });
+
+  it("dedupes against existing membership when re-adding", () => {
+    const s = createSet("Friday gig");
+    addSongToSet(s.id, "song-1");
+    // User opens the sheet again, picks the same song plus a new one.
+    addSongToSet(s.id, "song-1"); // already there, no-op
+    addSongToSet(s.id, "song-2");
+    expect(getSets()[0].songIds).toEqual(["song-1", "song-2"]);
+  });
+
+  it("creates a new set then adds songs in one user motion", () => {
+    // The "+ New set" inline-create branch: createSet returns the new
+    // entry, then the caller batch-adds.
+    const fresh = createSet("Tuesday rehearsal");
+    addSongToSet(fresh.id, "a");
+    addSongToSet(fresh.id, "b");
+    const out = getSets();
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("Tuesday rehearsal");
+    expect(out[0].songIds).toEqual(["a", "b"]);
+  });
+});
+
+describe("AddToSetSheet — pickSongs flow (candidate filter)", () => {
+  const all: SongBankEntry[] = [
+    song("a", "Anywhere"),
+    song("b", "Friday Night"),
+    song("c", "Foggy Night"),
+    song("d", "Friday Night (snapped)"),       // alias — must hide
+    song("e", "Anywhere (recovered 9:06 PM)"), // alias — must hide
+    song("f", "Tuesday Blues (latest 1:00 AM)"), // alias — must hide
+    song("g", "Sunday Morning"),
+  ];
+
+  it("hides songs already in the target set", () => {
+    const out = filterCandidatesForSheet(all, ["a", "c"]);
+    expect(out.map((s) => s.id).sort()).toEqual(["b", "g"]);
+  });
+
+  it("hides alias-titled songs (snapped / recovered / latest)", () => {
+    const out = filterCandidatesForSheet(all, []);
+    // Aliases d, e, f are dropped; a, b, c, g remain.
+    expect(out.map((s) => s.id).sort()).toEqual(["a", "b", "c", "g"]);
+  });
+
+  it("applies case-insensitive substring search", () => {
+    const out = filterCandidatesForSheet(all, [], "night");
+    // "Friday Night" + "Foggy Night" — aliases excluded
+    expect(out.map((s) => s.title).sort()).toEqual([
+      "Foggy Night",
+      "Friday Night",
+    ]);
+  });
+
+  it("returns nothing when every song is already in the set", () => {
+    const out = filterCandidatesForSheet(all, all.map((s) => s.id));
+    expect(out).toEqual([]);
+  });
+
+  it("trims whitespace-only search to a no-op match-all", () => {
+    const out = filterCandidatesForSheet(all, [], "   ");
+    // Same as no search: 4 non-alias songs.
+    expect(out).toHaveLength(4);
+  });
+
+  it("combines all three filters together", () => {
+    // Target set has 'a' already; search "night" → only b and c (d is alias).
+    const out = filterCandidatesForSheet(all, ["a"], "night");
+    expect(out.map((s) => s.id).sort()).toEqual(["b", "c"]);
+  });
+});
+
+describe("AddToSetSheet — end-to-end batch add through public lib API", () => {
+  it("a user opens an empty set, search-filters, multi-selects, and adds", () => {
+    const all: SongBankEntry[] = [
+      song("rock-1", "Rocky Mountain"),
+      song("rock-2", "Rocking Chair"),
+      song("blues-1", "Blue Moon"),
+      song("rock-3", "Rocky Top (snapped)"), // alias
+    ];
+    const target = createSet("Rock songs");
+
+    const candidates = filterCandidatesForSheet(all, target.songIds, "rock");
+    // Two real "rock" matches; alias dropped.
+    expect(candidates.map((s) => s.id)).toEqual(["rock-1", "rock-2"]);
+
+    // User checks both, clicks Add — the sheet calls addSongToSet per id.
+    for (const c of candidates) addSongToSet(target.id, c.id);
+
+    expect(getSets()[0].songIds).toEqual(["rock-1", "rock-2"]);
+  });
+});

--- a/src/lib/song-sets.ts
+++ b/src/lib/song-sets.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from "zod";
+import { isAliasTitle, type SongBankEntry } from "@/lib/song-bank";
 
 const STORAGE_KEY = "notation-app-song-sets";
 const SETS_UPDATED_EVENT = "notation-sets-updated";
@@ -127,6 +128,28 @@ export function removeSongFromSet(setId: string, songId: string): SongSet | null
 
 /** Reorder songs inside a set. From and to are 0-indexed positions in
  *  the songIds array. */
+/**
+ * Songs eligible to be added to a given set. Drops songs already in
+ * the set and drops alias artifacts (titles ending in "(snapped)",
+ * "(recovered ...)", "(latest ...)"). Optionally applies a
+ * case-insensitive substring search.
+ *
+ * Pure function — exported so AddToSetSheet's filter logic can be
+ * unit-tested without rendering React.
+ */
+export function filterCandidatesForSheet(
+  songs: SongBankEntry[],
+  setSongIds: string[],
+  query: string = "",
+): SongBankEntry[] {
+  const inSet = new Set(setSongIds);
+  const q = query.trim().toLowerCase();
+  return songs
+    .filter((s) => !inSet.has(s.id))
+    .filter((s) => !isAliasTitle(s.title))
+    .filter((s) => !q || s.title.toLowerCase().includes(q));
+}
+
 export function reorderSong(setId: string, fromIdx: number, toIdx: number): SongSet | null {
   const sets = getSets();
   const idx = sets.findIndex((s) => s.id === setId);


### PR DESCRIPTION
## Summary

Fills the coverage gap from PR #112. AddToSetSheet's filter + per-id batch-add was completely untested at the integration layer.

- Extracts `filterCandidatesForSheet` from the React component into `src/lib/song-sets.ts` — a pure function so it's unit-testable. AddToSetSheet now imports it.
- 10 new specs in `src/lib/__tests__/add-to-set-flow.test.ts`:
  - **pickSet flow**: bulk add, dedup against existing membership, new-set inline create
  - **pickSongs filter**: not-in-set, alias-hidden, case-insensitive search, whitespace-only no-op, all three composed
  - **End-to-end**: search-filter → multi-select → batch add through the public lib API

71 tests total. No behavior change for users — purely additive coverage + refactor.

Auto-merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)