### PR TITLE
Auto-scroll: separate trigger threshold from target position

### DIFF
--- a/src/lib/__tests__/perform-scroll.test.ts
+++ b/src/lib/__tests__/perform-scroll.test.ts
@@ -9,31 +9,46 @@ import { computeBarInventory } from "@/lib/chord-bar-inventory";
 
 // A typical iPad-ish viewport in portrait.
 const VIEWPORT = 900;
-const ONE_THIRD = VIEWPORT / 3; // 300
+// Default trigger threshold = viewport/2 = 450.
+// Default target settling position = viewport/3 = 300.
 
-describe("computeLineScrollTarget — warmup behaviour", () => {
-  it("returns 0 when the line is at the top of content (warmup)", () => {
-    // Line at content-Y 0 → ideal = -300 → clamp to 0.
+describe("computeLineScrollTarget — warmup (trigger threshold)", () => {
+  it("returns 0 when the line is at the top of content", () => {
     expect(computeLineScrollTarget(0, VIEWPORT, 5000)).toBe(0);
   });
 
-  it("returns 0 when the line is within the top 1/3 of the viewport", () => {
-    // Line at content-Y 200, viewport/3 = 300 → ideal = -100 → 0.
+  it("returns 0 when the line is within the top half (default trigger 0.5)", () => {
+    // viewport/2 = 450. Line at 200 → well under threshold → 0.
     expect(computeLineScrollTarget(200, VIEWPORT, 5000)).toBe(0);
   });
 
-  it("returns 0 exactly at the 1/3 boundary", () => {
-    expect(computeLineScrollTarget(ONE_THIRD, VIEWPORT, 5000)).toBe(0);
+  // REGRESSION (Twig): line 2 at content-Y ≈ 200 was producing a
+  // non-zero target under the old single-fraction model (trigger=
+  // target=viewport/3=300) because line 2 in some chord charts sits
+  // past viewport/3 due to section headers + line-height. With the
+  // new trigger=viewport/2 default, scroll stays parked for line 2.
+  it("REGRESSION: line 2 at content-Y 350 does NOT engage scroll", () => {
+    expect(computeLineScrollTarget(350, VIEWPORT, 5000)).toBe(0);
+  });
+
+  it("returns 0 exactly at the trigger boundary (450)", () => {
+    expect(computeLineScrollTarget(450, VIEWPORT, 5000)).toBe(0);
+  });
+
+  it("returns 0 just below trigger boundary (449)", () => {
+    expect(computeLineScrollTarget(449, VIEWPORT, 5000)).toBe(0);
   });
 });
 
-describe("computeLineScrollTarget — normal scroll", () => {
-  it("places the line at viewport/3 once it crosses that mark", () => {
-    // Line at 400 → ideal = 400 - 300 = 100.
-    expect(computeLineScrollTarget(400, VIEWPORT, 5000)).toBe(100);
+describe("computeLineScrollTarget — engagement and settling", () => {
+  it("engages scroll once the line crosses the trigger threshold", () => {
+    // Line at 451 → past trigger 450, settle target = lineY - viewport/3
+    //   = 451 - 300 = 151
+    expect(computeLineScrollTarget(451, VIEWPORT, 5000)).toBe(151);
   });
 
-  it("scales linearly as the line moves further down", () => {
+  it("settles deeper lines at viewport/3 from top", () => {
+    expect(computeLineScrollTarget(600, VIEWPORT, 5000)).toBe(300);
     expect(computeLineScrollTarget(1000, VIEWPORT, 5000)).toBe(700);
     expect(computeLineScrollTarget(2000, VIEWPORT, 5000)).toBe(1700);
   });
@@ -41,13 +56,10 @@ describe("computeLineScrollTarget — normal scroll", () => {
 
 describe("computeLineScrollTarget — end-of-content clamp", () => {
   it("never exceeds maxScroll (would scroll past the bottom)", () => {
-    // Line content-Y 10000, viewport 900, maxScroll 5000.
-    // Ideal would be 9700 — but scrollable range is only 5000.
     expect(computeLineScrollTarget(10000, VIEWPORT, 5000)).toBe(5000);
   });
 
   it("respects the clamp exactly at the max", () => {
-    // Ideal = 5000 → target = 5000.
     expect(computeLineScrollTarget(5300, VIEWPORT, 5000)).toBe(5000);
   });
 });
@@ -59,6 +71,40 @@ describe("computeLineScrollTarget — defensive zero / negative input", () => {
 
   it("returns 0 when maxScroll is zero (content fits in viewport)", () => {
     expect(computeLineScrollTarget(500, VIEWPORT, 0)).toBe(0);
+  });
+});
+
+describe("computeLineScrollTarget — custom trigger / target fractions", () => {
+  it("respects a deeper trigger (2/3 viewport) for slower engagement", () => {
+    // Trigger at viewport*2/3 = 600. Line at 500 → still parked.
+    const target = computeLineScrollTarget(500, VIEWPORT, 5000, {
+      triggerFraction: 2 / 3,
+    });
+    expect(target).toBe(0);
+  });
+
+  it("respects a shallower trigger (1/4 viewport) for earlier engagement", () => {
+    // Trigger at 225. Line at 300 → engaged.
+    const target = computeLineScrollTarget(300, VIEWPORT, 5000, {
+      triggerFraction: 1 / 4,
+    });
+    // Settle: 300 - viewport/3 = 0 (clamp to 0 since ideal isn't positive)
+    expect(target).toBe(0);
+    // Try a deeper line so settle is positive:
+    const target2 = computeLineScrollTarget(400, VIEWPORT, 5000, {
+      triggerFraction: 1 / 4,
+    });
+    expect(target2).toBe(100); // 400 - 300
+  });
+
+  it("targetFraction overrides the settling position", () => {
+    // Trigger 0.5, target 0.25. Line at 500 → past trigger; settle
+    //   at 500 - viewport*0.25 = 500 - 225 = 275.
+    const target = computeLineScrollTarget(500, VIEWPORT, 5000, {
+      triggerFraction: 0.5,
+      targetFraction: 0.25,
+    });
+    expect(target).toBe(275);
   });
 });
 

--- a/src/lib/perform-scroll.ts
+++ b/src/lib/perform-scroll.ts
@@ -24,18 +24,46 @@
 import type { BarPos } from "@/lib/chord-bar-inventory";
 
 /**
- * Position the active line at the 1/3-from-top mark of the viewport,
- * but never propose scrolling above 0 (warmup) or past the maximum
- * scroll (end-of-content clamp).
+ * Compute the scrollTop position that should hold the active line at
+ * `targetFraction` from the top of the viewport, but DON'T engage
+ * scroll until the line's content-Y has passed `triggerFraction` of
+ * the viewport. Separating the two means scroll can stay parked while
+ * early lines are read (line 1, 2, 3 in the top half), then start
+ * tracking the active line once it's past the trigger zone.
+ *
+ *  - `triggerFraction` (default 0.5): "warm-up zone." While the
+ *    active line's content-Y is at or below `viewport × triggerFraction`,
+ *    target stays at 0. The chord chart doesn't scroll at all during
+ *    the song's opening — the user reads top-down while the playhead
+ *    walks toward the trigger.
+ *
+ *  - `targetFraction` (default 1/3): where the active line settles
+ *    once scroll is engaged. The user said "1/3 of the page above the
+ *    active bar," which matches.
+ *
+ * Why two values and not one: testing on Twig showed the
+ * single-fraction model engaged scroll on line 2, because line 2's
+ * content-Y already exceeded viewport/3. Pulling the trigger deeper
+ * (viewport/2) keeps line 2 parked, while still settling the active
+ * line at 1/3 once engagement happens.
  */
 export function computeLineScrollTarget(
   lineContentY: number,
   viewportSize: number,
   maxScroll: number,
+  options: {
+    triggerFraction?: number;
+    targetFraction?: number;
+  } = {},
 ): number {
+  const triggerFraction = options.triggerFraction ?? 0.5;
+  const targetFraction = options.targetFraction ?? 1 / 3;
   if (viewportSize <= 0) return 0;
   if (maxScroll <= 0) return 0;
-  const ideal = lineContentY - viewportSize / 3;
+  // Warm-up: don't engage scroll until the active line has crossed
+  // the trigger threshold.
+  if (lineContentY <= viewportSize * triggerFraction) return 0;
+  const ideal = lineContentY - viewportSize * targetFraction;
   if (ideal <= 0) return 0;
   if (ideal >= maxScroll) return maxScroll;
   return ideal;


### PR DESCRIPTION
## Summary

User reported scroll engaging on line 2 of Twig — too early. My existing test passed for that input because the pure function got an arbitrary `lineY` — it didn't model that real chord charts can put line 2 well past viewport/3 (large font, section header padding, line-height stacking). The function was right; the **rule** baked into it (single fraction) was wrong.

### Fix
Two separate fractions in `computeLineScrollTarget`:

- **`triggerFraction`** (default `0.5`): warm-up zone. While the active line's content-Y is at or below `viewport × triggerFraction`, target stays at 0. Scroll won't engage during the opening no matter how tall the lines are.
- **`targetFraction`** (default `1/3`): where the line settles **once scroll engages**. Matches the user's stated "1/3 of the page above the active bar."

### Regression lock
New spec: `REGRESSION: line 2 at content-Y 350 does NOT engage scroll`. Under the old single-fraction model, 350 > viewport/3=300 → non-zero target → scroll. Under the new model, 350 < viewport/2=450 → 0.

5 new specs cover trigger boundary, engagement math, custom options, the regression. 137 tests pass.

Auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)