### PR TITLE
Extract songSetMembership into song-sets.ts

### DIFF
--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -6,7 +6,7 @@ import { saveSnapshot } from "@/lib/autosave";
 import AutosaveRecoveryDialog from "@/components/AutosaveRecoveryDialog";
 import SetsPanel from "@/components/SetsPanel";
 import AddToSetSheet from "@/components/AddToSetSheet";
-import { getSets, SetsUpdatedEvent, type SongSet } from "@/lib/song-sets";
+import { getSets, SetsUpdatedEvent, songSetMembership, type SongSet } from "@/lib/song-sets";
 import {
   canonicalSongTitle,
   getSongs,
@@ -144,19 +144,10 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     window.addEventListener(SetsUpdatedEvent, refresh);
     return () => window.removeEventListener(SetsUpdatedEvent, refresh);
   }, []);
-  // songId → list of set names this song appears in. Memoed against
-  // the sets list reference so the per-row badge render is O(1).
-  const setMembership = useMemo(() => {
-    const map = new Map<string, string[]>();
-    for (const s of sets) {
-      for (const id of s.songIds) {
-        const cur = map.get(id);
-        if (cur) cur.push(s.name);
-        else map.set(id, [s.name]);
-      }
-    }
-    return map;
-  }, [sets]);
+  // songId → list of SongSets the song appears in. Shared helper in
+  // src/lib/song-sets.ts so MySongsModal (this badge) and PerformView
+  // (switch-to-set chips) compute it the same way.
+  const setMembership = useMemo(() => songSetMembership(sets), [sets]);
 
   // All distinct folder names across the bank, sorted — used by the
   // folder picker so the user doesn't have to remember/retype names.
@@ -948,14 +939,15 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
                             {!selectMode && (() => {
                               const memberOf = setMembership.get(entry.id);
                               if (!memberOf || memberOf.length === 0) return null;
+                              const names = memberOf.map((s) => s.name);
                               const label =
-                                memberOf.length === 1
-                                  ? `In: ${memberOf[0]}`
-                                  : `In ${memberOf.length} sets · ${memberOf.slice(0, 2).join(", ")}${memberOf.length > 2 ? ", …" : ""}`;
+                                names.length === 1
+                                  ? `In: ${names[0]}`
+                                  : `In ${names.length} sets · ${names.slice(0, 2).join(", ")}${names.length > 2 ? ", …" : ""}`;
                               return (
                                 <span
                                   className="text-[10px] px-1.5 py-0.5 rounded bg-pink-50 text-pink-700 border border-pink-100"
-                                  title={memberOf.join(", ")}
+                                  title={names.join(", ")}
                                 >
                                   {label}
                                 </span>

--- a/src/lib/__tests__/song-set-membership.test.ts
+++ b/src/lib/__tests__/song-set-membership.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { songSetMembership, type SongSet } from "@/lib/song-sets";
+
+function set(id: string, name: string, songIds: string[]): SongSet {
+  return { id, name, songIds, createdAt: 0, updatedAt: 0 };
+}
+
+describe("songSetMembership", () => {
+  it("returns an empty map for an empty sets list", () => {
+    expect(songSetMembership([]).size).toBe(0);
+  });
+
+  it("maps each songId to the single set it belongs to", () => {
+    const a = set("set-a", "Friday gig", ["song-1", "song-2"]);
+    const b = set("set-b", "Tuesday rehearsal", ["song-3"]);
+    const out = songSetMembership([a, b]);
+    expect(out.get("song-1")?.map((s) => s.id)).toEqual(["set-a"]);
+    expect(out.get("song-2")?.map((s) => s.id)).toEqual(["set-a"]);
+    expect(out.get("song-3")?.map((s) => s.id)).toEqual(["set-b"]);
+  });
+
+  it("collects multiple sets when a song belongs to several", () => {
+    const a = set("set-a", "Friday gig", ["song-1"]);
+    const b = set("set-b", "Tuesday rehearsal", ["song-1"]);
+    const c = set("set-c", "Solo", ["song-1"]);
+    const out = songSetMembership([a, b, c]);
+    expect(out.get("song-1")?.map((s) => s.id)).toEqual(["set-a", "set-b", "set-c"]);
+  });
+
+  it("preserves the input set order across each song's list", () => {
+    // Different input order → different output order. Important so
+    // the UI sees stable chip/pill ordering matching the user's
+    // saved set order.
+    const a = set("set-a", "Friday gig", ["song-1"]);
+    const b = set("set-b", "Tuesday rehearsal", ["song-1"]);
+    const c = set("set-c", "Solo", ["song-1"]);
+    const out1 = songSetMembership([c, a, b]);
+    expect(out1.get("song-1")?.map((s) => s.id)).toEqual(["set-c", "set-a", "set-b"]);
+  });
+
+  it("omits songIds that no set references", () => {
+    const a = set("set-a", "Friday gig", ["song-1"]);
+    const out = songSetMembership([a]);
+    expect(out.has("song-1")).toBe(true);
+    expect(out.has("song-unknown")).toBe(false);
+  });
+
+  it("handles empty songIds inside a set without crashing", () => {
+    const a = set("set-a", "Empty set", []);
+    const b = set("set-b", "Has one", ["song-1"]);
+    const out = songSetMembership([a, b]);
+    expect(out.size).toBe(1);
+    expect(out.get("song-1")?.map((s) => s.id)).toEqual(["set-b"]);
+  });
+});

--- a/src/lib/song-sets.ts
+++ b/src/lib/song-sets.ts
@@ -129,6 +129,28 @@ export function removeSongFromSet(setId: string, songId: string): SongSet | null
 /** Reorder songs inside a set. From and to are 0-indexed positions in
  *  the songIds array. */
 /**
+ * Per-song set-membership index. Returns a Map keyed by songId
+ * pointing at the list of full SongSet objects the song is a member
+ * of. Pure function — caller decides whether it wants names (for the
+ * "In N sets" badge), set ids (for the Perform switch-to-set chip
+ * action), or full objects.
+ *
+ * Order within each songId's list follows the input `sets` order so
+ * the UI sees stable chip / pill ordering across renders.
+ */
+export function songSetMembership(sets: SongSet[]): Map<string, SongSet[]> {
+  const map = new Map<string, SongSet[]>();
+  for (const s of sets) {
+    for (const id of s.songIds) {
+      const cur = map.get(id);
+      if (cur) cur.push(s);
+      else map.set(id, [s]);
+    }
+  }
+  return map;
+}
+
+/**
  * Songs eligible to be added to a given set. Drops songs already in
  * the set and drops alias artifacts (titles ending in "(snapped)",
  * "(recovered ...)", "(latest ...)"). Optionally applies a


### PR DESCRIPTION
## Summary

The map "songId → SongSets it belongs to" was computed inline in MySongsModal for the "In N sets" badge. Today's slice 2 (PerformView switch-to-set chips) needs the same computation. Move it once, test once, reuse.

- New `songSetMembership(sets)` in `src/lib/song-sets.ts` — returns `Map<songId, SongSet[]>` preserving input order so consumer UIs see stable ordering.
- 6 unit tests in `src/lib/__tests__/song-set-membership.test.ts`: empty input, single-set, multi-set, order preservation, songId-not-in-any-set, empty-songIds.
- `MySongsModal.tsx` refactored to use it. Pure refactor — badge call site projects to `.name` as before.

77 tests total, type check clean, no behavior change. Auto-merge after CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)