### PR TITLE
File → Push all songs to cloud (recovery)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ import PersistFailureBanner from "@/components/PersistFailureBanner";
 import FeedbackModal from "@/components/FeedbackModal";
 import { CLOUD_ENABLED, getDeviceId, cloudPutSong } from "@/lib/song-cloud";
 import { autosaveToCloud, CloudSaveEvents } from "@/lib/cloud-autosave";
-import { updateSong } from "@/lib/song-bank";
+import { getSongs, updateSong } from "@/lib/song-bank";
 import type { SongDTO } from "@/lib/song-cloud-types";
 import ConflictModal from "@/components/ConflictModal";
 import AnnotationLayer from "@/components/AnnotationLayer";
@@ -102,6 +102,55 @@ export default function Home() {
   >(null);
   const [inlineAI, setInlineAI] = useState<{ note: { measure: number; beat: number; pitch: string; staffIndex: number }; position: { x: number; y: number } } | null>(null);
   const printFnRef = useRef<(() => Promise<void>) | null>(null);
+  // Force-pushes every local song to cloud without expectedVersion.
+  // Recovery action for the case where another device wiped the cloud
+  // copy (e.g. accidental Delete-all-in-folder) and the local songs
+  // on THIS device are the last surviving copies. Lives on File menu
+  // so the user can run it WITHOUT first opening My Songs — which
+  // would trigger runSync and tombstone-drop the local entries
+  // before the recovery has a chance.
+  const handleForcePushCloud = useCallback(async () => {
+    if (!CLOUD_ENABLED) {
+      window.alert("Cloud sync isn't enabled in this build.");
+      return;
+    }
+    const songs = getSongs();
+    if (songs.length === 0) {
+      window.alert("No local songs to push.");
+      return;
+    }
+    const ok = window.confirm(
+      `Push all ${songs.length} song${songs.length === 1 ? "" : "s"} from this device to the cloud?\n\n` +
+        `This overwrites whatever the cloud has — use it if another device deleted songs you still want.\n\n` +
+        `Tip: open My Songs AFTER this finishes; opening it first would sync and could lose songs.`,
+    );
+    if (!ok) return;
+    let pushed = 0;
+    let failed = 0;
+    for (const entry of songs) {
+      try {
+        const dto = await cloudPutSong({
+          id: entry.id,
+          title: entry.title,
+          score: entry.score,
+          savedAt: entry.savedAt,
+          folder: entry.folder ?? null,
+          // No expectedVersion — force overwrite. The cloud row may
+          // have been deleted entirely; expectedVersion would 409 if
+          // we passed the stale cloudVersion.
+        });
+        updateSong(entry.id, { cloudVersion: dto.version });
+        pushed++;
+      } catch (err) {
+        failed++;
+        console.warn("[force-push] failed for", entry.title, err);
+      }
+    }
+    window.alert(
+      `Pushed ${pushed} song${pushed === 1 ? "" : "s"} to cloud.${failed > 0 ? `\n${failed} failed (see console).` : ""}\n\nOther devices can now sync to pick them back up.`,
+    );
+  }, []);
+
   const handlePrint = useCallback(() => {
     const isChordChart = !!(score?.sections && score.sections.length > 0);
     if (!isChordChart && printFnRef.current) {
@@ -768,6 +817,7 @@ export default function Home() {
           onToggleSidebar={() => setLeftPanelOpen(p => !p)}
           sidebarOpen={leftPanelOpen}
           onOpenAutosave={() => setAutosaveDialogOpen(true)}
+          onForcePushCloud={handleForcePushCloud}
           onPasteLyrics={() => setPasteLyricsOpen(true)}
           onMySongs={() => setMySongsOpen(true)}
           onSendFeedback={() => setFeedbackOpen(true)}

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -22,6 +22,7 @@ interface MenuBarProps {
   onToggleSidebar: () => void;
   sidebarOpen: boolean;
   onOpenAutosave?: () => void;
+  onForcePushCloud?: () => void;
   onPasteLyrics?: () => void;
   onMySongs?: () => void;
   onSendFeedback?: () => void;
@@ -118,7 +119,7 @@ function MenuDropdown({ label, items, isOpen, onToggle, onClose, onItemClick }: 
 }
 
 export default function MenuBar({
-  zoom, onZoomChange, onPrint, onOpenAutosave, onPasteLyrics, onMySongs, onApiKeys,
+  zoom, onZoomChange, onPrint, onOpenAutosave, onForcePushCloud, onPasteLyrics, onMySongs, onApiKeys,
   onToggleSidebar, sidebarOpen, onSendFeedback,
 }: MenuBarProps) {
   const {
@@ -359,6 +360,10 @@ export default function MenuBar({
     { separator: true },
     { label: "Open Project...", shortcut: "", action: () => projectInputRef.current?.click() },
     { label: "Recover from Auto-save...", action: () => onOpenAutosave?.() },
+    // Force-pushes every local song to cloud without expectedVersion,
+    // bypassing the My Songs sync flow that would otherwise tombstone
+    // local entries when cloud has been wiped on another device.
+    { label: "Push all songs to cloud (recovery)...", action: () => onForcePushCloud?.() },
     { label: "Import...", shortcut: "", action: () => fileInputRef.current?.click() },
     { separator: true },
     { label: "Save Revision", shortcut: "Cmd+S", action: handleSave, enabled: !!score },


### PR DESCRIPTION
## Summary

Closes the recovery gap when another device wipes the cloud (e.g. accidental Delete-all-in-folder). The local songs on this device are the surviving truth — but opening My Songs to push them back would first runSync, which tombstones the local entries because cloud is empty for those ids. Catch-22.

New File menu item **"Push all songs to cloud (recovery)…"** lives in the top-level File menu so the user can trigger it WITHOUT opening My Songs. Walks every local song, calls `cloudPutSong` without `expectedVersion` (force overwrite — the cloud row may have been deleted entirely, so a stale `cloudVersion` would 409), and updates the local `cloudVersion` with the new `dto.version`.

Confirms with the count + a "open My Songs AFTER this finishes" hint. Reports pushed / failed at the end.

83 tests passing. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)