### PR TITLE
Auto-scroll overshoot fix + out-of-scope title chip

### DIFF
--- a/e2e/auto-scroll.spec.ts
+++ b/e2e/auto-scroll.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect, Page } from "@playwright/test";
+
+// A realistic-shape chord chart with multiple sections and bar-marked
+// lines — enough to reproduce the section-transition regressions
+// the user has been reporting on Twig. Bars run fast (240 BPM) so a
+// full playthrough finishes inside Playwright's default 30s timeout.
+const TEST_CHORD_CHART = {
+  id: "test-chord-chart",
+  title: "Auto-scroll regression song",
+  composer: "",
+  tempo: 240,
+  timeSignature: "4/4",
+  keySignature: "C",
+  measures: 16,
+  staves: [],
+  sections: [
+    {
+      id: "intro",
+      label: "Intro",
+      lines: [
+        { chords: "| Em | Bm | C | D |", lyrics: "" },
+        { chords: "| Em | Bm | C | D |", lyrics: "" },
+      ],
+    },
+    {
+      id: "verse",
+      label: "Verse 1",
+      lines: [
+        { chords: "| Em | Bm |", lyrics: "way back then we ran the road" },
+        { chords: "| C | D |", lyrics: "up and up it goes" },
+        { chords: "| Em | Bm |", lyrics: "and the wind was free" },
+        { chords: "| C | D |", lyrics: "way back then" },
+      ],
+    },
+    {
+      id: "chorus",
+      label: "Chorus",
+      lines: [
+        { chords: "| F | G | Am | Em |", lyrics: "" },
+        { chords: "| F | G | C |", lyrics: "" },
+      ],
+    },
+  ],
+};
+
+async function seedScoreAndEnterPerform(page: Page) {
+  await page.goto("/");
+  await page.evaluate((score) => {
+    localStorage.setItem("notation-app-store", JSON.stringify({
+      state: {
+        score,
+        history: [score],
+        historyIndex: 0,
+        messages: [],
+        warnings: [],
+        isGenerating: false,
+        selection: null,
+        lastOperation: null,
+        savedRevisions: [],
+        stepEntry: null,
+        projectId: null,
+        // Enter perform mode immediately + sensible defaults
+        uiState: {
+          performMode: true,
+          annotationMode: false,
+          annotationFilters: {
+            showShared: true,
+            showPersonal: true,
+            hideInPerformance: false,
+            hiddenLabels: [],
+          },
+          currentSongId: null,
+          activeSetId: null,
+          performFolder: null,
+          collapsedFolders: [],
+        },
+        layout: {
+          titleSize: 2.4, composerSize: 1.4, titleTopDistance: 5, titleBottomDistance: 1,
+          pageTopMargin: 5, pageLeftMargin: 5, pageRightMargin: 5, systemSpacing: 5,
+          compactMode: false, measuresPerSystem: 0, pageBreaks: false, pageSize: "letter",
+          noteSize: 1.0, musicFont: "bravura", textFont: "georgia",
+          printPageNumbers: true, printHeader: "", printFooter: "",
+        },
+      },
+      version: 9,
+    }));
+  }, TEST_CHORD_CHART);
+  await page.reload();
+  // Wait for chord chart lines to render — the data-bar-line attribute
+  // is what the scroll logic queries to find line positions.
+  await page.waitForSelector("[data-bar-line]", { timeout: 10000 });
+}
+
+interface OverlayProbe {
+  found: boolean;
+  top?: number;
+  bottom?: number;
+  viewportH?: number;
+  scrollTop?: number;
+  /** key of the currently-highlighted bar's line, for sanity-tracing. */
+  activeLineKey?: string;
+}
+
+/** Capture the green active-bar overlay's viewport position + container
+ *  scroll position. Run repeatedly during a playthrough to verify the
+ *  overlay never leaves the viewport. */
+async function probeActiveBar(page: Page): Promise<OverlayProbe> {
+  return page.evaluate<OverlayProbe>(() => {
+    // Active bar overlay uses bg-green-400/70 (per ChordChartView).
+    const overlay = document.querySelector<HTMLElement>(
+      'div[aria-hidden="true"].bg-green-400\\/70',
+    );
+    if (!overlay) return { found: false };
+    const rect = overlay.getBoundingClientRect();
+    const lineWrapper = overlay.parentElement;
+    const activeLineKey = lineWrapper?.getAttribute("data-bar-line") ?? undefined;
+    // Scroll container is the absolute inset-0 overflow-auto div.
+    const container = document.querySelector<HTMLElement>(".overflow-auto");
+    return {
+      found: true,
+      top: rect.top,
+      bottom: rect.bottom,
+      viewportH: window.innerHeight,
+      scrollTop: container?.scrollTop,
+      activeLineKey,
+    };
+  });
+}
+
+test.describe("Auto-scroll regression: active bar stays in viewport", () => {
+  test("active bar visible throughout playthrough of intro + verse + chorus", async ({ page }) => {
+    await seedScoreAndEnterPerform(page);
+    // The play button lives in PerformView's auto-scroll toolbar. Its
+    // accessible label flips between "Start auto-scroll" and
+    // "Pause auto-scroll".
+    await page.locator('button[aria-label="Start auto-scroll"]').click();
+
+    // Sample every 250ms for 12 seconds — covers ~24 bars at 240 BPM,
+    // enough to traverse intro (8 bars), verse (8 bars), and into
+    // chorus (transition we've been regressing).
+    const samples: Array<OverlayProbe & { t: number }> = [];
+    const offScreenMisses: Array<{ t: number; probe: OverlayProbe }> = [];
+    for (let i = 0; i < 48; i++) {
+      await page.waitForTimeout(250);
+      const probe = await probeActiveBar(page);
+      samples.push({ t: i * 250, ...probe });
+      if (probe.found && probe.top !== undefined && probe.bottom !== undefined) {
+        const viewportH = probe.viewportH ?? 0;
+        const fullyVisible = probe.top >= 0 && probe.bottom <= viewportH;
+        if (!fullyVisible) {
+          offScreenMisses.push({ t: i * 250, probe });
+        }
+      }
+    }
+
+    // Surface the trace so failures are debuggable.
+    if (offScreenMisses.length > 0) {
+      console.log("Active-bar off-screen samples:", JSON.stringify(offScreenMisses, null, 2));
+      console.log("Full timeline:", JSON.stringify(samples, null, 2));
+    }
+    expect(offScreenMisses, "active bar went off-screen during playthrough").toEqual([]);
+  });
+
+  test("active bar viewport position stays near 1/3-from-top once scroll engages", async ({ page }) => {
+    await seedScoreAndEnterPerform(page);
+    await page.locator('button[aria-label="Start auto-scroll"]').click();
+
+    // After 4 seconds (~8 bars at 240 BPM), scroll should have engaged
+    // and the active line should be at roughly viewport/3 from top.
+    await page.waitForTimeout(4000);
+    const probe = await probeActiveBar(page);
+    expect(probe.found, "active bar overlay missing after 4s").toBe(true);
+    const viewportH = probe.viewportH!;
+    const oneThird = viewportH / 3;
+    const top = probe.top!;
+    // Tolerance: half a viewport — the overlay starts at the line's
+    // top and the trigger threshold is viewport/2, so a wide window
+    // covers initial warm-up + transition animations.
+    expect(top, `active bar at y=${top}, expected near ${oneThird}`).toBeGreaterThan(0);
+    expect(top, `active bar at y=${top}, expected near ${oneThird}`).toBeLessThan(viewportH * 0.85);
+  });
+});

--- a/e2e/auto-scroll.spec.ts
+++ b/e2e/auto-scroll.spec.ts
@@ -97,16 +97,20 @@ interface OverlayProbe {
   bottom?: number;
   viewportH?: number;
   scrollTop?: number;
+  scrollHeight?: number;
+  clientHeight?: number;
+  lineContentY?: number;
   /** key of the currently-highlighted bar's line, for sanity-tracing. */
   activeLineKey?: string;
 }
 
-/** Capture the green active-bar overlay's viewport position + container
- *  scroll position. Run repeatedly during a playthrough to verify the
- *  overlay never leaves the viewport. */
+/** Capture the green active-bar overlay's viewport position, plus its
+ *  scroll container's state and the line's absolute content-Y. Walks
+ *  the DOM up from the overlay to find the actual scrollable ancestor
+ *  (the `.overflow-auto` class isn't unique enough — there are nested
+ *  scroll containers). */
 async function probeActiveBar(page: Page): Promise<OverlayProbe> {
   return page.evaluate<OverlayProbe>(() => {
-    // Active bar overlay uses bg-green-400/70 (per ChordChartView).
     const overlay = document.querySelector<HTMLElement>(
       'div[aria-hidden="true"].bg-green-400\\/70',
     );
@@ -114,14 +118,31 @@ async function probeActiveBar(page: Page): Promise<OverlayProbe> {
     const rect = overlay.getBoundingClientRect();
     const lineWrapper = overlay.parentElement;
     const activeLineKey = lineWrapper?.getAttribute("data-bar-line") ?? undefined;
-    // Scroll container is the absolute inset-0 overflow-auto div.
-    const container = document.querySelector<HTMLElement>(".overflow-auto");
+    // Walk up to find the nearest scrollable ancestor.
+    let scrollContainer: HTMLElement | null = lineWrapper;
+    while (scrollContainer && scrollContainer !== document.body) {
+      const style = window.getComputedStyle(scrollContainer);
+      if (style.overflowY === "auto" || style.overflowY === "scroll") break;
+      scrollContainer = scrollContainer.parentElement;
+    }
+    if (!scrollContainer || scrollContainer === document.body) {
+      return { found: true, top: rect.top, bottom: rect.bottom, viewportH: window.innerHeight, activeLineKey };
+    }
+    const containerRect = scrollContainer.getBoundingClientRect();
+    let lineContentY: number | undefined;
+    if (lineWrapper) {
+      const lineRect = lineWrapper.getBoundingClientRect();
+      lineContentY = lineRect.top - containerRect.top + scrollContainer.scrollTop;
+    }
     return {
       found: true,
       top: rect.top,
       bottom: rect.bottom,
       viewportH: window.innerHeight,
-      scrollTop: container?.scrollTop,
+      scrollTop: scrollContainer.scrollTop,
+      scrollHeight: scrollContainer.scrollHeight,
+      clientHeight: scrollContainer.clientHeight,
+      lineContentY,
       activeLineKey,
     };
   });
@@ -153,12 +174,24 @@ test.describe("Auto-scroll regression: active bar stays in viewport", () => {
       }
     }
 
-    // Surface the trace so failures are debuggable.
-    if (offScreenMisses.length > 0) {
-      console.log("Active-bar off-screen samples:", JSON.stringify(offScreenMisses, null, 2));
-      console.log("Full timeline:", JSON.stringify(samples, null, 2));
-    }
-    expect(offScreenMisses, "active bar went off-screen during playthrough").toEqual([]);
+    // Build a compact timeline string so the failure message shows
+    // when scroll departed from the expected target — Playwright
+    // workers swallow most console output, but assertion messages
+    // surface reliably.
+    const timeline = samples
+      .filter((s) => s.found)
+      .map((s) => {
+        const expected =
+          s.lineContentY !== undefined
+            ? Math.max(0, s.lineContentY - (s.viewportH ?? 0) / 3).toFixed(0)
+            : "?";
+        return `t=${s.t} key=${s.activeLineKey} lineY=${s.lineContentY?.toFixed(0)} scroll=${s.scrollTop} want=${expected} barTop=${s.top?.toFixed(0)}`;
+      })
+      .join("\n");
+    expect(
+      offScreenMisses.length,
+      `active bar went off-screen during playthrough.\n\nTimeline:\n${timeline}`,
+    ).toBe(0);
   });
 
   test("active bar viewport position stays near 1/3-from-top once scroll engages", async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,13 +5,13 @@ export default defineConfig({
   timeout: 30000,
   expect: { timeout: 10000 },
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: "http://localhost:3001",
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },
   webServer: {
-    command: "npm run dev",
-    port: 3000,
+    command: "PORT=3001 npm run dev",
+    port: 3001,
     reuseExistingServer: true,
     timeout: 30000,
   },

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -346,7 +346,14 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
     if (!isLineTransition(prevBar, bar)) return;
     const container = prefs.columns === 2 ? horizScrollRef.current : scrollRef.current;
     if (!container) return;
-    const el = document.querySelector<HTMLElement>(
+    // SCOPE the query to the perform-mode scroll container. The editor's
+    // ChordChartView is still mounted underneath the fixed-inset perform
+    // overlay and ALSO renders [data-bar-line] attributes — without
+    // scoping, document.querySelector grabs the EDITOR's line, whose Y
+    // coordinates are unrelated to where the perform chord chart actually
+    // sits. That mismatch was producing wildly wrong scroll targets
+    // (overshooting the active line off the top of the page).
+    const el = container.querySelector<HTMLElement>(
       `[data-bar-line="${CSS.escape(`${bar.sectionId}-${bar.lineIdx}`)}"]`,
     );
     if (!el) return;

--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -165,8 +165,11 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
     [songs],
   );
 
-  // Find the position of the current song in the SCOPED list. Falls back
-  // to 0 if the loaded song isn't in scope (so prev/next still work).
+  // Find the position of the current song in the SCOPED list. Returns
+  // -1 when the loaded song isn't in scope (e.g., user switched folder
+  // or set after loading the song) — that disables prev/next and lets
+  // the chip fall through to `score.title` so it displays the
+  // ACTUALLY-loaded song rather than lying about being on scope[0].
   const currentIndex = useMemo(() => {
     if (!songsInScope.length) return -1;
     const byId = currentSongId
@@ -174,7 +177,7 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
       : -1;
     if (byId !== -1) return byId;
     const byTitle = songsInScope.findIndex(s => s.title === score.title);
-    return byTitle !== -1 ? byTitle : 0;
+    return byTitle;
   }, [songsInScope, currentSongId, score.title]);
 
   const loadAt = (idx: number) => {


### PR DESCRIPTION
## Summary

Two bugs the user hit testing perform mode, plus a Playwright regression test that catches the first one.

**1. Auto-scroll overshoot (75c485b)** — Active-bar scroll ran off the top of the page mid-verse. Root cause: the line-transition effect's `document.querySelector('[data-bar-line=...]')` matched the editor's still-mounted ChordChartView (also renders the attribute) instead of the perform-mode overlay. Wrong Y coordinates → scroll targets several hundred pixels past the actual line. Fix: scope the query to `container.querySelector(...)`.

**2. Title chip lies when loaded song is out of scope (81d6899)** — Chip said "Twig" while the chord chart was Foggy Night, because `currentIndex` fell back to `0` when the loaded song wasn't in the current folder/set scope. Now returns -1; chip falls through to `score.title`, prev/next disable cleanly.

**3. Playwright e2e regression test** — Seeds a multi-section chord chart, plays auto-scroll for 12s, asserts the active bar stays in viewport. Reproduces the overshoot on pre-fix code; passes on fixed code. Config switches to :3001 (the project's documented dev port).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 137 tests pass
- [x] `npx playwright test e2e/auto-scroll.spec.ts` — both tests pass
- [ ] iPad: perform a multi-verse song with bar markers + tempo, confirm active bar stays in viewport throughout
- [ ] iPad: load a song from one folder/set, switch perform scope, confirm chip shows loaded song's title (not scope[0])