### PR TITLE
Harden share-code parser + surface Copy code button

### DIFF
--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -67,7 +67,6 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
   );
   const [pasteCode, setPasteCode] = useState("");
   const [showSync, setShowSync] = useState(false);
-  const [showRawCode, setShowRawCode] = useState(false);
   const [activeTab, setActiveTab] = useState<"songs" | "sets">("songs");
   const [linkCopied, setLinkCopied] = useState(false);
   const [codeCopied, setCodeCopied] = useState(false);
@@ -1362,6 +1361,7 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
                   <div className="text-xs text-gray-500 mb-1">
                     Share this songbook with another device
                   </div>
+                  {/* Link row — the URL form, easy to text/email. */}
                   <div className="flex items-center gap-2">
                     <code className="flex-1 px-2 py-1.5 text-xs bg-white border border-gray-200 rounded text-gray-700 truncate">
                       {buildShareLink(deviceId)}
@@ -1373,25 +1373,24 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
                       {linkCopied ? "Copied!" : "Copy link"}
                     </button>
                   </div>
-                  <button
-                    onClick={() => setShowRawCode(s => !s)}
-                    className="text-xs text-gray-500 hover:text-gray-700 mt-2"
-                  >
-                    {showRawCode ? "Hide raw code" : "Show raw code"}
-                  </button>
-                  {showRawCode && (
-                    <div className="flex items-center gap-2 mt-2">
-                      <code className="flex-1 px-2 py-1.5 text-xs font-mono bg-white border border-gray-200 rounded text-gray-700 truncate">
-                        {deviceId}
-                      </code>
-                      <button
-                        onClick={handleCopyDeviceId}
-                        className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-200 hover:bg-gray-100 active:bg-gray-200 rounded transition-colors shrink-0"
-                      >
-                        {codeCopied ? "Copied!" : "Copy"}
-                      </button>
-                    </div>
-                  )}
+                  {/* Code row — the bare UUID. Critical to surface
+                      this prominently: pasting the URL through some
+                      chat apps URL-encodes characters into the
+                      payload (e.g. \ → %5C, which then decodes back
+                      to \<uuid> on the other side and partitions a
+                      separate songbook). Copy code avoids that
+                      whole round-trip. */}
+                  <div className="flex items-center gap-2 mt-2">
+                    <code className="flex-1 px-2 py-1.5 text-xs font-mono bg-white border border-gray-200 rounded text-gray-700 truncate">
+                      {deviceId}
+                    </code>
+                    <button
+                      onClick={handleCopyDeviceId}
+                      className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 rounded transition-colors shrink-0"
+                    >
+                      {codeCopied ? "Copied!" : "Copy code"}
+                    </button>
+                  </div>
                 </div>
                 <div className="pt-2 border-t border-gray-200">
                   <div className="text-xs text-gray-500 mb-1">

--- a/src/lib/__tests__/extract-join-code.test.ts
+++ b/src/lib/__tests__/extract-join-code.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { extractJoinCode } from "@/lib/song-cloud";
+
+const UUID = "5d30c34c-5d51-4e69-9eda-b6e717ea2315";
+
+describe("extractJoinCode — happy paths", () => {
+  it("accepts a raw UUID", () => {
+    expect(extractJoinCode(UUID)).toBe(UUID);
+  });
+
+  it("accepts a share URL and extracts the join param", () => {
+    expect(extractJoinCode(`https://gibsonds.github.io/NotationApp/?join=${UUID}`)).toBe(UUID);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(extractJoinCode(`   ${UUID}   `)).toBe(UUID);
+  });
+
+  it("lowercases an upper-cased UUID for consistent partitioning", () => {
+    expect(extractJoinCode(UUID.toUpperCase())).toBe(UUID);
+  });
+});
+
+describe("extractJoinCode — sanitisation of pasted garbage", () => {
+  it("strips a leading backslash (the bug that started this)", () => {
+    // URL-encoded paste round-trip produced \5d30c34c-... once in
+    // production; the UUID part is fine, the leading slash partitioned
+    // the device to its own private songbook.
+    expect(extractJoinCode(`\\${UUID}`)).toBe(UUID);
+  });
+
+  it("strips a leading quote (chat-app smart-quote auto-correct)", () => {
+    expect(extractJoinCode(`"${UUID}"`)).toBe(UUID);
+  });
+
+  it("decodes URL-encoded backslash inside the join param and strips it", () => {
+    // %5C decodes to \, then sanitize strips it.
+    expect(
+      extractJoinCode(`https://example.com/?join=%5C${UUID}`),
+    ).toBe(UUID);
+  });
+});
+
+describe("extractJoinCode — invalid input rejected", () => {
+  it("returns null for empty string", () => {
+    expect(extractJoinCode("")).toBeNull();
+  });
+
+  it("returns null for whitespace only", () => {
+    expect(extractJoinCode("   ")).toBeNull();
+  });
+
+  it("returns null for a non-UUID string", () => {
+    expect(extractJoinCode("not-a-uuid")).toBeNull();
+  });
+
+  it("returns null when the URL has no join param", () => {
+    expect(extractJoinCode("https://example.com/?other=1")).toBeNull();
+  });
+
+  it("returns null when interior characters break the UUID shape", () => {
+    // Mid-string spaces or stray chars aren't auto-corrected — better
+    // to reject than mutate something the user intended to be valid.
+    expect(extractJoinCode(`5d30c34c 5d51-4e69-9eda-b6e717ea2315`)).toBeNull();
+  });
+});

--- a/src/lib/song-cloud.ts
+++ b/src/lib/song-cloud.ts
@@ -381,19 +381,42 @@ export async function syncSongbook(opts?: {
   }
 }
 
-// Parse a pasted value as either a share URL (?join=<id>) or a raw device
-// code. Returns the device id, or null if nothing usable is found.
+// UUID v4-ish shape — 8-4-4-4-12 hex with dashes. crypto.randomUUID()
+// always produces this; cloud-side partitioning depends on the
+// canonical lowercase form.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Parse a pasted value as either a share URL (?join=<id>) or a raw
+// device code. Returns the device id ONLY if it cleans up to a valid
+// UUID shape — otherwise null. Strips non-hex garbage from either end
+// (this catches the "\<uuid>" mishap from URL-encoded paste round-
+// trips). Returns lowercase canonical form so the cloud partition
+// key is consistent.
 export function extractJoinCode(input: string): string | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
+  // URL form: ?join=<id>. URL parsing also URL-decodes %5C → \, so
+  // the sanitize step below still picks up the slash and strips it.
   if (trimmed.includes("?") || trimmed.startsWith("http")) {
     try {
       const url = new URL(trimmed);
       const join = url.searchParams.get("join");
-      if (join) return join;
+      if (join) return sanitizeDeviceCode(join);
     } catch {
       /* not a URL — fall through to raw */
     }
   }
-  return trimmed;
+  return sanitizeDeviceCode(trimmed);
+}
+
+function sanitizeDeviceCode(raw: string): string | null {
+  // Strip everything that isn't hex / dash from the front and back.
+  // Internal garbage (e.g. spaces) would break a real UUID, so we
+  // let the regex check reject it rather than mutate the middle.
+  const cleaned = raw
+    .trim()
+    .replace(/^[^0-9a-fA-F]+/, "")
+    .replace(/[^0-9a-fA-F]+$/, "")
+    .toLowerCase();
+  return UUID_RE.test(cleaned) ? cleaned : null;
 }


### PR DESCRIPTION
## Summary

Two-prong fix for the deviceId-with-leading-backslash partition bug that bit a device today.

### 1) `extractJoinCode` is now strict
- Strips non-hex garbage from start/end of candidate.
- Normalises to lowercase.
- Validates against UUID v4 shape; returns `null` if it doesn't match.
- 12 new specs in `src/lib/__tests__/extract-join-code.test.ts` cover happy paths, the `\<uuid>` and `%5C<uuid>` sanitise paths, and every reject branch.

### 2) "Copy code" button always visible
The "Show raw code" toggle is gone. The bare UUID is now shown alongside the share-link, each with its own prominent Copy button:
- **Copy link** (existing) — URL form, easy to text/email.
- **Copy code** (new, always-visible) — bare UUID. Avoids the chat-app URL-encoding round-trip that turned `https://...?join=<uuid>` into `\<uuid>` after paste.

`showRawCode` state goes away.

95 tests passing. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)