### PR TITLE
Auto-scroll: lock scroll to bar transitions + perform-tempo override

### DIFF
--- a/src/components/ChordChartView.tsx
+++ b/src/components/ChordChartView.tsx
@@ -213,7 +213,16 @@ function SectionBlock({
           ].filter(Boolean).join(" ");
           const isActiveBarLine = !!activeBarInSection && activeBarInSection.lineIdx === i;
           return (
-            <div key={i} className={`mb-2 relative ${markerClasses}`}>
+            <div
+              key={i}
+              className={`mb-2 relative ${markerClasses}`}
+              // Addressable by PerformView's scroll-track-active-bar
+              // effect. Uses stable section id (not idx) so reorders
+              // don't break the lookup. Lyric-only / blank lines also
+              // carry this attribute — cheap, lets future features
+              // (e.g. lyrics-line-aware features) reuse the addressing.
+              data-bar-line={`${section.id}-${i}`}
+            >
               {/* Auto-scroll playhead: lights the bar-line `|` character
                   itself (1ch wide at startCol) when this bar is active.
                   Narrow target — no whole-bar tint, no animated slide

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -201,7 +201,17 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   // as bars are "played") is a follow-up slice — needs ChordChartView
   // to split chord-line text into per-bar spans first.
   const songTempo = score?.tempo ?? 0;
-  const tempoFactor = songTempo > 0 ? songTempo / 120 : 1;
+  // Perform-mode tempo override — for practicing slower without
+  // mutating the song's saved tempo. Resets when the loaded song
+  // changes so a slow rehearsal of Song A doesn't leak into Song B.
+  // null = use song's tempo; otherwise this value drives both the
+  // scroll rate AND the bar-highlight advance rate.
+  const [performTempoOverride, setPerformTempoOverride] = useState<number | null>(null);
+  useEffect(() => {
+    setPerformTempoOverride(null);
+  }, [score?.id]);
+  const effectiveTempo = performTempoOverride ?? songTempo;
+  const tempoFactor = effectiveTempo > 0 ? effectiveTempo / 120 : 1;
   const effectiveScrollSpeed = prefs.scrollSpeed * tempoFactor;
 
   // Bar inventory drives the green per-bar highlight overlay during
@@ -245,29 +255,38 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
       const nextBarIdx = activeBarFromElapsed(
         barInventory,
         autoScrollElapsedRef.current,
-        songTempo,
+        effectiveTempo,
         beatsPerBar,
       );
       setActiveBarIdx((prev) => (prev === nextBarIdx ? prev : nextBarIdx));
-      const delta = effectiveScrollSpeed * dt;
-      scrollAccumRef.current += delta;
-      if (scrollAccumRef.current >= 1) {
-        const whole = Math.floor(scrollAccumRef.current);
-        scrollAccumRef.current -= whole;
-        if (prefs.columns === 2) {
-          const el = horizScrollRef.current;
-          if (el) {
-            const max = el.scrollWidth - el.clientWidth;
-            el.scrollLeft = Math.min(max, el.scrollLeft + whole);
-            // Stop at end of page strip rather than spinning.
-            if (el.scrollLeft >= max) setAutoScroll(false);
-          }
-        } else {
-          const el = scrollRef.current;
-          if (el) {
-            const max = el.scrollHeight - el.clientHeight;
-            el.scrollTop = Math.min(max, el.scrollTop + whole);
-            if (el.scrollTop >= max) setAutoScroll(false);
+      // Constant px/sec scroll — used ONLY when the song has no bar
+      // inventory (no `|` markers OR no tempo). With bar tracking
+      // active, scroll is driven by the separate scroll-to-line
+      // effect below so it stays locked to bar transitions instead
+      // of drifting at an independent rate (which was the "skipping
+      // measures" perception — highlight and scroll moving at
+      // different speeds caused bars to slide off-screen before the
+      // user saw them flash).
+      if (barInventory.length === 0 || effectiveTempo <= 0) {
+        const delta = effectiveScrollSpeed * dt;
+        scrollAccumRef.current += delta;
+        if (scrollAccumRef.current >= 1) {
+          const whole = Math.floor(scrollAccumRef.current);
+          scrollAccumRef.current -= whole;
+          if (prefs.columns === 2) {
+            const el = horizScrollRef.current;
+            if (el) {
+              const max = el.scrollWidth - el.clientWidth;
+              el.scrollLeft = Math.min(max, el.scrollLeft + whole);
+              if (el.scrollLeft >= max) setAutoScroll(false);
+            }
+          } else {
+            const el = scrollRef.current;
+            if (el) {
+              const max = el.scrollHeight - el.clientHeight;
+              el.scrollTop = Math.min(max, el.scrollTop + whole);
+              if (el.scrollTop >= max) setAutoScroll(false);
+            }
           }
         }
       }
@@ -281,7 +300,30 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
       }
       scrollAccumRef.current = 0;
     };
-  }, [autoScroll, effectiveScrollSpeed, prefs.columns, barInventory, songTempo, beatsPerBar]);
+  }, [autoScroll, effectiveScrollSpeed, prefs.columns, barInventory, effectiveTempo, beatsPerBar]);
+
+  // Scroll-to-active-line: when the active bar's line changes,
+  // smooth-scroll the chord chart so that line is centered in view.
+  // Only fires once per line transition (not per bar within a line),
+  // so reading stays still while the playhead walks the bars on a
+  // line, then advances to the next line in lockstep with the music.
+  const lastScrolledLineRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!autoScroll) {
+      lastScrolledLineRef.current = null;
+      return;
+    }
+    if (activeBarIdx === null) return;
+    const bar = barInventory[activeBarIdx];
+    if (!bar) return;
+    const lineKey = `${bar.sectionId}-${bar.lineIdx}`;
+    if (lineKey === lastScrolledLineRef.current) return;
+    lastScrolledLineRef.current = lineKey;
+    const el = document.querySelector(`[data-bar-line="${CSS.escape(lineKey)}"]`);
+    if (el instanceof HTMLElement) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [autoScroll, activeBarIdx, barInventory]);
 
   // Manual pager / picker / Escape should all pause auto-scroll so the
   // user isn't fighting the loop while interacting with the chrome.
@@ -764,6 +806,53 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
             ⊕
           </button>
         </div>
+        {/* Perform-tempo override cluster — adjust tempo just for
+            this performance (e.g. practice slower). Does NOT save
+            back to the song; resets when you load a different song.
+            ♩ button reverts to the song's saved tempo. Only shown
+            when the song has a tempo set. */}
+        {songTempo > 0 && (
+          <div className="flex items-center gap-1 bg-gray-900/80 backdrop-blur-sm rounded-xl p-1 shadow border border-white/10">
+            <button
+              type="button"
+              onClick={() =>
+                setPerformTempoOverride((cur) => Math.max(20, (cur ?? songTempo) - 5))
+              }
+              className={btn}
+              aria-label="Slower tempo"
+              title={`Slower (${Math.max(20, effectiveTempo - 5)} bpm)`}
+            >
+              ♩−
+            </button>
+            <button
+              type="button"
+              onClick={() => setPerformTempoOverride(null)}
+              disabled={performTempoOverride === null}
+              className="h-11 px-3 flex items-center text-sm font-medium text-gray-100 hover:bg-gray-800 active:bg-gray-700 rounded-lg disabled:opacity-60 disabled:cursor-default"
+              title={
+                performTempoOverride === null
+                  ? `Song tempo: ${songTempo} bpm`
+                  : `Click to reset to song tempo (${songTempo} bpm)`
+              }
+            >
+              {effectiveTempo} bpm
+              {performTempoOverride !== null && (
+                <span className="ml-1.5 text-[9px] uppercase tracking-wider opacity-60">⟲</span>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setPerformTempoOverride((cur) => Math.min(300, (cur ?? songTempo) + 5))
+              }
+              className={btn}
+              aria-label="Faster tempo"
+              title={`Faster (${Math.min(300, effectiveTempo + 5)} bpm)`}
+            >
+              ♩+
+            </button>
+          </div>
+        )}
         {onOpenMySongs && (
           <button
             type="button"

--- a/src/lib/__tests__/chord-bar-inventory.test.ts
+++ b/src/lib/__tests__/chord-bar-inventory.test.ts
@@ -118,9 +118,9 @@ describe("beatsPerBarOf", () => {
 
 describe("activeBarFromElapsed", () => {
   const inv = [
-    { globalIdx: 0, sectionIdx: 0, lineIdx: 0, startCol: 0, endCol: 4 },
-    { globalIdx: 1, sectionIdx: 0, lineIdx: 0, startCol: 4, endCol: 8 },
-    { globalIdx: 2, sectionIdx: 0, lineIdx: 0, startCol: 8, endCol: 12 },
+    { globalIdx: 0, sectionIdx: 0, sectionId: "v", lineIdx: 0, startCol: 0, endCol: 4 },
+    { globalIdx: 1, sectionIdx: 0, sectionId: "v", lineIdx: 0, startCol: 4, endCol: 8 },
+    { globalIdx: 2, sectionIdx: 0, sectionId: "v", lineIdx: 0, startCol: 8, endCol: 12 },
   ];
 
   it("returns 0 at t=0", () => {

--- a/src/lib/chord-bar-inventory.ts
+++ b/src/lib/chord-bar-inventory.ts
@@ -22,6 +22,9 @@ export interface BarPos {
   globalIdx: number;
   /** Index of the section in score.sections[]. */
   sectionIdx: number;
+  /** Stable section id (matches Score.sections[i].id). Used to address
+   *  the DOM line wrapper when PerformView scroll-tracks the active bar. */
+  sectionId: string;
   /** Index of the line within the section's lines[]. */
   lineIdx: number;
   /** Inclusive start column in the chord line (the leading `|`). */
@@ -45,6 +48,7 @@ export function computeBarInventory(score: Score): BarPos[] {
         out.push({
           globalIdx: out.length,
           sectionIdx: si,
+          sectionId: sections[si].id,
           lineIdx: li,
           startCol: pipes[p],
           endCol: pipes[p + 1],


### PR DESCRIPTION
## Summary

Two fixes for issues hit on the Twig test.

### 1) "Skipping measures" — really a scroll/highlight drift
Wasn't a missing-bar bug. The constant px/sec scroll and the tempo-driven bar-highlight ran at independent rates, so the highlight drifted off-screen between visible flashes.

**Fix**: when the song has both a tempo *and* bar inventory, scroll is driven by the active bar's line instead of constant px/sec. Scroll-to-line fires **once per LINE transition** (not per bar inside a line) — the page stays still while the playhead walks bars across the current line, then `scrollIntoView({block: 'center'})` advances to the next line in view. Songs without bar markers fall back to constant tempo-scaled scroll (unchanged).

- `BarPos` now carries `sectionId` (stable id, not just index) so DOM lookups survive section reorder.
- `ChordChartView` stamps `data-bar-line="<sectionId>-<lineIdx>"` on each line wrapper.
- New PerformView effect dedupes via `lastScrolledLineRef` so within-line bar transitions don't re-trigger scroll.

### 2) Perform-mode tempo override
Toolbar cluster `♩−` / `130 bpm` / `♩+` lets you slow down or speed up **this performance** without touching the saved song tempo. Click the bpm label to reset. Resets automatically when the loaded song changes. Flows through both scroll rate AND bar-highlight advance rate.

108 tests pass. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)