### PR TITLE
Sets + AddToSet quick wins: folder pill, canonical search, inline + Add

### DIFF
--- a/src/components/AddToSetSheet.tsx
+++ b/src/components/AddToSetSheet.tsx
@@ -352,26 +352,43 @@ function PickSongsBody({
               const t = scoreTypeOf(entry.score);
               return (
                 <li key={entry.id}>
-                  <label className="flex items-center gap-3 px-5 py-3 hover:bg-gray-50 cursor-pointer">
+                  <label className="flex items-start gap-3 px-5 py-3 hover:bg-gray-50 cursor-pointer">
                     <input
                       type="checkbox"
                       checked={picked.has(entry.id)}
                       onChange={() => togglePicked(entry.id)}
-                      className="w-4 h-4 text-blue-600"
+                      className="w-4 h-4 text-blue-600 mt-0.5 shrink-0"
                     />
-                    <span className="flex-1 min-w-0 text-sm text-gray-900 truncate">
-                      {entry.title}
-                      {t === "chord-chart" && (
-                        <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-pink-100 text-pink-700 ml-2">
-                          Chart
-                        </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm text-gray-900 truncate inline-flex items-center gap-2">
+                        <span className="truncate">{entry.title}</span>
+                        {t === "chord-chart" && (
+                          <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-pink-100 text-pink-700 shrink-0">
+                            Chart
+                          </span>
+                        )}
+                        {t === "notation" && (
+                          <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 shrink-0">
+                            Score
+                          </span>
+                        )}
+                      </div>
+                      {/* Folder pill — critical for disambiguating
+                          same-titled songs that live in different
+                          folders. Hidden when the song has no folder
+                          (avoids a generic "(Unfiled)" pill on most
+                          rows). */}
+                      {entry.folder && (
+                        <div className="mt-0.5">
+                          <span
+                            className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200"
+                            title={`Folder: ${entry.folder}`}
+                          >
+                            {entry.folder}
+                          </span>
+                        </div>
                       )}
-                      {t === "notation" && (
-                        <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 ml-2">
-                          Score
-                        </span>
-                      )}
-                    </span>
+                    </div>
                   </label>
                 </li>
               );

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -30,11 +30,12 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
   const [newName, setNewName] = useState("");
   const [renameOpen, setRenameOpen] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
-  // Stacked sheet for "+ Add songs…" entry path. AddToSetSheet in
-  // pickSongs mode lets the user multi-select songs to add at once,
-  // with a search field — replaces the per-row "Add" buttons that
-  // made the original detail view feel cramped.
-  const [addOpen, setAddOpen] = useState(false);
+  // Target set for the AddToSetSheet (pickSongs mode). Lets us trigger
+  // the sheet from either the list view (inline "+ Add songs" on each
+  // row) or the detail view (header button) — both write the same
+  // setId here, so the sheet pre-targets correctly without an extra
+  // boolean.
+  const [addToSetId, setAddToSetId] = useState<string | null>(null);
   // Live search filter for the songs-in-set list. Critical once a set
   // gets above ~10 songs.
   const [setQuery, setSetQuery] = useState("");
@@ -143,6 +144,19 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
                         )}
                       </div>
                     </button>
+                    {/* Inline "+ Add songs" — skips the open-the-set
+                        step. Pre-targets the AddToSetSheet at this set,
+                        so the sheet opens straight into pickSongs mode.
+                        Critical for "I just want to add a song without
+                        clicking into the set first." */}
+                    <button
+                      type="button"
+                      onClick={() => setAddToSetId(set.id)}
+                      className="px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 active:bg-blue-100 border border-blue-200 rounded"
+                      title={`Add songs to ${set.name}`}
+                    >
+                      + Add songs
+                    </button>
                     <button
                       type="button"
                       onClick={() => {
@@ -211,6 +225,16 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
             </div>
           )}
         </div>
+        {/* AddToSetSheet — also mounted from the list view so the
+            inline "+ Add songs" button on each row works without first
+            opening a set. */}
+        {addToSetId && (
+          <AddToSetSheet
+            mode="pickSongs"
+            targetSetId={addToSetId}
+            onClose={() => setAddToSetId(null)}
+          />
+        )}
       </div>
     );
   }
@@ -246,7 +270,7 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
         </span>
         <button
           type="button"
-          onClick={() => setAddOpen(true)}
+          onClick={() => setAddToSetId(openSet.id)}
           className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg"
           title="Add multiple songs to this set"
         >
@@ -343,11 +367,11 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
         )}
       </div>
 
-      {addOpen && (
+      {addToSetId && (
         <AddToSetSheet
           mode="pickSongs"
-          targetSetId={openSet.id}
-          onClose={() => setAddOpen(false)}
+          targetSetId={addToSetId}
+          onClose={() => setAddToSetId(null)}
         />
       )}
     </div>

--- a/src/lib/__tests__/add-to-set-flow.test.ts
+++ b/src/lib/__tests__/add-to-set-flow.test.ts
@@ -98,6 +98,26 @@ describe("AddToSetSheet — pickSongs flow (candidate filter)", () => {
     const out = filterCandidatesForSheet(all, ["a"], "night");
     expect(out.map((s) => s.id).sort()).toEqual(["b", "c"]);
   });
+
+  it("search is canonical-aware (smart quotes match straight)", () => {
+    const iPadList: SongBankEntry[] = [
+      song("p1", "Friday’s gig"),  // smart quote (iPad auto-correct)
+      song("p2", "Tuesday Blues"),
+    ];
+    // Mac-typed straight-quote query matches iPad smart-quote song
+    const out = filterCandidatesForSheet(iPadList, [], "friday's");
+    expect(out.map((s) => s.id)).toEqual(["p1"]);
+  });
+
+  it("search is canonical-aware (NFD accents match NFC)", () => {
+    const list: SongBankEntry[] = [
+      song("p1", "Café Anthem"),       // precomposed é (NFC)
+      song("p2", "Random other song"),
+    ];
+    // Decomposed query (e + combining acute) matches precomposed song
+    const out = filterCandidatesForSheet(list, [], "café");
+    expect(out.map((s) => s.id)).toEqual(["p1"]);
+  });
 });
 
 describe("AddToSetSheet — end-to-end batch add through public lib API", () => {

--- a/src/lib/song-sets.ts
+++ b/src/lib/song-sets.ts
@@ -9,7 +9,11 @@
  */
 
 import { z } from "zod";
-import { isAliasTitle, type SongBankEntry } from "@/lib/song-bank";
+import {
+  canonicalSongTitle,
+  isAliasTitle,
+  type SongBankEntry,
+} from "@/lib/song-bank";
 
 const STORAGE_KEY = "notation-app-song-sets";
 const SETS_UPDATED_EVENT = "notation-sets-updated";
@@ -165,11 +169,14 @@ export function filterCandidatesForSheet(
   query: string = "",
 ): SongBankEntry[] {
   const inSet = new Set(setSongIds);
-  const q = query.trim().toLowerCase();
+  // Canonical-match both sides so iPad smart-quote / NFC-NFD variants
+  // (per #113) match. "Friday's gig" typed on iPad collides with
+  // "Friday's gig" typed on Mac under canonicalSongTitle.
+  const qCanon = canonicalSongTitle(query);
   return songs
     .filter((s) => !inSet.has(s.id))
     .filter((s) => !isAliasTitle(s.title))
-    .filter((s) => !q || s.title.toLowerCase().includes(q));
+    .filter((s) => !qCanon || canonicalSongTitle(s.title).includes(qCanon));
 }
 
 export function reorderSong(setId: string, fromIdx: number, toIdx: number): SongSet | null {


### PR DESCRIPTION
## Summary

Three targeted fixes for the song-picker workflow:

1. **Folder pill in pickSongs.** Each candidate row in `AddToSetSheet` now shows its folder as a small grey pill below the title — disambiguates duplicate titles across folders ("which Anywhere should I add?").
2. **Canonical search.** `filterCandidatesForSheet` matches via `canonicalSongTitle` on both sides — iPad smart-quote / NFD variants collide with their Mac counterparts (e.g. "Friday's" matches "Friday's"). 2 new specs.
3. **Inline "+ Add songs" on each Sets-list row.** Skips the open-the-set step. Tap the button, sheet opens pre-targeted at that set. State flipped from a boolean to a string so list-view and detail-view both feed the same trigger.

79 tests passing, type check clean. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)