### PR TITLE
Auto-scroll: green per-bar highlight as bars are 'played'

### DIFF
--- a/src/components/ChordChartView.tsx
+++ b/src/components/ChordChartView.tsx
@@ -59,6 +59,10 @@ interface ChordChartViewProps {
   /** On-screen column count (1 or 2). Only consulted when performMode is on;
    *  defaults to 1. PerformView toggles this for landscape layouts. */
   performColumns?: 1 | 2;
+  /** Optional currently-playing bar position from PerformView's auto-scroll
+   *  loop. Rendered as a green overlay over the bar's char-column range on
+   *  the matching line. `null` = no highlight. */
+  activeBar?: { sectionIdx: number; lineIdx: number; startCol: number; endCol: number } | null;
 }
 
 interface EditState {
@@ -111,6 +115,7 @@ function SectionBlock({
   labelPosition,
   headerFont,
   chartFont,
+  activeBarInSection,
 }: {
   section: ChordChartSection;
   onLineClick: (sectionId: string, lineIdx: number, col: number) => void;
@@ -129,6 +134,9 @@ function SectionBlock({
   labelPosition: LabelPosition;
   headerFont: TextFont;
   chartFont: ChartFont;
+  /** When the auto-scroll playhead is on a bar belonging to THIS section,
+   *  this is the line + column range to highlight. null otherwise. */
+  activeBarInSection: { lineIdx: number; startCol: number; endCol: number } | null;
 }) {
   // Side-label modes use a flex row with the rotated label centered against
   // the section content. Tight gap so the label sits close to the lyrics.
@@ -203,8 +211,24 @@ function SectionBlock({
             line.highlight ? "bg-yellow-300/20 -mx-2 px-2 rounded" : "",
             line.underline ? "border-b-2 border-yellow-400/80" : "",
           ].filter(Boolean).join(" ");
+          const isActiveBarLine = !!activeBarInSection && activeBarInSection.lineIdx === i;
           return (
             <div key={i} className={`mb-2 relative ${markerClasses}`}>
+              {/* Auto-scroll bar-highlight overlay. Positioned by character
+                  column (1ch = one monospace char width); covers the full
+                  vertical extent of this line (chord row + lyric row),
+                  behind both via z-0. Stays out of the way of clicks
+                  via pointer-events:none. */}
+              {isActiveBarLine && (
+                <div
+                  className="absolute top-0 bottom-0 bg-green-400/30 border border-green-400/60 rounded pointer-events-none z-0 transition-all duration-100"
+                  style={{
+                    left: `${activeBarInSection!.startCol}ch`,
+                    width: `${Math.max(1, activeBarInSection!.endCol - activeBarInSection!.startCol)}ch`,
+                  }}
+                  aria-hidden
+                />
+              )}
               {isEditingThisLine && (
                 <div
                   className="absolute top-0 bottom-0 w-px bg-pink-400 pointer-events-none z-0"
@@ -817,7 +841,7 @@ interface HeaderContextMenuState {
   y: number;
 }
 
-export default function ChordChartView({ score, performMode = false, performColumns = 1 }: ChordChartViewProps) {
+export default function ChordChartView({ score, performMode = false, performColumns = 1, activeBar = null }: ChordChartViewProps) {
   const applyPatches = useScoreStore((s) => s.applyPatches);
   const [editing, setEditing] = useState<EditState | null>(null);
   const [textEditing, setTextEditing] = useState<TextEditState | null>(null);
@@ -1557,7 +1581,7 @@ export default function ChordChartView({ score, performMode = false, performColu
         </div>
       ) : (
         <>
-          {displayOrder.map(section => (
+          {displayOrder.map((section, sIdx) => (
             <SectionBlock
               key={section.id}
               section={section}
@@ -1577,6 +1601,11 @@ export default function ChordChartView({ score, performMode = false, performColu
               labelPosition={labelPosition}
               headerFont={headerFont}
               chartFont={chartFont}
+              activeBarInSection={
+                activeBar && activeBar.sectionIdx === sIdx
+                  ? { lineIdx: activeBar.lineIdx, startCol: activeBar.startCol, endCol: activeBar.endCol }
+                  : null
+              }
             />
           ))}
           {!performMode && (

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -9,6 +9,11 @@ import AnnotateToggle from "@/components/AnnotateToggle";
 import { useScoreStore } from "@/store/score-store";
 import { getSongs, SongsUpdatedEvent, type SongBankEntry } from "@/lib/song-bank";
 import { getSets, SetsUpdatedEvent, songSetMembership, type SongSet } from "@/lib/song-sets";
+import {
+  activeBarFromElapsed,
+  beatsPerBarOf,
+  computeBarInventory,
+} from "@/lib/chord-bar-inventory";
 
 const PREFS_KEY = "notation-app-perform-prefs";
 
@@ -198,6 +203,22 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   const songTempo = score?.tempo ?? 0;
   const tempoFactor = songTempo > 0 ? songTempo / 120 : 1;
   const effectiveScrollSpeed = prefs.scrollSpeed * tempoFactor;
+
+  // Bar inventory drives the green per-bar highlight overlay during
+  // auto-scroll. Computed once per score; activeBarIdx is the only
+  // value that changes during the RAF loop, and it only changes
+  // ~once per bar (~once every 2 seconds at 120 BPM 4/4) — far less
+  // often than every frame, so React reconciliation stays cheap.
+  const barInventory = useMemo(
+    () => (score ? computeBarInventory(score) : []),
+    [score],
+  );
+  const beatsPerBar = useMemo(
+    () => beatsPerBarOf(score?.timeSignature),
+    [score?.timeSignature],
+  );
+  const autoScrollElapsedRef = useRef(0);
+  const [activeBarIdx, setActiveBarIdx] = useState<number | null>(null);
   // Track the fractional pixel position separately from element
   // scrollTop, which only accepts integers — without this, slow speeds
   // (e.g. 5 px/sec ≈ 0.08 px/frame) would round to 0 every frame and
@@ -205,11 +226,29 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   const scrollAccumRef = useRef(0);
 
   useEffect(() => {
-    if (!autoScroll) return;
+    if (!autoScroll) {
+      // Reset elapsed when scroll stops, so a re-press of play starts
+      // bar tracking from bar 0 again (matches the user expectation:
+      // pause+play = "play from where I am visually" — and the active
+      // bar starts from the visual top).
+      autoScrollElapsedRef.current = 0;
+      setActiveBarIdx(null);
+      return;
+    }
     let lastTime = performance.now();
     const step = (now: number) => {
       const dt = (now - lastTime) / 1000;
       lastTime = now;
+      autoScrollElapsedRef.current += dt;
+      // Active bar derivation — only setState when the value changes
+      // so we don't churn the chord chart every frame.
+      const nextBarIdx = activeBarFromElapsed(
+        barInventory,
+        autoScrollElapsedRef.current,
+        songTempo,
+        beatsPerBar,
+      );
+      setActiveBarIdx((prev) => (prev === nextBarIdx ? prev : nextBarIdx));
       const delta = effectiveScrollSpeed * dt;
       scrollAccumRef.current += delta;
       if (scrollAccumRef.current >= 1) {
@@ -242,7 +281,7 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
       }
       scrollAccumRef.current = 0;
     };
-  }, [autoScroll, effectiveScrollSpeed, prefs.columns]);
+  }, [autoScroll, effectiveScrollSpeed, prefs.columns, barInventory, songTempo, beatsPerBar]);
 
   // Manual pager / picker / Escape should all pause auto-scroll so the
   // user isn't fighting the loop while interacting with the chrome.
@@ -328,7 +367,12 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
           className="absolute inset-0 overflow-auto pt-[7vh] pb-16"
         >
           <div className="relative">
-            <ChordChartView score={score} performMode performColumns={1} />
+            <ChordChartView
+              score={score}
+              performMode
+              performColumns={1}
+              activeBar={activeBarIdx !== null ? barInventory[activeBarIdx] ?? null : null}
+            />
             <AnnotationLayer />
           </div>
         </div>

--- a/src/lib/__tests__/chord-bar-inventory.test.ts
+++ b/src/lib/__tests__/chord-bar-inventory.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import type { Score } from "@/lib/schema";
+import {
+  computeBarInventory,
+  beatsPerBarOf,
+  activeBarFromElapsed,
+} from "@/lib/chord-bar-inventory";
+
+// Minimal Score factory — only the fields chord-bar-inventory looks at.
+function score(
+  sections: Array<{ id: string; label?: string; lines: Array<{ chords?: string; lyrics?: string }> }>,
+): Score {
+  return { sections } as unknown as Score;
+}
+
+describe("computeBarInventory", () => {
+  it("returns empty for a score with no sections", () => {
+    expect(computeBarInventory({} as Score)).toEqual([]);
+  });
+
+  it("counts N-1 bars for a line with N pipes", () => {
+    // "| C | F | G |" → 4 pipes → 3 bars
+    const s = score([
+      { id: "v", lines: [{ chords: "| C | F | G |" }] },
+    ]);
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(3);
+    expect(inv.map((b) => [b.startCol, b.endCol])).toEqual([
+      [0, 4],
+      [4, 8],
+      [8, 12],
+    ]);
+  });
+
+  it("skips lines with zero or one pipe", () => {
+    // First line: no pipes → 0 bars. Second line: 1 pipe → 0 bars.
+    // Third line: 2 pipes → 1 bar.
+    const s = score([
+      {
+        id: "v",
+        lines: [
+          { chords: "G D Em C" },
+          { chords: "Am | C" },
+          { chords: "| C |" },
+        ],
+      },
+    ]);
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(1);
+    expect(inv[0]).toMatchObject({ sectionIdx: 0, lineIdx: 2, startCol: 0, endCol: 4 });
+  });
+
+  it("preserves section + line ordering across the song", () => {
+    const s = score([
+      { id: "v", lines: [{ chords: "| C |" }] },           // 1 bar  (global 0)
+      { id: "c", lines: [
+        { chords: "| F | G |" },                            // 2 bars (global 1, 2)
+        { chords: "| C |" },                                // 1 bar  (global 3)
+      ] },
+    ]);
+    const inv = computeBarInventory(s);
+    expect(inv.map((b) => [b.globalIdx, b.sectionIdx, b.lineIdx])).toEqual([
+      [0, 0, 0],
+      [1, 1, 0],
+      [2, 1, 0],
+      [3, 1, 1],
+    ]);
+  });
+
+  it("tolerates pipes at non-zero starting columns", () => {
+    // chord line starts with a chord, then has bars later
+    const s = score([
+      { id: "v", lines: [{ chords: "G   | C | F |" }] },
+    ]);
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(2);
+    expect(inv[0].startCol).toBe(4);
+    expect(inv[1].startCol).toBe(8);
+  });
+});
+
+describe("beatsPerBarOf", () => {
+  it("returns the numerator of a standard time signature", () => {
+    expect(beatsPerBarOf("4/4")).toBe(4);
+    expect(beatsPerBarOf("3/4")).toBe(3);
+    expect(beatsPerBarOf("6/8")).toBe(6);
+    expect(beatsPerBarOf("12/8")).toBe(12);
+  });
+  it("falls back to 4 for missing / malformed values", () => {
+    expect(beatsPerBarOf(undefined)).toBe(4);
+    expect(beatsPerBarOf(null)).toBe(4);
+    expect(beatsPerBarOf("")).toBe(4);
+    expect(beatsPerBarOf("garbage")).toBe(4);
+    expect(beatsPerBarOf("0/4")).toBe(4);
+  });
+});
+
+describe("activeBarFromElapsed", () => {
+  const inv = [
+    { globalIdx: 0, sectionIdx: 0, lineIdx: 0, startCol: 0, endCol: 4 },
+    { globalIdx: 1, sectionIdx: 0, lineIdx: 0, startCol: 4, endCol: 8 },
+    { globalIdx: 2, sectionIdx: 0, lineIdx: 0, startCol: 8, endCol: 12 },
+  ];
+
+  it("returns 0 at t=0", () => {
+    expect(activeBarFromElapsed(inv, 0, 120, 4)).toBe(0);
+  });
+
+  it("advances by one bar every beatsPerBar / (tempo/60) seconds", () => {
+    // At 120 BPM, 4 beats per bar → 2 seconds per bar.
+    expect(activeBarFromElapsed(inv, 1.99, 120, 4)).toBe(0);
+    expect(activeBarFromElapsed(inv, 2.0, 120, 4)).toBe(1);
+    expect(activeBarFromElapsed(inv, 4.0, 120, 4)).toBe(2);
+  });
+
+  it("returns null when elapsed runs past the end of the inventory", () => {
+    // 3 bars × 2 s/bar = 6 s total at 120 BPM 4/4.
+    expect(activeBarFromElapsed(inv, 6.0, 120, 4)).toBeNull();
+    expect(activeBarFromElapsed(inv, 10.0, 120, 4)).toBeNull();
+  });
+
+  it("returns null when inventory is empty or tempo is zero", () => {
+    expect(activeBarFromElapsed([], 5, 120, 4)).toBeNull();
+    expect(activeBarFromElapsed(inv, 5, 0, 4)).toBeNull();
+    expect(activeBarFromElapsed(inv, 5, 120, 0)).toBeNull();
+  });
+
+  it("scales with tempo (slower BPM advances slower)", () => {
+    // 60 BPM, 4/4 → 4 seconds per bar.
+    expect(activeBarFromElapsed(inv, 3.99, 60, 4)).toBe(0);
+    expect(activeBarFromElapsed(inv, 4.0, 60, 4)).toBe(1);
+  });
+});

--- a/src/lib/chord-bar-inventory.ts
+++ b/src/lib/chord-bar-inventory.ts
@@ -1,0 +1,87 @@
+/**
+ * Flat list of every bar in a chord-chart score, in playback order.
+ *
+ * A "bar" is the column range from one `|` marker (inclusive) up to
+ * the next `|` (exclusive). N pipes on a line → N-1 bars. Lines
+ * without `|` markers contribute zero bars; lines with one `|` also
+ * contribute zero (no closing barline). This keeps the inventory
+ * grounded in explicit bar markers — songs that pre-date barline
+ * editing fall back to constant-rate scroll without highlighting.
+ *
+ * Used by:
+ *  - PerformView's auto-scroll loop to derive the active bar from
+ *    elapsed time × BPM (one bar = `beatsPerBar` beats).
+ *  - ChordChartView to render the active bar's green overlay at the
+ *    correct char-column range on the correct line.
+ */
+
+import type { Score } from "@/lib/schema";
+
+export interface BarPos {
+  /** Index into the flat inventory list (0-based, global across the song). */
+  globalIdx: number;
+  /** Index of the section in score.sections[]. */
+  sectionIdx: number;
+  /** Index of the line within the section's lines[]. */
+  lineIdx: number;
+  /** Inclusive start column in the chord line (the leading `|`). */
+  startCol: number;
+  /** Exclusive end column (the next `|`). Use endCol - startCol for the bar's character width. */
+  endCol: number;
+}
+
+export function computeBarInventory(score: Score): BarPos[] {
+  const out: BarPos[] = [];
+  const sections = score.sections ?? [];
+  for (let si = 0; si < sections.length; si++) {
+    const lines = sections[si].lines ?? [];
+    for (let li = 0; li < lines.length; li++) {
+      const chords = lines[li].chords ?? "";
+      const pipes: number[] = [];
+      for (let c = 0; c < chords.length; c++) {
+        if (chords[c] === "|") pipes.push(c);
+      }
+      for (let p = 0; p < pipes.length - 1; p++) {
+        out.push({
+          globalIdx: out.length,
+          sectionIdx: si,
+          lineIdx: li,
+          startCol: pipes[p],
+          endCol: pipes[p + 1],
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse a time-signature string like "4/4" / "6/8" / "12/8". Returns
+ * the numerator (beats per bar). Defaults to 4 on parse failure so
+ * autoscroll never explodes on weird input.
+ */
+export function beatsPerBarOf(timeSignature: string | undefined | null): number {
+  if (!timeSignature) return 4;
+  const [num] = timeSignature.split("/");
+  const n = parseInt(num ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : 4;
+}
+
+/**
+ * Given a tempo (BPM) and beats-per-bar, return the active bar index
+ * for an `elapsedSec` reading. Returns null when the elapsed time
+ * runs past the end of the inventory (caller can pause auto-scroll).
+ */
+export function activeBarFromElapsed(
+  inventory: readonly BarPos[],
+  elapsedSec: number,
+  tempo: number,
+  beatsPerBar: number,
+): number | null {
+  if (inventory.length === 0 || tempo <= 0 || beatsPerBar <= 0) return null;
+  const beats = elapsedSec * (tempo / 60);
+  const idx = Math.floor(beats / beatsPerBar);
+  if (idx < 0) return 0;
+  if (idx >= inventory.length) return null;
+  return idx;
+}


### PR DESCRIPTION
## Summary

Builds on the tempo-aware scroll from #130. While auto-scroll is active, the active bar gets a green overlay covering its char-column range; advances every `(60/bpm) × beatsPerBar` seconds, in lockstep with the song's tempo. Closes the "where am I in the song?" feedback gap.

### Pieces

- **New `src/lib/chord-bar-inventory.ts`** — pure helpers:
  - `computeBarInventory(score)` emits a flat playback-order list of bars: `{ globalIdx, sectionIdx, lineIdx, startCol, endCol }`. Bar = column range from one `|` (inclusive) to the next `|` (exclusive). N pipes → N-1 bars; lines without bar markers contribute nothing.
  - `activeBarFromElapsed(inv, t, bpm, beatsPerBar)` returns the active bar index or `null` (past end / zero tempo).
  - `beatsPerBarOf(timeSig)` parses `"4/4"` etc.; defaults to 4.

- **12 unit tests** cover the inventory shape, edge cases (0 / 1 pipe lines, varying section orders, mid-line starts), the tempo/time-sig math, and past-the-end + zero-tempo null returns.

- **PerformView** tracks `autoScrollElapsedRef` during the RAF loop, derives the active bar, and only `setState`s on bar change — re-renders happen every ~2 seconds at typical tempos, not every frame. Resets to null on pause.

- **ChordChartView** accepts an `activeBar` prop, threads it into `SectionBlock` as `activeBarInSection`. The matching line gets a semi-transparent green overlay (positioned by `1ch` column units, full line height, behind chord/lyric text via z-0 + pointer-events-none). `transition-duration-100` gives a soft fade between bars.

### Behaviour for songs without bar markers
Unchanged from #130 — tempo-scaled constant scroll, no highlight. Bar markers in chord lines (added via the existing `|` editing flow) unlock the green playhead.

### Known v1 limitation
Play always starts from bar 0. If the user scrolled mid-song before pressing play, the highlight lands above the visible area until elapsed catches up. Worth a follow-up ("start at top-most visible bar"). Calling it out so you can decide whether to ship now or hold.

107 tests pass. Type check clean. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)