### PR TITLE
Auto-scroll: teleprompter spacers keep active bar at 1/3

### DIFF
--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -469,6 +469,12 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
           ref={scrollRef}
           className="absolute inset-0 overflow-auto pt-[7vh] pb-16"
         >
+          {/* Top spacer: pushes the first chord line down so when
+              scrollTop=0 the first line sits at ~1/3 of the viewport
+              from the top — the "1/3 of the page above the active
+              bar" position the user wants throughout playback.
+              7vh from pt + 26vh from spacer = 33vh total top offset. */}
+          <div style={{ height: "26vh" }} aria-hidden />
           <div className="relative">
             <ChordChartView
               score={score}
@@ -478,6 +484,12 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
             />
             <AnnotationLayer />
           </div>
+          {/* Bottom spacer: extends the scrollable range so the LAST
+              line can still scroll up to the 1/3 mark instead of
+              hitting max_scroll clamp at some lower position. Without
+              this, the active-bar overlay drifts below 1/3 toward the
+              end of the song and looks "off the rails". */}
+          <div style={{ height: "67vh" }} aria-hidden />
         </div>
       ) : (
         <PaginatedPerformChart


### PR DESCRIPTION
## Summary

User reported the active bar drifts higher than 1/3 from top during the intro (warmup) and goes "off the rails" near the end of Twig (e.g. at "Way back then"). Both come from scroll-position clamps — `scrollTop ≥ 0` keeps first lines near the top, `scrollTop ≤ max` lets last lines drift below 1/3 once the clamp engages.

**Fix**: teleprompter-style spacer divs above and below the chord chart inside the scroll container.

- **Top spacer 26vh** (+ existing 7vh `pt` = 33vh of empty content before the first chord line). `computeLineScrollTarget` for the first line becomes `~33vh - viewport/3 = 0`; scroll stays at 0; the first line sits at the 1/3 mark visually.
- **Bottom spacer 67vh** extends scrollable range so the last chord lines can still scroll up to the 1/3 mark before hitting the clamp.

Net: active bar at 1/3 from top, consistent from first bar to last. No logic change in `computeLineScrollTarget` — the math was always right; spacers just give it room to land where it should.

132 tests pass. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)