### PR TITLE
Auto-scroll: highlight bar-line char only, not whole bar

### DIFF
--- a/src/components/ChordChartView.tsx
+++ b/src/components/ChordChartView.tsx
@@ -214,17 +214,17 @@ function SectionBlock({
           const isActiveBarLine = !!activeBarInSection && activeBarInSection.lineIdx === i;
           return (
             <div key={i} className={`mb-2 relative ${markerClasses}`}>
-              {/* Auto-scroll bar-highlight overlay. Positioned by character
-                  column (1ch = one monospace char width); covers the full
-                  vertical extent of this line (chord row + lyric row),
-                  behind both via z-0. Stays out of the way of clicks
-                  via pointer-events:none. */}
+              {/* Auto-scroll playhead: lights the bar-line `|` character
+                  itself (1ch wide at startCol) when this bar is active.
+                  Narrow target — no whole-bar tint, no animated slide
+                  across intermediate columns that could read as "skipped".
+                  Stays out of click handling via pointer-events:none. */}
               {isActiveBarLine && (
                 <div
-                  className="absolute top-0 bottom-0 bg-green-400/30 border border-green-400/60 rounded pointer-events-none z-0 transition-all duration-100"
+                  className="absolute top-0 bottom-0 bg-green-400/70 rounded-sm pointer-events-none z-0"
                   style={{
                     left: `${activeBarInSection!.startCol}ch`,
-                    width: `${Math.max(1, activeBarInSection!.endCol - activeBarInSection!.startCol)}ch`,
+                    width: `1ch`,
                   }}
                   aria-hidden
                 />


### PR DESCRIPTION
## Summary

Per feedback on #131: narrow the active-bar overlay from the full bar-width range to **1ch wide on the leading `|` character**. As bars play, just the `|` marker lights green — no whole-bar tint, no animated slide across intermediate columns that could read as "skipping".

Also drops the `transition-all duration-100` slide animation so the highlight switches discretely between bars instead of sliding.

107 tests pass. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)