### PR TITLE
Auto-scroll: drop top spacer (keep warmup model)

### DIFF
--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -469,12 +469,12 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
           ref={scrollRef}
           className="absolute inset-0 overflow-auto pt-[7vh] pb-16"
         >
-          {/* Top spacer: pushes the first chord line down so when
-              scrollTop=0 the first line sits at ~1/3 of the viewport
-              from the top — the "1/3 of the page above the active
-              bar" position the user wants throughout playback.
-              7vh from pt + 26vh from spacer = 33vh total top offset. */}
-          <div style={{ height: "26vh" }} aria-hidden />
+          {/* No top spacer — user wants the chord chart to start at
+              the top of the viewport. computeLineScrollTarget already
+              clamps target to 0 while the active line's content-Y is
+              within the top viewport/3 (the "warmup" period), so
+              scroll stays at 0 until the active line passes the 1/3
+              mark, then engages to hold the line at that mark. */}
           <div className="relative">
             <ChordChartView
               score={score}


### PR DESCRIPTION
## Summary

Per user: don't want empty space at the top. Chord chart starts at the top of the viewport; scroll stays at 0 until the active bar reaches ~1/3 down, then engages.

That's already what `computeLineScrollTarget` does (clamps ≤ 0 for lines in top `viewport/3`), so removing the 26vh top spacer restores warmup. **Bottom spacer stays** — prevents last lines from drifting below 1/3 once max-scroll engages near song's end.

132 tests pass. Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)