### PR TITLE
File → Import songbook from JSON (Fork / Replace)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,8 +24,9 @@ import JoinSongbookModal from "@/components/JoinSongbookModal";
 import PerformView from "@/components/PerformView";
 import PersistFailureBanner from "@/components/PersistFailureBanner";
 import FeedbackModal from "@/components/FeedbackModal";
-import { CLOUD_ENABLED, getDeviceId, cloudPutSong, syncSongbook } from "@/lib/song-cloud";
-import { setSongs as writeLocalSongs } from "@/lib/song-bank";
+import { CLOUD_ENABLED, getDeviceId, setDeviceId, cloudPutSong, syncSongbook } from "@/lib/song-cloud";
+import { setSongs as writeLocalSongs, type SongBankEntry } from "@/lib/song-bank";
+import ImportSongbookDialog, { type ImportSongbookPayload } from "@/components/ImportSongbookDialog";
 import { autosaveToCloud, CloudSaveEvents } from "@/lib/cloud-autosave";
 import { getSongs, updateSong } from "@/lib/song-bank";
 import type { SongDTO } from "@/lib/song-cloud-types";
@@ -150,6 +151,73 @@ export default function Home() {
     window.alert(
       `Pushed ${pushed} song${pushed === 1 ? "" : "s"} to cloud.${failed > 0 ? `\n${failed} failed (see console).` : ""}\n\nOther devices can now sync to pick them back up.`,
     );
+  }, []);
+
+  // Import flow: file → parse → preview modal (Fork / Replace).
+  const songbookInputRef = useRef<HTMLInputElement | null>(null);
+  const [importPayload, setImportPayload] = useState<ImportSongbookPayload | null>(null);
+
+  const handleImportSongbookClick = useCallback(() => {
+    songbookInputRef.current?.click();
+  }, []);
+
+  const handleSongbookFileSelected = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-picking the same file
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      // Accept either { songs: [...] } (full export shape) or a bare
+      // array of song entries. Keeps the format forgiving.
+      const songs: SongBankEntry[] = Array.isArray(parsed)
+        ? parsed
+        : Array.isArray(parsed?.songs)
+          ? parsed.songs
+          : [];
+      if (songs.length === 0) {
+        window.alert("That file didn't contain any songs. Expected a JSON export from File → Export all songs.");
+        return;
+      }
+      // Light sanity check on the first entry's shape.
+      const sample = songs[0];
+      if (!sample || typeof sample.id !== "string" || typeof sample.title !== "string" || !sample.score) {
+        window.alert("That file doesn't look like a NotationApp songbook export. Expected entries with id / title / score fields.");
+        return;
+      }
+      setImportPayload({
+        fileName: file.name,
+        songs,
+        exportedAt: typeof parsed?.exportedAt === "string" ? parsed.exportedAt : undefined,
+        sourceDeviceId: typeof parsed?.deviceId === "string" ? parsed.deviceId : undefined,
+      });
+    } catch (err) {
+      console.warn("[import-songbook] parse failed", err);
+      window.alert(`Couldn't read that file as JSON: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, []);
+
+  const doImportSongs = useCallback(async (mode: "fork" | "replace", songs: SongBankEntry[]) => {
+    writeLocalSongs(songs);
+    if (mode === "fork" && CLOUD_ENABLED) {
+      // Fresh deviceId = fresh cloud partition. No songs land in the
+      // shared songbook on next sync; this device pushes up to its
+      // own brand-new bucket.
+      const fresh = (typeof crypto !== "undefined" && "randomUUID" in crypto)
+        ? crypto.randomUUID()
+        : `${Date.now().toString(16)}-${Math.random().toString(36).slice(2, 10)}`;
+      setDeviceId(fresh);
+    }
+    setImportPayload(null);
+    if (CLOUD_ENABLED) {
+      // Kick a sync so the cloud partition (fresh for fork, existing
+      // for replace) gets the imported songs pushed up.
+      try { await syncSongbook(); } catch { /* best-effort */ }
+    }
+    // Reload so every component re-reads localStorage state (deviceId,
+    // songs) from scratch — simpler than threading the change through
+    // every subscriber.
+    location.reload();
   }, []);
 
   // Bulk export: every local song as a single JSON file. Safety net
@@ -882,6 +950,7 @@ export default function Home() {
           onForcePushCloud={handleForcePushCloud}
           onExportAllSongs={handleExportAllSongs}
           onResetAndPullFromCloud={handleResetAndPullFromCloud}
+          onImportSongbook={handleImportSongbookClick}
           onPasteLyrics={() => setPasteLyricsOpen(true)}
           onMySongs={() => setMySongsOpen(true)}
           onSendFeedback={() => setFeedbackOpen(true)}
@@ -1427,6 +1496,25 @@ export default function Home() {
       {/* Autosave recovery dialog */}
       {autosaveDialogOpen && (
         <AutosaveRecoveryDialog onClose={() => setAutosaveDialogOpen(false)} />
+      )}
+
+      {/* Songbook JSON import — hidden file input + preview/choice modal */}
+      <input
+        ref={songbookInputRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        onChange={handleSongbookFileSelected}
+      />
+      {importPayload && (
+        <ImportSongbookDialog
+          payload={importPayload}
+          currentDeviceId={CLOUD_ENABLED ? getDeviceId() : ""}
+          currentLocalCount={getSongs().length}
+          onCancel={() => setImportPayload(null)}
+          onFork={() => doImportSongs("fork", importPayload.songs)}
+          onReplace={() => doImportSongs("replace", importPayload.songs)}
+        />
       )}
 
       {/* Join shared songbook prompt (from ?join=<deviceId> link) */}

--- a/src/components/ImportSongbookDialog.tsx
+++ b/src/components/ImportSongbookDialog.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { SongBankEntry } from "@/lib/song-bank";
+
+/**
+ * Choose how to handle an imported songbook JSON file:
+ *
+ *  - **Fork**: replace local songs AND generate a brand-new deviceId
+ *    so subsequent cloud syncs land in a fresh, isolated cloud
+ *    songbook. Use this to experiment on the same songs without
+ *    polluting your shared / primary songbook.
+ *
+ *  - **Replace**: replace local songs but KEEP the current deviceId.
+ *    Next sync pushes these songs up to your existing cloud
+ *    songbook (e.g. restoring from a backup file you previously
+ *    exported).
+ *
+ * Either way the current local song list is wiped; recommend the
+ * user back it up first via File → Export all songs.
+ */
+export interface ImportSongbookPayload {
+  fileName: string;
+  songs: SongBankEntry[];
+  /** Whatever metadata the export wrote (exportedAt, deviceId, etc.).
+   *  Surfaced to help the user spot mismatched files. */
+  exportedAt?: string;
+  sourceDeviceId?: string;
+}
+
+interface Props {
+  payload: ImportSongbookPayload;
+  currentDeviceId: string;
+  currentLocalCount: number;
+  onCancel: () => void;
+  onFork: () => void;
+  onReplace: () => void;
+}
+
+export default function ImportSongbookDialog({
+  payload,
+  currentDeviceId,
+  currentLocalCount,
+  onCancel,
+  onFork,
+  onReplace,
+}: Props) {
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        if (!busy) onCancel();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [busy, onCancel]);
+
+  const previewTitles = payload.songs.slice(0, 8).map((s) => s.title);
+
+  return (
+    <div
+      className="fixed inset-0 z-[130] flex items-start justify-center pt-[10vh] bg-black/40"
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!busy) onCancel();
+      }}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl border border-gray-200 w-[560px] max-w-[92vw] max-h-[80vh] flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-5 py-3 border-b border-gray-200">
+          <h2 className="text-base font-semibold text-gray-900">
+            Import {payload.songs.length} song{payload.songs.length === 1 ? "" : "s"}
+            {payload.fileName ? <span className="text-gray-500 font-normal"> from {payload.fileName}</span> : null}
+          </h2>
+          <p className="text-xs text-gray-500 mt-1">
+            This replaces your current local songbook ({currentLocalCount} song{currentLocalCount === 1 ? "" : "s"}).
+            Tip: File → Export all songs first if you haven&rsquo;t backed up.
+          </p>
+        </div>
+        <div className="flex-1 overflow-y-auto px-5 py-3 space-y-3">
+          {(payload.exportedAt || payload.sourceDeviceId) && (
+            <div className="text-xs text-gray-500 font-mono space-y-0.5">
+              {payload.exportedAt && (
+                <div>Exported: {payload.exportedAt}</div>
+              )}
+              {payload.sourceDeviceId && (
+                <div className="truncate">
+                  Source device: {payload.sourceDeviceId}
+                  {payload.sourceDeviceId === currentDeviceId && (
+                    <span className="text-amber-700 ml-2">(same as this device)</span>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+          <ul className="text-xs text-gray-700 space-y-0.5">
+            {previewTitles.map((t, i) => (
+              <li key={i} className="truncate">• {t}</li>
+            ))}
+            {payload.songs.length > 8 && (
+              <li className="italic text-gray-400">…and {payload.songs.length - 8} more</li>
+            )}
+          </ul>
+        </div>
+        <div className="px-5 py-3 border-t border-gray-200 space-y-2 bg-gray-50">
+          <button
+            type="button"
+            onClick={() => {
+              setBusy(true);
+              onFork();
+            }}
+            disabled={busy}
+            className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:bg-gray-300 rounded-lg text-left"
+          >
+            <div className="font-semibold">Fork — isolate this device (recommended)</div>
+            <div className="text-xs font-normal opacity-80 mt-0.5">
+              Generates a brand-new device id. Changes here won&rsquo;t reach your other devices. Use to experiment on the same songs without affecting your shared songbook.
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setBusy(true);
+              onReplace();
+            }}
+            disabled={busy}
+            className="w-full px-4 py-2 text-sm text-gray-800 border border-gray-300 hover:bg-gray-100 active:bg-gray-200 disabled:bg-gray-100 disabled:cursor-not-allowed rounded-lg text-left"
+          >
+            <div className="font-semibold">Replace — keep current device id</div>
+            <div className="text-xs font-normal text-gray-500 mt-0.5">
+              Loads the imported songs and pushes them to your existing shared songbook on next sync. Use to restore from a backup of THIS device.
+            </div>
+          </button>
+          <div className="flex items-center justify-end pt-1">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={busy}
+              className="px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 active:bg-gray-200 rounded-lg"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -24,6 +24,7 @@ interface MenuBarProps {
   onOpenAutosave?: () => void;
   onForcePushCloud?: () => void;
   onExportAllSongs?: () => void;
+  onImportSongbook?: () => void;
   onResetAndPullFromCloud?: () => void;
   onPasteLyrics?: () => void;
   onMySongs?: () => void;
@@ -122,7 +123,7 @@ function MenuDropdown({ label, items, isOpen, onToggle, onClose, onItemClick }: 
 
 export default function MenuBar({
   zoom, onZoomChange, onPrint, onOpenAutosave, onForcePushCloud,
-  onExportAllSongs, onResetAndPullFromCloud,
+  onExportAllSongs, onImportSongbook, onResetAndPullFromCloud,
   onPasteLyrics, onMySongs, onApiKeys,
   onToggleSidebar, sidebarOpen, onSendFeedback,
 }: MenuBarProps) {
@@ -367,6 +368,12 @@ export default function MenuBar({
     // Bulk backup — exports every local song as a single JSON file.
     // Always-safe operation; run before any destructive cloud action.
     { label: "Export all songs (backup)...", action: () => onExportAllSongs?.() },
+    // Pairs with Export: read a previously-exported JSON file and
+    // load it as the local songbook. Fork mode (default) gives this
+    // device a fresh deviceId so changes don't push back to your
+    // shared songbook — use it to experiment on the same songs in
+    // isolation.
+    { label: "Import songbook from JSON...", action: () => onImportSongbook?.() },
     // Force-pushes every local song to cloud without expectedVersion,
     // bypassing the My Songs sync flow that would otherwise tombstone
     // local entries when cloud has been wiped on another device.


### PR DESCRIPTION
## Summary

Pairs with the existing **Export all songs**. Reads a previously-exported songbook JSON file and loads it as the local songbook, with two modes:

- **Fork** (default, recommended for experimentation): wipes local songs, loads the imported ones, AND generates a fresh deviceId. The next cloud sync lands in a brand-new partition — changes on this device don't reach your shared songbook. Use case: work on the same songs in isolation, e.g. on a dev environment without polluting prod.
- **Replace**: wipes local songs, loads the imported ones, but KEEPS the current deviceId. Next sync pushes them up to your existing shared songbook — for restoring this device from a backup.

Accepts either the full export shape (`{ version, exportedAt, songs }`) or a bare array of song entries. Validates the first entry's shape before accepting. Preview modal shows file name, song count, first 8 titles, source deviceId vs. current — easy to spot mismatches.

After import: runs a sync (so the new/current partition gets the songs pushed up) then reloads.

95 tests pass. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)