### PR TITLE
Bar inventory: count chord-content edges as implicit bars

### DIFF
--- a/src/lib/__tests__/chord-bar-inventory.test.ts
+++ b/src/lib/__tests__/chord-bar-inventory.test.ts
@@ -32,22 +32,29 @@ describe("computeBarInventory", () => {
     ]);
   });
 
-  it("skips lines with zero or one pipe", () => {
-    // First line: no pipes → 0 bars. Second line: 1 pipe → 0 bars.
-    // Third line: 2 pipes → 1 bar.
+  it("contributes zero bars for a line with no pipes (no bar markers)", () => {
+    // Without any | the parser has no anchors — fall back to constant
+    // tempo-scaled scroll. User must add | markers to enable bar
+    // tracking on a chord line.
     const s = score([
-      {
-        id: "v",
-        lines: [
-          { chords: "G D Em C" },
-          { chords: "Am | C" },
-          { chords: "| C |" },
-        ],
-      },
+      { id: "v", lines: [{ chords: "G D Em C" }] },
+    ]);
+    expect(computeBarInventory(s)).toEqual([]);
+  });
+
+  it("counts 'Am | C' as 2 bars (implicit leading + trailing)", () => {
+    // Both sides have chord content outside the single pipe — both
+    // edges become bars. Was 0 under the old strict-pipe-bracketed
+    // model; now correctly 2.
+    const s = score([
+      { id: "v", lines: [{ chords: "Am | C" }] },
     ]);
     const inv = computeBarInventory(s);
-    expect(inv).toHaveLength(1);
-    expect(inv[0]).toMatchObject({ sectionIdx: 0, lineIdx: 2, startCol: 0, endCol: 4 });
+    expect(inv).toHaveLength(2);
+    expect(inv.map((b) => [b.startCol, b.endCol])).toEqual([
+      [0, 3],  // Am
+      [3, 6],  // | C
+    ]);
   });
 
   it("preserves section + line ordering across the song", () => {
@@ -88,15 +95,63 @@ describe("computeBarInventory", () => {
     ]);
   });
 
+  it("counts a leading chord without a leading | as a real bar", () => {
+    // "Em | Bm | C |" — Em is a bar even though no | precedes it.
+    // Previously counted as 2 bars (Bm, C); should be 3 (Em, Bm, C).
+    const s = score([{ id: "v", lines: [{ chords: "Em | Bm | C |" }] }]);
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(3);
+    expect(inv.map((b) => [b.startCol, b.endCol])).toEqual([
+      [0, 3],   // Em (implicit start to first |)
+      [3, 8],   // | Bm
+      [8, 12],  // | C
+    ]);
+  });
+
+  it("counts a trailing chord without a trailing | as a real bar", () => {
+    // "| C | F | G" — G is a bar even though no | follows it.
+    // Previously counted as 2 (C, F); should be 3 (C, F, G).
+    const s = score([{ id: "v", lines: [{ chords: "| C | F | G" }] }]);
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(3);
+    expect(inv.map((b) => [b.startCol, b.endCol])).toEqual([
+      [0, 4],   // | C
+      [4, 8],   // | F
+      [8, 11],  // | G (implicit end after last non-space char)
+    ]);
+  });
+
+  it("counts both leading and trailing implicit bars in the same line", () => {
+    const s = score([{ id: "v", lines: [{ chords: "Em | Bm | C" }] }]);
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(3);
+    expect(inv.map((b) => [b.startCol, b.endCol])).toEqual([
+      [0, 3],   // Em
+      [3, 8],   // | Bm
+      [8, 11],  // | C
+    ]);
+  });
+
+  it("ignores trailing whitespace when computing the trailing-content boundary", () => {
+    // "| C | F | G   " — the `G` is a bar; trailing spaces don't extend it.
+    const s = score([{ id: "v", lines: [{ chords: "| C | F | G   " }] }]);
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(3);
+    expect(inv[2]).toMatchObject({ startCol: 8, endCol: 11 });
+  });
+
   it("tolerates pipes at non-zero starting columns", () => {
-    // chord line starts with a chord, then has bars later
+    // "G   | C | F |" — the leading G is a real bar (3 bars: G, C, F).
     const s = score([
       { id: "v", lines: [{ chords: "G   | C | F |" }] },
     ]);
     const inv = computeBarInventory(s);
-    expect(inv).toHaveLength(2);
-    expect(inv[0].startCol).toBe(4);
-    expect(inv[1].startCol).toBe(8);
+    expect(inv).toHaveLength(3);
+    expect(inv.map((b) => [b.startCol, b.endCol])).toEqual([
+      [0, 4],   // G (implicit)
+      [4, 8],   // | C
+      [8, 12],  // | F
+    ]);
   });
 });
 

--- a/src/lib/chord-bar-inventory.ts
+++ b/src/lib/chord-bar-inventory.ts
@@ -44,14 +44,45 @@ export function computeBarInventory(score: Score): BarPos[] {
       for (let c = 0; c < chords.length; c++) {
         if (chords[c] === "|") pipes.push(c);
       }
-      for (let p = 0; p < pipes.length - 1; p++) {
+      // A line with no pipes contributes no bars — fall back to
+      // constant tempo-scaled scroll for that line. (User must add
+      // `|` markers to enable bar tracking on that line.)
+      if (pipes.length === 0) continue;
+
+      // Implicit boundaries: chord content that sits OUTSIDE the
+      // pipe-bracketed region still represents bars. Two common
+      // patterns we used to miss:
+      //
+      //   "Em | Bm | C |"  — leading Em chord before the first `|`
+      //                       is a real bar (3 bars total, not 2).
+      //   "| C | F | G"    — trailing G chord after the last `|` is
+      //                       a real bar (3 bars total, not 2).
+      //
+      // Treat the first non-space col as an implicit boundary when
+      // it precedes the first pipe; treat the position just past the
+      // last non-space col as an implicit boundary when it follows
+      // the last pipe.
+      const firstNonSpace = chords.search(/\S/);
+      // Index just past the last non-space character (exclusive end).
+      const lastNonSpaceEnd = chords.replace(/\s+$/, "").length;
+      const hasLeadingContent =
+        firstNonSpace !== -1 && firstNonSpace < pipes[0];
+      const hasTrailingContent =
+        lastNonSpaceEnd > pipes[pipes.length - 1] + 1;
+
+      const boundaries: number[] = [];
+      if (hasLeadingContent) boundaries.push(firstNonSpace);
+      for (const p of pipes) boundaries.push(p);
+      if (hasTrailingContent) boundaries.push(lastNonSpaceEnd);
+
+      for (let p = 0; p < boundaries.length - 1; p++) {
         out.push({
           globalIdx: out.length,
           sectionIdx: si,
           sectionId: sections[si].id,
           lineIdx: li,
-          startCol: pipes[p],
-          endCol: pipes[p + 1],
+          startCol: boundaries[p],
+          endCol: boundaries[p + 1],
         });
       }
     }


### PR DESCRIPTION
## Summary

User reported Twig skipping bars (e.g. 4th bar of intro, jumping from first verse bar to "way back when"). Investigation: the inventory only counted bars **strictly between** consecutive `|` markers. Common patterns were missing:

| Chord line | Old bar count | New bar count |
|---|---|---|
| `Em \| Bm \| C \|` | 2 (Bm, C) | **3** (Em, Bm, C) |
| `\| C \| F \| G` | 2 (C, F) | **3** (C, F, G) |
| `Am \| C` | 0 | **2** (Am, C) |

Fix: implicit boundaries at the first non-space char (if it precedes the first `|`) and at the position past the last non-space char (if it follows the last `|`). Lines with zero pipes still contribute zero bars (fall back to constant tempo-scaled scroll).

5 new tests cover leading-implicit, trailing-implicit, both, and the whitespace-trimming edge case. 113 tests pass total. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)