### PR TITLE
Fix Rename / kebab menu closing the whole modal

### DIFF
--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -1336,6 +1336,14 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           <div
             className="fixed z-[120] w-48 bg-white rounded-lg shadow-2xl border border-gray-200 py-1 text-sm"
             style={{ top: menuAnchor.top, right: menuAnchor.right }}
+            // Stop clicks from bubbling to the outer modal-backdrop's
+            // onClose. The menu lives OUTSIDE the inner-modal
+            // stopPropagation wrapper so it can render past the
+            // overflow-y-auto on iPad — but that means menu-item clicks
+            // would otherwise close the whole modal before the action
+            // can take effect (e.g. Rename: state was set, then modal
+            // unmounted before the input could render).
+            onClick={(e) => e.stopPropagation()}
           >
             <button
               onClick={() => startRename(menuAnchor.entry)}
@@ -1373,6 +1381,10 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           <div
             className="fixed z-[120] w-56 bg-white rounded-lg shadow-2xl border border-gray-200 py-1 text-sm max-h-[60vh] overflow-y-auto"
             style={{ top: pickerAnchor.top, right: pickerAnchor.right }}
+            // Same fix as the kebab menu — popovers rendered outside
+            // the inner-modal wrapper need to stop click bubble or the
+            // outer modal-backdrop's onClose fires.
+            onClick={(e) => e.stopPropagation()}
           >
             <div className="px-3 py-1 text-[10px] uppercase tracking-wider text-gray-400">Move to…</div>
             <button


### PR DESCRIPTION
## Summary

Tapping kebab → Rename was closing the entire My Songs modal instead of starting the rename. State was set but the modal unmounted before the input could render.

**Cause:** the kebab menu and per-row folder picker are rendered as siblings of the inner-modal `stopPropagation` wrapper (deliberately — they need to escape the modal's `overflow-y-auto` so popovers don't get clipped on iPad). But that placement meant menu-item clicks bubbled past the inner-modal stop and reached the **outer** modal-backdrop's `onClick={onClose}`.

**Fix:** add `onClick={e => e.stopPropagation()}` on the kebab-menu and folder-picker container divs. The dedicated `z-[110]` backdrops still close the popovers cleanly when clicked elsewhere.

Pre-existing bug; surfaced now because rename is being used more after recent UI changes.

Auto-merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)