### PR TITLE
Auto-scroll test harness + helper extraction

### DIFF
--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -14,6 +14,10 @@ import {
   beatsPerBarOf,
   computeBarInventory,
 } from "@/lib/chord-bar-inventory";
+import {
+  computeLineScrollTarget,
+  isLineTransition,
+} from "@/lib/perform-scroll";
 
 const PREFS_KEY = "notation-app-perform-prefs";
 
@@ -316,11 +320,16 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   // the top of the viewport, eased over one bar's duration. Within the
   // same line: no scroll (long-line pause). At the start of the song
   // before any line crosses the 1/3 mark: target is 0, no scroll (warmup).
-  const lastScrolledLineRef = useRef<string | null>(null);
+  //
+  // Pure logic (computeLineScrollTarget / isLineTransition) lives in
+  // src/lib/perform-scroll.ts and is covered by perform-scroll.test.ts —
+  // tests guard the warmup / long-line-pause / off-the-page regressions
+  // we've hit on this surface.
+  const lastActiveBarRef = useRef<typeof activeBarIdx extends infer T ? T : null>(null);
   const scrollAnimHandleRef = useRef<number | null>(null);
   useEffect(() => {
     if (!autoScroll) {
-      lastScrolledLineRef.current = null;
+      lastActiveBarRef.current = null;
       if (scrollAnimHandleRef.current !== null) {
         cancelAnimationFrame(scrollAnimHandleRef.current);
         scrollAnimHandleRef.current = null;
@@ -330,13 +339,15 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
     if (activeBarIdx === null) return;
     const bar = barInventory[activeBarIdx];
     if (!bar) return;
-    const lineKey = `${bar.sectionId}-${bar.lineIdx}`;
-    if (lineKey === lastScrolledLineRef.current) return;
-    lastScrolledLineRef.current = lineKey;
+    const prevBar = lastActiveBarRef.current != null ? barInventory[lastActiveBarRef.current as number] ?? null : null;
+    lastActiveBarRef.current = activeBarIdx;
+    // Only trigger scroll when the LINE changes (not on every bar
+    // within a line). The pure helper makes this rule testable.
+    if (!isLineTransition(prevBar, bar)) return;
     const container = prefs.columns === 2 ? horizScrollRef.current : scrollRef.current;
     if (!container) return;
     const el = document.querySelector<HTMLElement>(
-      `[data-bar-line="${CSS.escape(lineKey)}"]`,
+      `[data-bar-line="${CSS.escape(`${bar.sectionId}-${bar.lineIdx}`)}"]`,
     );
     if (!el) return;
     const containerRect = container.getBoundingClientRect();
@@ -348,7 +359,7 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
     const max = horizontal
       ? container.scrollWidth - container.clientWidth
       : container.scrollHeight - container.clientHeight;
-    const target = Math.max(0, Math.min(max, elStart - viewport / 3));
+    const target = computeLineScrollTarget(elStart, viewport, max);
     const startScroll = horizontal ? container.scrollLeft : container.scrollTop;
     if (target === startScroll) return; // nothing to do
     // Duration matches one bar's worth of music time, so the line

--- a/src/lib/__tests__/perform-scroll.test.ts
+++ b/src/lib/__tests__/perform-scroll.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import type { Score } from "@/lib/schema";
+import {
+  computeLineScrollTarget,
+  isLineTransition,
+  scrollTriggerSequence,
+} from "@/lib/perform-scroll";
+import { computeBarInventory } from "@/lib/chord-bar-inventory";
+
+// A typical iPad-ish viewport in portrait.
+const VIEWPORT = 900;
+const ONE_THIRD = VIEWPORT / 3; // 300
+
+describe("computeLineScrollTarget — warmup behaviour", () => {
+  it("returns 0 when the line is at the top of content (warmup)", () => {
+    // Line at content-Y 0 → ideal = -300 → clamp to 0.
+    expect(computeLineScrollTarget(0, VIEWPORT, 5000)).toBe(0);
+  });
+
+  it("returns 0 when the line is within the top 1/3 of the viewport", () => {
+    // Line at content-Y 200, viewport/3 = 300 → ideal = -100 → 0.
+    expect(computeLineScrollTarget(200, VIEWPORT, 5000)).toBe(0);
+  });
+
+  it("returns 0 exactly at the 1/3 boundary", () => {
+    expect(computeLineScrollTarget(ONE_THIRD, VIEWPORT, 5000)).toBe(0);
+  });
+});
+
+describe("computeLineScrollTarget — normal scroll", () => {
+  it("places the line at viewport/3 once it crosses that mark", () => {
+    // Line at 400 → ideal = 400 - 300 = 100.
+    expect(computeLineScrollTarget(400, VIEWPORT, 5000)).toBe(100);
+  });
+
+  it("scales linearly as the line moves further down", () => {
+    expect(computeLineScrollTarget(1000, VIEWPORT, 5000)).toBe(700);
+    expect(computeLineScrollTarget(2000, VIEWPORT, 5000)).toBe(1700);
+  });
+});
+
+describe("computeLineScrollTarget — end-of-content clamp", () => {
+  it("never exceeds maxScroll (would scroll past the bottom)", () => {
+    // Line content-Y 10000, viewport 900, maxScroll 5000.
+    // Ideal would be 9700 — but scrollable range is only 5000.
+    expect(computeLineScrollTarget(10000, VIEWPORT, 5000)).toBe(5000);
+  });
+
+  it("respects the clamp exactly at the max", () => {
+    // Ideal = 5000 → target = 5000.
+    expect(computeLineScrollTarget(5300, VIEWPORT, 5000)).toBe(5000);
+  });
+});
+
+describe("computeLineScrollTarget — defensive zero / negative input", () => {
+  it("returns 0 when viewport size is zero (defensive)", () => {
+    expect(computeLineScrollTarget(500, 0, 5000)).toBe(0);
+  });
+
+  it("returns 0 when maxScroll is zero (content fits in viewport)", () => {
+    expect(computeLineScrollTarget(500, VIEWPORT, 0)).toBe(0);
+  });
+});
+
+describe("isLineTransition", () => {
+  const barA0 = { globalIdx: 0, sectionIdx: 0, sectionId: "v", lineIdx: 0, startCol: 0, endCol: 4 };
+  const barA1 = { globalIdx: 1, sectionIdx: 0, sectionId: "v", lineIdx: 0, startCol: 4, endCol: 8 };
+  const barB0 = { globalIdx: 2, sectionIdx: 0, sectionId: "v", lineIdx: 1, startCol: 0, endCol: 4 };
+  const barC0 = { globalIdx: 3, sectionIdx: 1, sectionId: "c", lineIdx: 0, startCol: 0, endCol: 4 };
+
+  it("first bar (prev=null) is a transition (starts the session)", () => {
+    expect(isLineTransition(null, barA0)).toBe(true);
+  });
+
+  it("two bars on the same (sectionId, lineIdx) are NOT a transition", () => {
+    expect(isLineTransition(barA0, barA1)).toBe(false);
+  });
+
+  it("changing lineIdx within the same section is a transition", () => {
+    expect(isLineTransition(barA1, barB0)).toBe(true);
+  });
+
+  it("changing sectionId is a transition (even with same lineIdx=0)", () => {
+    expect(isLineTransition(barB0, barC0)).toBe(true);
+  });
+
+  it("end-of-song (next=null) is NOT a transition (caller stops anyway)", () => {
+    expect(isLineTransition(barC0, null)).toBe(false);
+  });
+});
+
+describe("scrollTriggerSequence — regression: one trigger per LINE", () => {
+  // The user's headline complaint each time scroll has regressed:
+  // either too many scrolls (per bar) so the chord chart races, OR
+  // too few/never-resetting so it goes off the page. This locks in
+  // the rule: exactly ONE scroll trigger per line in the inventory.
+
+  it("4-bar single line emits ONE trigger (the first bar)", () => {
+    // "| C | F | G | Am |"
+    const s = {
+      sections: [{ id: "v", lines: [{ chords: "| C | F | G | Am |" }] }],
+    } as unknown as Score;
+    const inv = computeBarInventory(s);
+    const triggers = scrollTriggerSequence(inv).filter((t) => t.trigger);
+    expect(inv).toHaveLength(4);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].barIdx).toBe(0);
+  });
+
+  it("multi-line song fires exactly one trigger per line, in order", () => {
+    // Section v: 4 bars on line 0, 4 bars on line 1, 2 bars on line 2.
+    // Section c: 4 bars on line 0.
+    const s = {
+      sections: [
+        {
+          id: "v",
+          lines: [
+            { chords: "| Em | Bm | C | D |" },
+            { chords: "| Em | Bm | C | D |" },
+            { chords: "| Am | C |" },
+          ],
+        },
+        { id: "c", lines: [{ chords: "| F | G | Am | F |" }] },
+      ],
+    } as unknown as Score;
+    const inv = computeBarInventory(s);
+    expect(inv).toHaveLength(14); // 4+4+2+4
+    const triggers = scrollTriggerSequence(inv).filter((t) => t.trigger);
+    expect(triggers.map((t) => t.lineKey)).toEqual(["v-0", "v-1", "v-2", "c-0"]);
+    expect(triggers.map((t) => t.barIdx)).toEqual([0, 4, 8, 10]);
+  });
+
+  it("a long solo line (16 bars, 1 line) still fires only one trigger", () => {
+    // Worst case for the "scrolls off the page" bug: many bars in
+    // one line. Triggers must NOT fire on each bar within the line.
+    const longLine = "| " + Array.from({ length: 16 }, (_, i) => `C${i} | `).join("");
+    const s = {
+      sections: [{ id: "v", lines: [{ chords: longLine }] }],
+    } as unknown as Score;
+    const inv = computeBarInventory(s);
+    expect(inv.length).toBeGreaterThan(10);
+    const triggers = scrollTriggerSequence(inv).filter((t) => t.trigger);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].barIdx).toBe(0);
+  });
+});
+
+describe("scrollTriggerSequence — combined with target computation", () => {
+  // End-to-end check: simulate a playback sequence and compute the
+  // scroll targets the caller would set. Each line transition gets a
+  // distinct target; within-line bars keep the previous target.
+
+  it("simulates a 3-line song and yields three distinct scroll targets", () => {
+    const inv = [
+      { globalIdx: 0, sectionIdx: 0, sectionId: "v", lineIdx: 0, startCol: 0, endCol: 4 },
+      { globalIdx: 1, sectionIdx: 0, sectionId: "v", lineIdx: 0, startCol: 4, endCol: 8 },
+      { globalIdx: 2, sectionIdx: 0, sectionId: "v", lineIdx: 1, startCol: 0, endCol: 4 },
+      { globalIdx: 3, sectionIdx: 0, sectionId: "v", lineIdx: 1, startCol: 4, endCol: 8 },
+      { globalIdx: 4, sectionIdx: 0, sectionId: "v", lineIdx: 2, startCol: 0, endCol: 4 },
+    ];
+    // Pretend the chord chart has three lines at content-Y 100, 600, 1100.
+    const linePositions = new Map<string, number>([
+      ["v-0", 100],
+      ["v-1", 600],
+      ["v-2", 1100],
+    ]);
+    const targetForBar = (idx: number): number => {
+      const lineKey = `${inv[idx].sectionId}-${inv[idx].lineIdx}`;
+      return computeLineScrollTarget(linePositions.get(lineKey)!, VIEWPORT, 5000);
+    };
+    expect(targetForBar(0)).toBe(0);    // line at 100, in warmup zone
+    expect(targetForBar(1)).toBe(0);    // same line, same target
+    expect(targetForBar(2)).toBe(300);  // line at 600 — 300 = 300
+    expect(targetForBar(3)).toBe(300);  // same line as bar 2
+    expect(targetForBar(4)).toBe(800);  // line at 1100 — 300 = 800
+  });
+
+  it("never overshoots the bottom: long song clamps to maxScroll", () => {
+    // Last line is far below max scroll — should clamp.
+    const linePositions = new Map<string, number>([["v-0", 9999]]);
+    const t = computeLineScrollTarget(linePositions.get("v-0")!, VIEWPORT, 5000);
+    expect(t).toBe(5000);
+  });
+});

--- a/src/lib/perform-scroll.ts
+++ b/src/lib/perform-scroll.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure helpers for PerformView's auto-scroll. Extracted so the scroll
+ * behaviour (warmup, long-line pause, line-transition target,
+ * end-of-content clamp) is unit-testable without a real browser /
+ * layout engine.
+ *
+ * Three regression-prone behaviours we want to lock in tests:
+ *
+ *  1. Warmup — while the active line sits in the top viewport/3, the
+ *     scroll target is 0. The chart doesn't move until the playhead
+ *     would otherwise be too high in the viewport.
+ *
+ *  2. Long-line pause — while bars walk across the same line, the
+ *     target doesn't move. Scroll stays still.
+ *
+ *  3. Line transition — when the active bar moves to a different
+ *     line, the target jumps to the new line's position minus
+ *     viewport/3. Caller animates between targets.
+ *
+ *  4. End-of-content clamp — target never exceeds the scrollable
+ *     range (otherwise the lerp could overshoot off-screen).
+ */
+
+import type { BarPos } from "@/lib/chord-bar-inventory";
+
+/**
+ * Position the active line at the 1/3-from-top mark of the viewport,
+ * but never propose scrolling above 0 (warmup) or past the maximum
+ * scroll (end-of-content clamp).
+ */
+export function computeLineScrollTarget(
+  lineContentY: number,
+  viewportSize: number,
+  maxScroll: number,
+): number {
+  if (viewportSize <= 0) return 0;
+  if (maxScroll <= 0) return 0;
+  const ideal = lineContentY - viewportSize / 3;
+  if (ideal <= 0) return 0;
+  if (ideal >= maxScroll) return maxScroll;
+  return ideal;
+}
+
+/** True if `next` is on a different (sectionId, lineIdx) than `prev`. */
+export function isLineTransition(prev: BarPos | null, next: BarPos | null): boolean {
+  if (next === null) return false; // end-of-song; caller stops anyway
+  if (prev === null) return true;  // first bar of a session
+  return prev.sectionId !== next.sectionId || prev.lineIdx !== next.lineIdx;
+}
+
+/**
+ * Walk a bar inventory in playback order and emit the sequence of
+ * (barIdx, shouldTriggerScroll) decisions a caller would make. Used
+ * by tests to verify the scroll trigger pattern matches expected:
+ * one trigger per LINE, not one per BAR.
+ */
+export function scrollTriggerSequence(
+  inventory: readonly BarPos[],
+): { barIdx: number; lineKey: string; trigger: boolean }[] {
+  const out: { barIdx: number; lineKey: string; trigger: boolean }[] = [];
+  let prev: BarPos | null = null;
+  for (let i = 0; i < inventory.length; i++) {
+    const b = inventory[i];
+    const trigger = isLineTransition(prev, b);
+    out.push({
+      barIdx: i,
+      lineKey: `${b.sectionId}-${b.lineIdx}`,
+      trigger,
+    });
+    prev = b;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Multiple scroll regressions in a row each escaped review because the DOM measurements + animation kept the rules out of unit-test reach. This pulls the rules into pure helpers and locks them down.

### `src/lib/perform-scroll.ts`
- `computeLineScrollTarget(lineY, viewportSize, maxScroll)` — encodes warmup (≤ viewport/3 → 0), normal scroll (lineY - viewport/3), and end-of-content clamp.
- `isLineTransition(prev, next)` — "scroll only on LINE change" rule, so within-line bar walks don't fire animations.
- `scrollTriggerSequence(inv)` — produces a per-bar trigger sequence for integration-style asserts.

### 19 new specs in `perform-scroll.test.ts`
- Warmup boundaries (above, at, just past 1/3)
- Normal scaling
- **End-of-content clamp** (line below max scroll — the "off the page" regression)
- Defensive zero/negative input
- `isLineTransition`: first-bar / within-line / line change / section change / end-of-song
- `scrollTriggerSequence`: one trigger per line, 16-bar single-line long-solo case
- End-to-end: 3-line song produces three distinct targets in order

### PerformView
Now uses both helpers in place of inline math. Same behaviour, much harder to break silently.

132 tests pass. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)