### PR TITLE
MySongsModal right-pane redesign: fewer modals, bigger surface

### DIFF
--- a/src/components/AddToSetSheet.tsx
+++ b/src/components/AddToSetSheet.tsx
@@ -112,7 +112,7 @@ export default function AddToSetSheet(props: Props) {
 
 // ── pickSet mode ───────────────────────────────────────────────────
 
-function PickSetBody({
+export function PickSetBody({
   sets,
   songIds,
   onClose,
@@ -246,7 +246,7 @@ function PickSetBody({
 
 // ── pickSongs mode ────────────────────────────────────────────────
 
-function PickSongsBody({
+export function PickSongsBody({
   sets,
   songs,
   targetSetId,

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -681,7 +681,7 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-xl shadow-2xl w-[1100px] max-w-[95vw] flex flex-col max-h-[92vh]"
+        className="bg-white rounded-xl shadow-2xl w-[1100px] max-w-[95vw] flex flex-col h-[92vh]"
         onClick={e => e.stopPropagation()}
       >
         <div className="px-5 py-4 border-b border-gray-200 flex items-center justify-between">

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -5,7 +5,7 @@ import { useScoreStore } from "@/store/score-store";
 import { saveSnapshot } from "@/lib/autosave";
 import AutosaveRecoveryDialog from "@/components/AutosaveRecoveryDialog";
 import SetsPanel from "@/components/SetsPanel";
-import AddToSetSheet from "@/components/AddToSetSheet";
+import { PickSetBody, PickSongsBody } from "@/components/AddToSetSheet";
 import { getSets, SetsUpdatedEvent, songSetMembership, type SongSet } from "@/lib/song-sets";
 import {
   canonicalSongTitle,
@@ -87,11 +87,22 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
   // Esc exits.
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  // Stacked sheet for "Add to set…" bulk action. Pre-fills with the
-  // current selection; the sheet picks the target set (existing or new).
-  const [addToSetOpen, setAddToSetOpen] = useState(false);
-  // Centered "pick a folder" picker for the bulk Move action.
-  const [bulkFolderOpen, setBulkFolderOpen] = useState(false);
+  // Right-pane state machine. Replaces the previous stacked-sheet
+  // approach (AddToSetSheet, BulkFolderPicker, etc. as modal-on-modal).
+  // The pane lives INSIDE the modal so it's bigger, scrollable, and
+  // doesn't pile chrome on top of chrome.
+  //
+  //  - addToSet: pickSet flow (caller pre-chose songs)
+  //  - pickSongs: pickSongs flow (caller pre-chose the set)
+  //  - moveFolder: bulk folder picker
+  //  - null: pane closed; left pane is full-width
+  type RightPaneState =
+    | { kind: "addToSet"; songIds: string[] }
+    | { kind: "pickSongs"; targetSetId: string }
+    | { kind: "moveFolder"; songIds: string[] }
+    | { kind: null };
+  const [rightPane, setRightPane] = useState<RightPaneState>({ kind: null });
+  const closeRightPane = () => setRightPane({ kind: null });
 
   // Search box state. When non-empty, the list switches from
   // folder-grouped to a flat result list (folder shown inline). Folder
@@ -121,17 +132,25 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     });
   };
 
+  // Esc layering: close the right pane first, then exit select mode,
+  // then let the parent modal handle Esc itself (close). One layer per
+  // Esc press.
   useEffect(() => {
-    if (!selectMode) return;
+    if (!selectMode && rightPane.kind === null) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key !== "Escape") return;
+      if (rightPane.kind !== null) {
+        e.stopPropagation();
+        closeRightPane();
+      } else if (selectMode) {
         e.stopPropagation();
         exitSelectMode();
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [selectMode]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectMode, rightPane.kind]);
 
   const openKebab = (entry: SongBankEntry, e: React.MouseEvent<HTMLButtonElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -588,17 +607,17 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     }
   };
 
-  // Bulk move-to-folder. Called from the centered folder picker once
-  // the user picks a target folder (or creates a new one). All selected
-  // ids land in that folder; one sync at the end.
-  const handleBulkMoveToFolder = async (folder: string | null) => {
-    if (selectedIds.size === 0) return;
-    const ids = Array.from(selectedIds);
+  // Apply a folder choice to an arbitrary set of song ids. Used by
+  // the right-pane FolderPickerPaneBody for both the bulk-bar Move
+  // action AND single-row kebab Move (where the right pane targets
+  // just that one song). Local change runs first; cloud push happens
+  // after, with a final runSync().
+  const handleBulkMoveToFolderIds = async (ids: string[], folder: string | null) => {
+    if (ids.length === 0) return;
     for (const id of ids) {
       setSongFolder(id, folder && folder.trim() ? folder.trim() : null);
     }
     refreshLocal();
-    setBulkFolderOpen(false);
     exitSelectMode();
     if (CLOUD_ENABLED) {
       // Push each updated entry so the new folder propagates. Re-read
@@ -662,7 +681,7 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-xl shadow-2xl w-[800px] max-w-[92vw] flex flex-col max-h-[80vh]"
+        className="bg-white rounded-xl shadow-2xl w-[1100px] max-w-[95vw] flex flex-col max-h-[92vh]"
         onClick={e => e.stopPropagation()}
       >
         <div className="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
@@ -724,9 +743,10 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           )}
         </div>
 
-        {activeTab === "sets" ? (
-          <SetsPanel onClose={onClose} />
-        ) : score ? (() => {
+        {/* Save bar / no-score message — only on the Songs tab. SetsPanel
+            moved into the flex-row below so the right pane can sit
+            alongside either tab's content. */}
+        {activeTab === "songs" && (score ? (() => {
           // Save flow with explicit branching to prevent silent
           // overwrites. Three states:
           //
@@ -817,7 +837,7 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           <div className="px-5 py-3 bg-gray-50 border-b border-gray-200">
             <p className="text-sm text-gray-500">Open or create a score or chord chart to save it here.</p>
           </div>
-        )}
+        ))}
 
         {/* Search box — pinned above the list. Hidden in Sets tab and
             in select mode (the bulk-action bar already overloads the
@@ -844,6 +864,19 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           </div>
         )}
 
+        {/* Body row — splits into left pane (Songs list or Sets) and an
+            optional right pane (Add to set / Move to folder / Pick
+            songs for a set). The right pane replaces the previous
+            stacked-modal sheets so users get a bigger working surface
+            with no modal-on-modal. */}
+        <div className="flex-1 flex flex-row min-h-0 overflow-hidden">
+          <div className={`flex flex-col min-w-0 ${rightPane.kind ? "hidden md:flex md:flex-1" : "flex-1"}`}>
+        {activeTab === "sets" ? (
+          <SetsPanel
+            onClose={onClose}
+            onPickSongs={(setId) => setRightPane({ kind: "pickSongs", targetSetId: setId })}
+          />
+        ) : (
         <div className="flex-1 overflow-y-auto">
           {songs.length === 0 ? (
             <div className="px-5 py-10 text-center text-sm text-gray-400">
@@ -1159,6 +1192,47 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
             </div>
           )}
         </div>
+        )}
+          </div>
+          {/* Right pane — contextual action target. Replaces stacked
+              sheets. On wide viewports, sits alongside the left pane
+              (~380px). On narrow viewports (< md ≈ 768px), the left
+              pane is hidden and the right pane takes the whole modal,
+              Master/Detail style. */}
+          {rightPane.kind && (
+            <div className="flex flex-col w-full md:w-[380px] md:max-w-[42%] md:border-l md:border-gray-200 bg-white min-h-0">
+              {rightPane.kind === "addToSet" && (
+                <PickSetBody
+                  sets={sets}
+                  songIds={rightPane.songIds}
+                  onClose={() => {
+                    closeRightPane();
+                    exitSelectMode();
+                  }}
+                />
+              )}
+              {rightPane.kind === "pickSongs" && (
+                <PickSongsBody
+                  sets={sets}
+                  songs={songs}
+                  targetSetId={rightPane.targetSetId}
+                  onClose={closeRightPane}
+                />
+              )}
+              {rightPane.kind === "moveFolder" && (
+                <FolderPickerPaneBody
+                  folderNames={folderNames}
+                  count={rightPane.songIds.length}
+                  onCancel={closeRightPane}
+                  onPick={(folder) => {
+                    void handleBulkMoveToFolderIds(rightPane.songIds, folder);
+                    closeRightPane();
+                  }}
+                />
+              )}
+            </div>
+          )}
+        </div>
 
         {CLOUD_ENABLED && (
           <div className="px-5 py-3 border-t border-gray-100 bg-gray-50">
@@ -1256,13 +1330,13 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
             </span>
             <div className="flex items-center gap-2">
               <button
-                onClick={() => setAddToSetOpen(true)}
+                onClick={() => setRightPane({ kind: "addToSet", songIds: Array.from(selectedIds) })}
                 className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg"
               >
                 Add to set…
               </button>
               <button
-                onClick={() => setBulkFolderOpen(true)}
+                onClick={() => setRightPane({ kind: "moveFolder", songIds: Array.from(selectedIds) })}
                 className="px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg"
               >
                 Move to folder…
@@ -1303,30 +1377,6 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
         </div>
       </div>
 
-      {/* Stacked sheet for "Add to set…" — z-[110] sits above this modal's
-          z-50, matching the kebab-menu z-stack pattern. */}
-      {addToSetOpen && (
-        <AddToSetSheet
-          mode="pickSet"
-          songIds={Array.from(selectedIds)}
-          onClose={() => {
-            setAddToSetOpen(false);
-            exitSelectMode();
-          }}
-        />
-      )}
-
-      {/* Centered bulk folder picker — one picker for the entire selection
-          (vs. the per-row picker reached via the kebab menu). */}
-      {bulkFolderOpen && (
-        <BulkFolderPicker
-          folderNames={folderNames}
-          count={selectedIds.size}
-          onCancel={() => setBulkFolderOpen(false)}
-          onPick={(folder) => handleBulkMoveToFolder(folder)}
-        />
-      )}
-
       {/* Kebab menu — fixed-positioned at the button anchor so it isn't
           clipped by the modal's overflow-y-auto song list (the bug that
           made taps unreliable on iPad). */}
@@ -1356,6 +1406,16 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
               className="w-full text-left px-3 py-2 hover:bg-blue-50 active:bg-blue-100 text-gray-700"
             >
               Move to folder…
+            </button>
+            <button
+              onClick={() => {
+                const e = menuAnchor.entry;
+                setMenuAnchor(null);
+                setRightPane({ kind: "addToSet", songIds: [e.id] });
+              }}
+              className="w-full text-left px-3 py-2 hover:bg-blue-50 active:bg-blue-100 text-gray-700"
+            >
+              Add to set…
             </button>
             <button
               onClick={() => handleViewHistory(menuAnchor.entry)}
@@ -1440,12 +1500,15 @@ function truncate(s: string, max: number): string {
 }
 
 /**
- * Centered folder picker for the bulk Move action. Lists existing
- * folder names + "(Unfiled)" + "+ New folder" inline create. Pops over
- * the entire selection at once (vs. the kebab's per-row anchored
- * picker). Renders at z-[110] above MySongsModal's z-50.
+ * Folder picker body for the bulk Move action — renders inline inside
+ * the MySongsModal right pane, NOT as a standalone modal. (The old
+ * standalone stacked-sheet version was replaced when the modal grew
+ * a right pane; sheets-on-modals were the "small windows" complaint.)
+ *
+ * Lists existing folders + "(Unfiled)" + a "+ New folder" inline
+ * create. Caller owns positioning and Esc handling.
  */
-function BulkFolderPicker({
+function FolderPickerPaneBody({
   folderNames,
   count,
   onCancel,
@@ -1459,114 +1522,92 @@ function BulkFolderPicker({
   const [newFolder, setNewFolder] = useState("");
   const [creating, setCreating] = useState(false);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onCancel();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel]);
-
   return (
-    <div
-      className="fixed inset-0 z-[110] flex items-start justify-center pt-[12vh] bg-black/40"
-      onClick={(e) => {
-        e.stopPropagation();
-        onCancel();
-      }}
-    >
-      <div
-        className="bg-white rounded-xl shadow-2xl border border-gray-200 w-[440px] max-w-[92vw] max-h-[70vh] flex flex-col overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-gray-900">
-              Move {count} {count === 1 ? "song" : "songs"} to a folder
-            </h2>
-            <p className="text-xs text-gray-500 mt-0.5">
-              Pick an existing folder or name a new one.
-            </p>
-          </div>
-          <button
-            onClick={onCancel}
-            className="text-gray-500 hover:text-gray-700 text-lg px-2 shrink-0"
-            aria-label="Close"
-          >
-            ×
-          </button>
+    <>
+      <div className="px-5 py-3 border-b border-gray-200 flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-gray-900">
+            Move {count} {count === 1 ? "song" : "songs"} to a folder
+          </h2>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Pick an existing folder or name a new one.
+          </p>
         </div>
-        <div className="flex-1 overflow-y-auto">
-          <ul className="divide-y divide-gray-100">
-            <li>
+        <button
+          onClick={onCancel}
+          className="text-gray-500 hover:text-gray-700 text-lg px-2 shrink-0"
+          aria-label="Close pane"
+        >
+          ×
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <ul className="divide-y divide-gray-100">
+          <li>
+            <button
+              type="button"
+              onClick={() => onPick(null)}
+              className="w-full text-left px-5 py-3 text-sm hover:bg-gray-50 active:bg-gray-100 text-gray-900"
+            >
+              (Unfiled)
+            </button>
+          </li>
+          {folderNames.map((f) => (
+            <li key={f}>
               <button
                 type="button"
-                onClick={() => onPick(null)}
+                onClick={() => onPick(f)}
                 className="w-full text-left px-5 py-3 text-sm hover:bg-gray-50 active:bg-gray-100 text-gray-900"
               >
-                (Unfiled)
+                {f}
               </button>
             </li>
-            {folderNames.map((f) => (
-              <li key={f}>
-                <button
-                  type="button"
-                  onClick={() => onPick(f)}
-                  className="w-full text-left px-5 py-3 text-sm hover:bg-gray-50 active:bg-gray-100 text-gray-900"
-                >
-                  {f}
-                </button>
-              </li>
-            ))}
-          </ul>
-          <div className="border-t border-gray-100 px-5 py-3">
-            {creating ? (
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  autoFocus
-                  value={newFolder}
-                  onChange={(e) => setNewFolder(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      const t = newFolder.trim();
-                      if (t) onPick(t);
-                    }
-                    if (e.key === "Escape") {
-                      setCreating(false);
-                      setNewFolder("");
-                    }
-                  }}
-                  placeholder="Folder name"
-                  className="flex-1 text-sm text-gray-900 placeholder-gray-400 border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <button
-                  type="button"
-                  onClick={() => {
+          ))}
+        </ul>
+        <div className="border-t border-gray-100 px-5 py-3">
+          {creating ? (
+            <div className="flex gap-2">
+              <input
+                type="text"
+                autoFocus
+                value={newFolder}
+                onChange={(e) => setNewFolder(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
                     const t = newFolder.trim();
                     if (t) onPick(t);
-                  }}
-                  disabled={!newFolder.trim()}
-                  className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:bg-gray-300 rounded-lg"
-                >
-                  Move
-                </button>
-              </div>
-            ) : (
+                  }
+                  if (e.key === "Escape") {
+                    setCreating(false);
+                    setNewFolder("");
+                  }
+                }}
+                placeholder="Folder name"
+                className="flex-1 text-sm text-gray-900 placeholder-gray-400 border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
               <button
                 type="button"
-                onClick={() => setCreating(true)}
-                className="w-full text-left text-sm text-blue-700 hover:underline"
+                onClick={() => {
+                  const t = newFolder.trim();
+                  if (t) onPick(t);
+                }}
+                disabled={!newFolder.trim()}
+                className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:bg-gray-300 rounded-lg"
               >
-                + New folder…
+                Move
               </button>
-            )}
-          </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setCreating(true)}
+              className="w-full text-left text-sm text-blue-700 hover:underline"
+            >
+              + New folder…
+            </button>
+          )}
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -301,9 +301,12 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
         </button>
       </div>
 
-      {/* Top-left nav cluster — Prev / Title (opens picker) / Next */}
+      {/* Top-left nav cluster — Prev / Title (opens picker) / Next.
+          Fixed-width cluster so the ▶ next-song arrow doesn't drift
+          when song titles vary in length. Title button takes flex-1
+          of the remaining space and truncates anything longer. */}
       {songs.length > 0 && (
-        <div className="absolute top-3 left-3 flex items-center gap-1 bg-gray-900/80 backdrop-blur-sm rounded-xl p-1 shadow border border-white/10 max-w-[calc(50vw-1rem)]">
+        <div className="absolute top-3 left-3 flex items-center gap-1 bg-gray-900/80 backdrop-blur-sm rounded-xl p-1 shadow border border-white/10 w-[min(34rem,calc(50vw-1rem))]">
           <button
             type="button"
             onClick={() => loadAt(currentIndex - 1)}
@@ -317,20 +320,20 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
           <button
             type="button"
             onClick={() => setPickerOpen(o => !o)}
-            className="h-11 px-3 flex flex-col items-start justify-center text-gray-100 hover:bg-gray-800 active:bg-gray-700 rounded-lg max-w-[40vw]"
+            className="h-11 px-3 flex flex-col items-start justify-center text-gray-100 hover:bg-gray-800 active:bg-gray-700 rounded-lg flex-1 min-w-0"
             title="Jump to song"
           >
             {activeSet ? (
-              <span className="text-[9px] uppercase tracking-wider text-pink-300 leading-none mb-0.5 truncate max-w-[40vw]">
+              <span className="text-[9px] uppercase tracking-wider text-pink-300 leading-none mb-0.5 truncate max-w-full">
                 Set: {activeSet.name}
               </span>
             ) : performFolder ? (
-              <span className="text-[9px] uppercase tracking-wider text-gray-400 leading-none mb-0.5">
+              <span className="text-[9px] uppercase tracking-wider text-gray-400 leading-none mb-0.5 truncate max-w-full">
                 {performFolder}
               </span>
             ) : null}
-            <span className="flex items-center gap-1 truncate text-sm font-medium leading-tight">
-              <span className="truncate">
+            <span className="flex items-center gap-1 text-sm font-medium leading-tight w-full min-w-0">
+              <span className="truncate flex-1 text-left">
                 {songsInScope[currentIndex]?.title ?? score.title ?? "Untitled"}
               </span>
               <svg className="w-3 h-3 shrink-0 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -2,16 +2,18 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
+  addSongToSet,
   createSet,
   deleteSet,
   getSets,
   removeSongFromSet,
   renameSet,
   reorderSong,
+  songSetMembership,
   SetsUpdatedEvent,
   type SongSet,
 } from "@/lib/song-sets";
-import { getSongs, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
+import { getSongs, isAliasTitle, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
 import AddToSetSheet from "@/components/AddToSetSheet";
 import { useScoreStore } from "@/store/score-store";
 import { saveSnapshot } from "@/lib/autosave";
@@ -51,6 +53,20 @@ export default function SetsPanel({
   // Live search filter for the songs-in-set list. Critical once a set
   // gets above ~10 songs.
   const [setQuery, setSetQuery] = useState("");
+  // Which sets are checked in the list-view multi-select. When ≥1 is
+  // checked, the Songs section below shows per-row Add buttons that
+  // commit to all checked sets at once. This is the inverse of the
+  // pickSongs sheet flow: instead of pick-songs-then-pick-set, here
+  // it's pick-sets-then-add-songs.
+  const [selectedSetIds, setSelectedSetIds] = useState<Set<string>>(new Set());
+  const toggleSelectedSet = (id: string) => {
+    setSelectedSetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
   const setScore = useScoreStore((s) => s.setScore);
   const setUIState = useScoreStore((s) => s.setUIState);
   const score = useScoreStore((s) => s.score);
@@ -88,6 +104,30 @@ export default function SetsPanel({
     setOpenSetId(s.id);
   };
 
+  // Load the first existing song of a set and enter perform mode.
+  // Critical for "open a set and play it" — without this, the only
+  // way to load a set was: open detail view → tap a song. This makes
+  // sets usable from the list view directly.
+  const handlePlaySet = async (setId: string) => {
+    const set = sets.find((s) => s.id === setId);
+    if (!set) return;
+    const firstSongId = set.songIds.find((id) => songsById.has(id));
+    if (!firstSongId) {
+      window.alert(`"${set.name}" has no songs yet. Add some songs first.`);
+      return;
+    }
+    await handleLoadSong(firstSongId, setId);
+  };
+
+  // Bulk-add a single song to every currently-checked set. Skips sets
+  // that already contain the song (dedup handled inside addSongToSet).
+  const handleAddSongToSelectedSets = (songId: string) => {
+    if (selectedSetIds.size === 0) return;
+    for (const setId of selectedSetIds) {
+      addSongToSet(setId, songId);
+    }
+  };
+
   const handleLoadSong = async (songId: string, setId: string) => {
     const entry = songsById.get(songId);
     if (!entry) return;
@@ -107,6 +147,16 @@ export default function SetsPanel({
   // ── List view: all sets ─────────────────────────────────────────────
 
   if (!openSet) {
+    // Membership map: songId → SongSets the song belongs to. Drives the
+    // per-song "✓ Added" / "Add" state in the Songs section below.
+    const membership = songSetMembership(sets);
+    // Songs to show in the bottom section. Alias artifacts ("(snapped)"
+    // etc.) hidden so the list stays scannable — same convention as
+    // AddToSetSheet's pickSongs.
+    const songsForAdd = Array.from(songsById.values())
+      .filter((s) => !isAliasTitle(s.title))
+      .sort((a, b) => b.savedAt - a.savedAt);
+
     return (
       <div className="flex flex-col flex-1 min-h-0">
         <div className="px-5 py-3 bg-gray-50 border-b border-gray-200 flex items-center gap-2">
@@ -128,23 +178,54 @@ export default function SetsPanel({
             Create
           </button>
         </div>
-        <div className="flex-1 overflow-y-auto">
-          {sets.length === 0 ? (
-            <div className="px-5 py-10 text-center text-sm text-gray-500">
-              No sets yet. Type a name above to create one — useful for grouping
-              songs you play together at a gig or rehearsal.
+
+        {/* ── Sets section (top): multi-select target picker ─────────
+            Capped at ~40% of available height so the songs section
+            below always has room. When empty, shows an explanatory
+            empty state and skips straight to "No sets yet" guidance. */}
+        {sets.length === 0 ? (
+          <div className="px-5 py-10 text-center text-sm text-gray-500">
+            No sets yet. Type a name above to create one — useful for grouping
+            songs you play together at a gig or rehearsal.
+          </div>
+        ) : (
+          <>
+            <div className="px-5 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 bg-gray-50 border-b border-gray-100 flex items-center justify-between">
+              <span>Sets ({sets.length})</span>
+              {selectedSetIds.size > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedSetIds(new Set())}
+                  className="text-[10px] normal-case tracking-normal text-gray-500 hover:text-gray-700"
+                >
+                  Clear selection
+                </button>
+              )}
             </div>
-          ) : (
-            <ul className="divide-y divide-gray-100">
+            <ul className="overflow-y-auto divide-y divide-gray-100 max-h-[40%] shrink-0">
               {sets.map((set) => {
                 const songCount = set.songIds.filter((id) => songsById.has(id)).length;
                 const missingCount = set.songIds.length - songCount;
+                const isSelected = selectedSetIds.has(set.id);
                 return (
-                  <li key={set.id} className="flex items-center px-5 py-3 hover:bg-gray-50 gap-3">
+                  <li
+                    key={set.id}
+                    className={`flex items-center px-5 py-3 hover:bg-gray-50 gap-3 ${
+                      isSelected ? "bg-blue-50/40" : ""
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => toggleSelectedSet(set.id)}
+                      className="w-4 h-4 text-blue-600 shrink-0"
+                      title="Select to bulk-add songs to this set"
+                    />
                     <button
                       type="button"
                       onClick={() => setOpenSetId(set.id)}
                       className="flex-1 text-left min-w-0"
+                      title="Open this set to reorder or remove songs"
                     >
                       <div className="text-sm font-medium text-gray-900 truncate">{set.name}</div>
                       <div className="text-xs text-gray-400 mt-0.5">
@@ -156,18 +237,14 @@ export default function SetsPanel({
                         )}
                       </div>
                     </button>
-                    {/* Inline "+ Add songs" — skips the open-the-set
-                        step. Pre-targets the AddToSetSheet at this set,
-                        so the sheet opens straight into pickSongs mode.
-                        Critical for "I just want to add a song without
-                        clicking into the set first." */}
                     <button
                       type="button"
-                      onClick={() => onPickSongs ? onPickSongs(set.id) : setAddToSetId(set.id)}
-                      className="px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 active:bg-blue-100 border border-blue-200 rounded"
-                      title={`Add songs to ${set.name}`}
+                      onClick={() => handlePlaySet(set.id)}
+                      disabled={songCount === 0}
+                      className="px-2 py-1 text-xs font-medium text-green-700 hover:bg-green-50 active:bg-green-100 border border-green-200 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                      title={songCount === 0 ? "Empty set" : `Play ${set.name} from the top in perform mode`}
                     >
-                      + Add songs
+                      ▶ Play
                     </button>
                     <button
                       type="button"
@@ -184,6 +261,11 @@ export default function SetsPanel({
                       onClick={() => {
                         if (confirm(`Delete set "${set.name}"? Songs themselves are not deleted.`)) {
                           deleteSet(set.id);
+                          setSelectedSetIds((prev) => {
+                            const next = new Set(prev);
+                            next.delete(set.id);
+                            return next;
+                          });
                         }
                       }}
                       className="px-2 py-1 text-xs text-red-500 hover:text-red-700 hover:bg-red-50 rounded"
@@ -194,7 +276,105 @@ export default function SetsPanel({
                 );
               })}
             </ul>
-          )}
+          </>
+        )}
+
+        {/* ── Songs section (bottom): per-row Add to selected sets ──
+            Mirrors the Songs tab list but the only action is Add. Disabled
+            until ≥1 set is checked above. When a song is already in every
+            checked set, button flips to "✓ Added" (still tap-friendly so
+            you can tap-add the same song again to MORE sets after
+            checking them — addSongToSet is idempotent). */}
+        {sets.length > 0 && (
+          <>
+            <div className="px-5 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 bg-gray-50 border-y border-gray-100 flex items-center justify-between">
+              <span>
+                Add songs to{" "}
+                {selectedSetIds.size === 0
+                  ? <em className="not-italic text-gray-400">no set selected</em>
+                  : selectedSetIds.size === 1
+                  ? sets.find((s) => selectedSetIds.has(s.id))?.name ?? "1 set"
+                  : `${selectedSetIds.size} sets`}
+              </span>
+            </div>
+            <ul className="flex-1 overflow-y-auto divide-y divide-gray-100">
+              {songsForAdd.length === 0 ? (
+                <li className="px-5 py-6 text-sm text-gray-500 text-center">
+                  No songs saved yet.
+                </li>
+              ) : (
+                songsForAdd.map((entry) => {
+                  const memberOf = membership.get(entry.id) ?? [];
+                  const inSelectedCount = memberOf.filter((s) =>
+                    selectedSetIds.has(s.id),
+                  ).length;
+                  const allSelectedAlreadyHave =
+                    selectedSetIds.size > 0 &&
+                    inSelectedCount === selectedSetIds.size;
+                  const t = scoreTypeOf(entry.score);
+                  return (
+                    <li key={entry.id} className="flex items-center px-5 py-3 hover:bg-gray-50 gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-gray-900 truncate inline-flex items-center gap-2">
+                          <span className="truncate">{entry.title}</span>
+                          {t === "chord-chart" && (
+                            <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-pink-100 text-pink-700 shrink-0">
+                              Chart
+                            </span>
+                          )}
+                          {t === "notation" && (
+                            <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 shrink-0">
+                              Score
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-gray-400 mt-0.5 flex items-center gap-2 flex-wrap">
+                          {entry.folder && (
+                            <span
+                              className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 border border-gray-200"
+                              title={`Folder: ${entry.folder}`}
+                            >
+                              {entry.folder}
+                            </span>
+                          )}
+                          {memberOf.length > 0 && (
+                            <span
+                              className="text-[10px] px-1.5 py-0.5 rounded bg-pink-50 text-pink-700 border border-pink-100"
+                              title={memberOf.map((s) => s.name).join(", ")}
+                            >
+                              In {memberOf.length} set{memberOf.length === 1 ? "" : "s"}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleAddSongToSelectedSets(entry.id)}
+                        disabled={selectedSetIds.size === 0 || allSelectedAlreadyHave}
+                        className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors shrink-0 ${
+                          allSelectedAlreadyHave
+                            ? "text-green-700 bg-green-50 border border-green-200 cursor-default"
+                            : selectedSetIds.size === 0
+                            ? "text-gray-400 bg-gray-50 border border-gray-200 cursor-not-allowed"
+                            : "text-blue-700 hover:bg-blue-50 active:bg-blue-100 border border-blue-200"
+                        }`}
+                        title={
+                          selectedSetIds.size === 0
+                            ? "Select one or more sets above first"
+                            : allSelectedAlreadyHave
+                            ? "Already in every selected set"
+                            : `Add to ${selectedSetIds.size} selected set${selectedSetIds.size === 1 ? "" : "s"}`
+                        }
+                      >
+                        {allSelectedAlreadyHave ? "✓ Added" : "Add"}
+                      </button>
+                    </li>
+                  );
+                })
+              )}
+            </ul>
+          </>
+        )}
           {renameOpen && (
             <div className="absolute inset-0 bg-black/30 flex items-center justify-center p-4 z-10">
               <div
@@ -236,10 +416,9 @@ export default function SetsPanel({
               </div>
             </div>
           )}
-        </div>
-        {/* AddToSetSheet — also mounted from the list view so the
-            inline "+ Add songs" button on each row works without first
-            opening a set. */}
+        {/* AddToSetSheet — kept for any caller path that still uses
+            addToSetId, but the list-view's row workflow no longer
+            opens it (per-song Add via the new Songs section). */}
         {addToSetId && (
           <AddToSetSheet
             mode="pickSongs"

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -184,9 +184,13 @@ export default function SetsPanel({
             below always has room. When empty, shows an explanatory
             empty state and skips straight to "No sets yet" guidance. */}
         {sets.length === 0 ? (
-          <div className="px-5 py-10 text-center text-sm text-gray-500">
-            No sets yet. Type a name above to create one — useful for grouping
-            songs you play together at a gig or rehearsal.
+          // Compact empty-state — kept small so the Songs section
+          // below stays visible. Without this, the modal collapsed
+          // to a tiny height the moment you switched to the Sets tab
+          // before creating your first set.
+          <div className="px-5 py-3 text-sm text-gray-500 bg-gray-50 border-b border-gray-100">
+            No sets yet. Type a name above to create one — useful for
+            grouping songs you play together at a gig or rehearsal.
           </div>
         ) : (
           <>
@@ -284,8 +288,11 @@ export default function SetsPanel({
             until ≥1 set is checked above. When a song is already in every
             checked set, button flips to "✓ Added" (still tap-friendly so
             you can tap-add the same song again to MORE sets after
-            checking them — addSongToSet is idempotent). */}
-        {sets.length > 0 && (
+            checking them — addSongToSet is idempotent).
+            Rendered regardless of sets count so the layout doesn't
+            jump when you first land on the Sets tab — the Add buttons
+            stay disabled until ≥1 set is selected. */}
+        {(
           <>
             <div className="px-5 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 bg-gray-50 border-y border-gray-100 flex items-center justify-between">
               <span>

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -101,7 +101,12 @@ export default function SetsPanel({
     if (!name) return;
     const s = createSet(name);
     setNewName("");
-    setOpenSetId(s.id);
+    // Stay on the list view so the user immediately sees the songs
+    // section below — auto-checking the new set means tapping Add on
+    // any song commits to it. The previous flow dumped them into the
+    // detail view of a brand-new empty set, which was just blank
+    // whitespace and required a second hop to start adding songs.
+    setSelectedSetIds(new Set([s.id]));
   };
 
   // Load the first existing song of a set and enter perform mode.
@@ -227,9 +232,22 @@ export default function SetsPanel({
                     />
                     <button
                       type="button"
-                      onClick={() => setOpenSetId(set.id)}
+                      // Empty sets have nothing to manage in detail view
+                      // (no songs to reorder/remove) — just auto-check
+                      // them so the user can immediately add songs from
+                      // the Songs section below. Populated sets go into
+                      // detail view as before.
+                      onClick={() =>
+                        set.songIds.length === 0
+                          ? setSelectedSetIds(new Set([set.id]))
+                          : setOpenSetId(set.id)
+                      }
                       className="flex-1 text-left min-w-0"
-                      title="Open this set to reorder or remove songs"
+                      title={
+                        set.songIds.length === 0
+                          ? "Empty set — check it and add songs below"
+                          : "Open this set to reorder or remove songs"
+                      }
                     >
                       <div className="text-sm font-medium text-gray-900 truncate">{set.name}</div>
                       <div className="text-xs text-gray-400 mt-0.5">

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -24,7 +24,19 @@ import { scoreTypeOf } from "@/lib/analytics";
  * No cloud sync yet (per-device only). Cloud-aware sets land alongside
  * #74 OAuth42 since per-set permissions need user identity.
  */
-export default function SetsPanel({ onClose }: { onClose: () => void }) {
+export default function SetsPanel({
+  onClose,
+  onPickSongs,
+}: {
+  onClose: () => void;
+  /** Optional: when set, the "+ Add songs" actions delegate to the
+   *  parent instead of opening SetsPanel's own AddToSetSheet. The
+   *  parent (MySongsModal) uses this to route the pickSongs flow into
+   *  its right pane — no modal-on-modal. When unset, SetsPanel falls
+   *  back to mounting AddToSetSheet itself so it remains usable in
+   *  isolation. */
+  onPickSongs?: (setId: string) => void;
+}) {
   const [sets, setSetsState] = useState<SongSet[]>(() => getSets());
   const [openSetId, setOpenSetId] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
@@ -151,7 +163,7 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
                         clicking into the set first." */}
                     <button
                       type="button"
-                      onClick={() => setAddToSetId(set.id)}
+                      onClick={() => onPickSongs ? onPickSongs(set.id) : setAddToSetId(set.id)}
                       className="px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 active:bg-blue-100 border border-blue-200 rounded"
                       title={`Add songs to ${set.name}`}
                     >
@@ -270,7 +282,7 @@ export default function SetsPanel({ onClose }: { onClose: () => void }) {
         </span>
         <button
           type="button"
-          onClick={() => setAddToSetId(openSet.id)}
+          onClick={() => onPickSongs ? onPickSongs(openSet.id) : setAddToSetId(openSet.id)}
           className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg"
           title="Add multiple songs to this set"
         >

--- a/src/components/SetsPanel.tsx
+++ b/src/components/SetsPanel.tsx
@@ -468,9 +468,15 @@ export default function SetsPanel({
         </span>
         <button
           type="button"
-          onClick={() => onPickSongs ? onPickSongs(openSet.id) : setAddToSetId(openSet.id)}
+          // Bounce back into the list view with THIS set already
+          // checked. Single workflow for adding songs to any set —
+          // no separate right-pane picker, no inline AddToSetSheet.
+          onClick={() => {
+            setSelectedSetIds(new Set([openSet.id]));
+            setOpenSetId(null);
+          }}
           className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded-lg"
-          title="Add multiple songs to this set"
+          title="Go to Sets list with this set checked, then tap Add on each song"
         >
           + Add songs…
         </button>
@@ -491,12 +497,13 @@ export default function SetsPanel({
       )}
 
       <div className="flex-1 overflow-y-auto">
-        {/* Songs in the set, in order, with up/down/remove controls. */}
-        {openSet.songIds.length === 0 ? (
-          <div className="px-5 py-6 text-sm text-gray-500 text-center">
-            Empty set. Tap <strong>+ Add songs…</strong> above to pick songs to add.
-          </div>
-        ) : (
+        {/* Songs in the set, in order, with up/down/remove controls.
+            Empty set just renders an empty list — the same layout as a
+            populated set. Removed the big centered placeholder so the
+            empty and populated states feel like the same UI (just with
+            zero rows). The header's + Add songs button is always the
+            primary action for adding more. */}
+        {openSet.songIds.length === 0 ? null : (
           <ul className="divide-y divide-gray-100">
             {openSet.songIds.map((songId, idx) => {
               const entry = songsById.get(songId);

--- a/src/lib/__tests__/song-bank-aliases.test.ts
+++ b/src/lib/__tests__/song-bank-aliases.test.ts
@@ -26,6 +26,30 @@ describe("aliasCanonicalTitle", () => {
     expect(aliasCanonicalTitle("Song (live version)")).toBeNull();
     expect(aliasCanonicalTitle("Take 2 (rehearsal)")).toBeNull();
   });
+
+  it("strips (with highlights HH:MM PM)", () => {
+    expect(aliasCanonicalTitle("Foggy Night (with highlights 10:26 PM)")).toBe(
+      "Foggy Night",
+    );
+  });
+
+  it("strips (chords fixed HH:MM PM)", () => {
+    expect(aliasCanonicalTitle("Star to Star (chords fixed 9:59 PM)")).toBe(
+      "Star to Star",
+    );
+  });
+
+  it("strips bare (old) tag", () => {
+    expect(aliasCanonicalTitle("Anywhere (old)")).toBe("Anywhere");
+  });
+
+  it("catches future timestamped aliases via trailing HH:MM AM|PM rule", () => {
+    // Even unknown verbs get caught if they trail with a time.
+    expect(aliasCanonicalTitle("Twig (remixed 10:42 PM)")).toBe("Twig");
+    expect(aliasCanonicalTitle("Hurricane (autosaved 1:00 am)")).toBe(
+      "Hurricane",
+    );
+  });
 });
 
 describe("isAliasTitle", () => {

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -28,18 +28,56 @@ function fireSongsUpdated(): void {
 }
 
 /**
- * Recognises titles that past autosave-recovery / dedup-cleanup runs
- * suffixed to disambiguate copies, e.g.
+ * Recognises titles that past autosave-recovery / dedup-cleanup /
+ * change-marker flows suffixed to disambiguate copies, e.g.
  *   "Anywhere (snapped)"
  *   "Foggy Night (recovered 9:06 PM)"
  *   "Star to Star (latest 10:37 PM)"
+ *   "Foggy Night (with highlights 10:26 PM)"
+ *   "Star to Star (chords fixed 9:59 PM)"
+ *   "Anywhere (old)"
  * These are alias entries — we hide them from the Sets candidate
  * picker and offer a one-click cleanup. Returns the canonical title
  * (suffix stripped) if matched, else null.
+ *
+ * Two complementary rules so we keep matching new auto-generated
+ * patterns without enumerating each one:
+ *
+ *   1. Known-verb prefix: `(snapped|recovered|latest|with X|chords X|
+ *      lyrics X|fixed X|old)` followed by anything.
+ *   2. Trailing timestamp: any parenthetical that *ends with* a clock
+ *      time like "9:06 PM" — typical of save-timestamp aliasing.
+ *
+ * Bare keywords like "(live version)" or "(acoustic)" stay matched
+ * as user-meaningful titles, not aliases.
  */
 export function aliasCanonicalTitle(title: string): string | null {
-  const m = title.match(/^(.*?)\s*\((snapped|recovered|latest)(?:\s[^)]*)?\)\s*$/i);
-  return m ? m[1].trim() : null;
+  // Keyword-prefix patterns the codebase or migration scripts have
+  // historically generated.
+  const KEYWORDS = [
+    "snapped",
+    "recovered",
+    "latest",
+    "with highlights",
+    "with chords",
+    "chords fixed",
+    "lyrics fixed",
+    "fixed",
+    "old",
+  ];
+  const keywordAlt = KEYWORDS.map((k) => k.replace(/\s/g, "\\s")).join("|");
+  const keywordRe = new RegExp(
+    `^(.*?)\\s*\\((?:${keywordAlt})(?:\\s[^)]*)?\\)\\s*$`,
+    "i",
+  );
+  const m1 = title.match(keywordRe);
+  if (m1) return m1[1].trim();
+  // Safety net: any parenthetical that ENDS with an HH:MM AM/PM
+  // timestamp. Catches future auto-generated patterns without
+  // updating the keyword list (e.g. "(remixed 10:42 PM)").
+  const m2 = title.match(/^(.*?)\s*\([^)]*\d{1,2}:\d{2}\s*(?:AM|PM|am|pm)\)\s*$/);
+  if (m2) return m2[1].trim();
+  return null;
 }
 
 /** True if the title looks like an autosave-/recovery-/sync-generated alias. */


### PR DESCRIPTION
## Summary

Two related redesigns of the My Songs surface. PR addresses direct user feedback: *"the maze is still stupid"*, *"small windows where you can't scroll"*, *"why open a set to add a song to it"*, *"select one or more sets and click an add button for each song"*, *"in perform mode there's no way to load the set"*.

### Part A — MySongsModal right-pane redesign

Restructures contextual actions (Add to set, Move to folder, Pick songs) to render in a **right-side pane inside the modal** instead of stacked sheets.

- Modal grows from **800px/80vh** → **1100px/92vh** (capped at 95vw).
- Inner body becomes a flex-row: left pane (existing songs list or Sets tab) + right pane (~380px) when active.
- Below `md` breakpoint, **left pane hides** when the right pane is open — Master/Detail collapse.
- New `rightPane` union state replaces old `addToSetOpen` / `bulkFolderOpen` booleans. `PickSetBody` / `PickSongsBody` exported from `AddToSetSheet.tsx`. `FolderPickerPaneBody` is the wrapper-less version of the old `BulkFolderPicker`.
- Bulk-action bar Add-to-set / Move-to-folder + new kebab **Add to set…** item all route through the right pane.
- Esc layering: closes pane → exits select mode → closes modal.

### Part B — Sets tab workflow inversion

Top-down redesign of the Sets-tab list view per the screenshot feedback. Sets section with checkboxes; songs section below with per-row Add.

- **Sets section** (top, ~40% height cap): checkbox + name + ▶ Play + Rename + Delete per row. Multi-select drives the targets for Add. Plain set name is still clickable to open the detail view (reorder / remove).
- **▶ Play** button: loads the first song of the set in perform mode AND sets `activeSetId`. Solves *"in perform mode there's no way to load the set"* — sets are now usable end-to-end.
- **Songs section** (bottom, fills remaining height): every real song (alias artifacts hidden) with title + type badge + folder pill + "in N sets" pill. Add button per row: disabled if no sets checked, "✓ Added" if already in every selected set, else adds to all checked sets.
- **No Load button** on the Sets tab — per feedback. Tap the set name to enter detail (reorder/remove), or ▶ Play to load.
- Old inline `+ Add songs` per-set-row button removed; the new Songs section replaces it.

## Test plan

- [ ] Open My Songs — confirm the bigger 1100×92vh size.
- [ ] **Sets tab**: type a name, Create. Check 2 sets. Scroll the songs section, tap Add on a few songs. Confirm they land in both checked sets.
- [ ] On a song that's already in every checked set, button shows "✓ Added".
- [ ] ▶ Play on a non-empty set: enters perform mode, prev/next walks the set.
- [ ] ▶ Play on an empty set: alert, no nav.
- [ ] Songs tab `[Select]` → pick 2 → `Add to set…` → right pane PickSet flow → pick a set → confirm.
- [ ] Same selection → `Move to folder…` → right pane PickFolder → choose folder.
- [ ] Single-row kebab → `Add to set…` → right pane with just that id.
- [ ] Esc with pane open → pane closes; modal stays.
- [ ] Narrow viewport (~700px) with pane open → left hides, right takes modal.
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 79 passing

**Not auto-merging** — large UI shift on the most-used surface; review on iPad before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)