### PR TITLE
2-col perform: wrap long lines at bar boundaries

### DIFF
--- a/src/components/PaginatedPerformChart.tsx
+++ b/src/components/PaginatedPerformChart.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ChordChartSection, ChordChartLine, Score } from "@/lib/schema";
+import { wrapChordLineAtBars } from "@/lib/chord-line-wrap";
 
 const MONO_FONT_STACK =
   "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
@@ -57,9 +58,16 @@ export default function PaginatedPerformChart({
   const outerRef = useRef<HTMLDivElement | null>(null);
   const measureContainerRef = useRef<HTMLDivElement | null>(null);
   const measureRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  // Hidden probe used to measure rendered char width in the same font /
+  // size / kerning as visible chord lines. Without this we'd have to
+  // guess `ch` and the wrap point would drift on font-size changes.
+  const charProbeRef = useRef<HTMLSpanElement | null>(null);
 
   const [pages, setPages] = useState<Page[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
+  // Max characters a single chord line can occupy before the wrap helper
+  // splits it across multiple visual rows. Null until first layout pass.
+  const [maxCharsPerRow, setMaxCharsPerRow] = useState<number | null>(null);
 
   // Flatten the score into per-line blocks. Headers are their own block so
   // we can measure them and decide whether to keep the header attached to
@@ -180,16 +188,42 @@ export default function PaginatedPerformChart({
     void pageW;
   }, [blocks]);
 
+  // Recompute the per-row character budget. Column width in px ÷ rendered
+  // char width in px. The wrap helper splits chord lines that exceed this
+  // so long lines stop getting clipped in narrow 2-col columns.
+  const recomputeMaxChars = useCallback(() => {
+    const outer = outerRef.current;
+    const probe = charProbeRef.current;
+    if (!outer || !probe) return;
+    // Page = full outer width; grid uses px-4 (32px total) + gap-8 (32px).
+    // So each column gets (clientWidth - 64) / 2.
+    const colW = (outer.clientWidth - 64) / 2;
+    const text = probe.textContent ?? "";
+    if (text.length === 0) return;
+    const chW = probe.getBoundingClientRect().width / text.length;
+    if (chW <= 0 || colW <= 0) return;
+    // Min of 8 chars/row guards against degenerate viewports where the
+    // column shrinks below a single chord token's width.
+    const next = Math.max(8, Math.floor(colW / chW));
+    setMaxCharsPerRow((cur) => (cur === next ? cur : next));
+  }, []);
+
   // Measure-then-pack on mount, when score or prefs change, and on resize.
+  // maxCharsPerRow goes first because pagination's height measurements
+  // depend on whether lines have wrapped into multiple sub-rows.
   useLayoutEffect(() => {
+    recomputeMaxChars();
     recompute();
-  }, [recompute, prefs.fontSize, prefs.lineHeight, prefs.letterSpacing]);
+  }, [recompute, recomputeMaxChars, prefs.fontSize, prefs.lineHeight, prefs.letterSpacing, maxCharsPerRow]);
 
   useEffect(() => {
-    const ro = new ResizeObserver(() => recompute());
+    const ro = new ResizeObserver(() => {
+      recomputeMaxChars();
+      recompute();
+    });
     if (outerRef.current) ro.observe(outerRef.current);
     return () => ro.disconnect();
-  }, [recompute]);
+  }, [recompute, recomputeMaxChars]);
 
   // Track current page from scroll position (for the page indicator).
   useEffect(() => {
@@ -230,6 +264,7 @@ export default function PaginatedPerformChart({
               : undefined
           }
           lines={runLines}
+          maxCharsPerRow={maxCharsPerRow}
         />,
       );
       runSectionId = null;
@@ -262,6 +297,25 @@ export default function PaginatedPerformChart({
       ref={outerRef}
       className="absolute inset-0 pt-[7vh] pb-16 overflow-hidden"
     >
+      {/* Hidden char-width probe. Rendered in the SAME font / size /
+          letter-spacing as visible chord lines, so `boundingRect.width /
+          textContent.length` gives us the actual rendered `ch` width
+          including kerning. Drives the wrap helper's column budget. */}
+      <span
+        ref={charProbeRef}
+        aria-hidden
+        className="absolute opacity-0 pointer-events-none top-0 left-0"
+        style={{
+          fontFamily: MONO_FONT_STACK,
+          fontSize: "var(--perf-font-size, 0.875rem)",
+          lineHeight: "var(--perf-line-height, 1.25)",
+          letterSpacing: "var(--perf-letter-spacing, normal)",
+          whiteSpace: "pre",
+        }}
+      >
+        {"0".repeat(40)}
+      </span>
+
       {/* Hidden measurement column. Width matches a real visible column
           (page px-4 + grid gap-8 = 64px non-column overhead per page).
           Each block — section header and individual line — is measured
@@ -282,7 +336,7 @@ export default function PaginatedPerformChart({
               {b.kind === "header" ? (
                 <PerformSectionHeader section={b.section} />
               ) : (
-                <PerformLine line={b.line} />
+                <PerformLine line={b.line} maxCharsPerRow={maxCharsPerRow} />
               )}
             </div>
           );
@@ -399,11 +453,30 @@ function PerformSectionHeader({ section }: { section: ChordChartSection }) {
   );
 }
 
-function PerformLine({ line }: { line: ChordChartLine }) {
+function PerformLine({
+  line,
+  maxCharsPerRow,
+}: {
+  line: ChordChartLine;
+  maxCharsPerRow: number | null;
+}) {
   const markerClasses = [
     line.highlight ? "bg-yellow-300/20 rounded px-1" : "",
     line.underline ? "border-b-2 border-yellow-400/80" : "",
   ].filter(Boolean).join(" ");
+
+  // Wrap long lines so they don't get clipped in narrow 2-col columns.
+  // Each sub-row preserves the chord/lyric column alignment of the
+  // original. When maxCharsPerRow is null (first render before
+  // measurement) skip wrapping — the post-measure pass will re-render
+  // with the right budget.
+  const lyrics = line.lyrics ?? "";
+  const chords = line.chords ?? "";
+  const subRows =
+    maxCharsPerRow !== null && (chords.length > maxCharsPerRow || lyrics.length > maxCharsPerRow)
+      ? wrapChordLineAtBars(chords, lyrics, maxCharsPerRow)
+      : [{ chords, lyrics, offset: 0 }];
+
   return (
     <div
       className={`mb-2 ${markerClasses}`}
@@ -414,25 +487,53 @@ function PerformLine({ line }: { line: ChordChartLine }) {
         letterSpacing: "var(--perf-letter-spacing, normal)",
       }}
     >
-      {line.chords && (
-        <div className="text-yellow-300 whitespace-pre min-h-[1em]">
-          {line.chords}
-        </div>
-      )}
-      {line.lyrics && (
-        <div className="text-gray-100 whitespace-pre">
-          <PerformMarkedLyric
-            text={line.lyrics}
-            highlightRanges={line.highlightRanges}
-            underlineRanges={line.underlineRanges}
-          />
-        </div>
-      )}
-      {!line.chords && !line.lyrics && (
-        <div className="text-gray-500 whitespace-pre min-h-[1em]">&nbsp;</div>
-      )}
+      {subRows.map((row, idx) => {
+        const hasChords = row.chords.length > 0;
+        const hasLyrics = row.lyrics.length > 0;
+        return (
+          <div key={idx}>
+            {hasChords && (
+              <div className="text-yellow-300 whitespace-pre min-h-[1em]">
+                {row.chords}
+              </div>
+            )}
+            {hasLyrics && (
+              <div className="text-gray-100 whitespace-pre">
+                <PerformMarkedLyric
+                  text={row.lyrics}
+                  // Shift highlight / underline ranges into the sub-row's
+                  // local coordinate space. Ranges that don't intersect
+                  // this sub-row drop out cleanly.
+                  highlightRanges={shiftRanges(line.highlightRanges, row.offset, row.lyrics.length)}
+                  underlineRanges={shiftRanges(line.underlineRanges, row.offset, row.lyrics.length)}
+                />
+              </div>
+            )}
+            {idx === 0 && !hasChords && !hasLyrics && (
+              <div className="text-gray-500 whitespace-pre min-h-[1em]">&nbsp;</div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
+}
+
+/** Clip an array of [start,end) ranges to a sub-row's window
+ *  `[offset, offset+length)` and re-base them to start at 0. */
+function shiftRanges(
+  ranges: ReadonlyArray<readonly [number, number]> | undefined,
+  offset: number,
+  length: number,
+): ReadonlyArray<readonly [number, number]> | undefined {
+  if (!ranges?.length) return ranges;
+  const end = offset + length;
+  const out: [number, number][] = [];
+  for (const [s, e] of ranges) {
+    if (e <= offset || s >= end) continue;
+    out.push([Math.max(s, offset) - offset, Math.min(e, end) - offset]);
+  }
+  return out;
 }
 
 /** A run of one or more consecutive lines from the same section — either
@@ -444,11 +545,13 @@ function PerformSectionGroup({
   continuation,
   continuationLabel,
   lines,
+  maxCharsPerRow,
 }: {
   section: ChordChartSection | null;
   continuation: boolean;
   continuationLabel?: string;
   lines: { line: ChordChartLine; lineIdx: number }[];
+  maxCharsPerRow: number | null;
 }) {
   return (
     <section className="mb-3">
@@ -459,7 +562,7 @@ function PerformSectionGroup({
         </div>
       )}
       {lines.map(({ line, lineIdx }) => (
-        <PerformLine key={lineIdx} line={line} />
+        <PerformLine key={lineIdx} line={line} maxCharsPerRow={maxCharsPerRow} />
       ))}
     </section>
   );

--- a/src/lib/__tests__/chord-line-wrap.test.ts
+++ b/src/lib/__tests__/chord-line-wrap.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { wrapChordLineAtBars } from "@/lib/chord-line-wrap";
+
+describe("wrapChordLineAtBars — short lines (no wrap)", () => {
+  it("returns a single row when chord+lyric both fit", () => {
+    const out = wrapChordLineAtBars("| Em | Bm |", "I miss you", 20);
+    expect(out).toEqual([
+      { chords: "| Em | Bm |", lyrics: "I miss you", offset: 0 },
+    ]);
+  });
+
+  it("returns a single row when both strings are empty", () => {
+    const out = wrapChordLineAtBars("", "", 10);
+    expect(out).toEqual([{ chords: "", lyrics: "", offset: 0 }]);
+  });
+});
+
+describe("wrapChordLineAtBars — bar-boundary split (preferred)", () => {
+  it("splits a long chord-only line at the rightmost `|` that fits", () => {
+    // "| Em | Bm | C | D |" — 19 chars. maxChars=10 → split at last `|` ≤ 10
+    // i.e., position 10 ("| C "). Row 1 = "| Em | Bm ", row 2 = "| C | D |".
+    const out = wrapChordLineAtBars("| Em | Bm | C | D |", "", 10);
+    expect(out).toEqual([
+      { chords: "| Em | Bm ", lyrics: "", offset: 0 },
+      { chords: "| C | D |", lyrics: "", offset: 10 },
+    ]);
+  });
+
+  it("preserves column alignment between chord and lyric across wraps", () => {
+    // The character that sat at column N in the original pair must
+    // stay at column (N - row.offset) within whichever sub-row covers
+    // column N. Lyric char unique IDs make this verifiable without
+    // hand-computing the exact split points.
+    const chords = "| Em | Bm | C | D |";
+    const lyrics = "ABCDEFGHIJKLMNOPQRS"; // same length as chords, unique chars
+    const out = wrapChordLineAtBars(chords, lyrics, 10);
+    for (const row of out) {
+      for (let k = 0; k < row.chords.length; k++) {
+        expect(row.chords[k]).toBe(chords[row.offset + k]);
+      }
+      for (let k = 0; k < row.lyrics.length; k++) {
+        expect(row.lyrics[k]).toBe(lyrics[row.offset + k]);
+      }
+    }
+  });
+
+  it("emits 3+ sub-rows for very long bar-lines", () => {
+    // 6 bars on one line. maxChars=10 → wraps to 3 rows of 2 bars each.
+    const chords = "| C | C | C | C | C | C |";
+    const out = wrapChordLineAtBars(chords, "", 10);
+    expect(out).toHaveLength(3);
+    expect(out.map((r) => r.chords)).toEqual(["| C | C ", "| C | C ", "| C | C |"]);
+    expect(out.map((r) => r.offset)).toEqual([0, 8, 16]);
+  });
+
+  it("every sub-row (except possibly the first) starts on a `|`", () => {
+    const chords = "| Em | Bm | C | D | Em | Bm |";
+    const out = wrapChordLineAtBars(chords, "", 12);
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i].chords.startsWith("|")).toBe(true);
+    }
+  });
+});
+
+describe("wrapChordLineAtBars — whitespace fallback (no bars in window)", () => {
+  it("splits on whitespace when no `|` fits inside maxChars", () => {
+    // Lyric-only line — no bars to anchor to. Falls back to space split.
+    const out = wrapChordLineAtBars("", "hello world goodbye friend", 12);
+    // Rightmost whitespace at column ≤ 12 in "hello world goodbye friend":
+    //   h e l l o   w o r l d   g o o d b y e
+    //   0 1 2 3 4 5 6 7 8 9 10 11 12
+    // col 11 is a space → split at 11. Row 1 = "hello world", row 2 = " goodbye friend"
+    expect(out[0].lyrics).toBe("hello world");
+    expect(out[1].lyrics.startsWith(" ")).toBe(true);
+    expect(out.map((r) => r.lyrics).join("")).toBe("hello world goodbye friend");
+  });
+
+  it("treats whitespace in EITHER chord or lyric as a candidate break", () => {
+    // Chord has no whitespace, lyric does — the lyric's space drives the wrap.
+    const out = wrapChordLineAtBars("AbCdEfGhIjKl", "abc def ghi jkl", 8);
+    // Last space ≤ col 8 in lyric: col 7 (between "def" and "ghi").
+    expect(out[0].chords.length).toBeLessThanOrEqual(8);
+    expect(out[0].lyrics.length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("wrapChordLineAtBars — hard cut (no breakable boundary)", () => {
+  it("hard-cuts at maxChars when there's no `|` and no whitespace", () => {
+    const out = wrapChordLineAtBars("AbCdEfGhIjKlMnOp", "AbCdEfGhIjKlMnOp", 6);
+    expect(out[0].chords).toBe("AbCdEf");
+    expect(out[1].chords.length).toBeLessThanOrEqual(6);
+  });
+});
+
+describe("wrapChordLineAtBars — invariants", () => {
+  it("rejoining all sub-rows reproduces the originals exactly", () => {
+    const cases: [string, string, number][] = [
+      ["| Em | Bm | C | D |", "I miss you my love today", 10],
+      ["| C | F | G | Am | F | G | C |", "", 8],
+      ["", "hello world goodbye friend tonight", 12],
+      ["short", "lyric", 50],
+      ["| Em |", "ok", 3],
+    ];
+    for (const [chords, lyrics, maxChars] of cases) {
+      const out = wrapChordLineAtBars(chords, lyrics, maxChars);
+      const rejoinedC = out.map((r) => r.chords).join("");
+      const rejoinedL = out.map((r) => r.lyrics).join("");
+      expect(rejoinedC).toBe(chords);
+      expect(rejoinedL).toBe(lyrics);
+    }
+  });
+
+  it("every sub-row fits within maxChars (or contains a single unsplittable token)", () => {
+    const chords = "| C | F | G | Am | F | G | C | F |";
+    const out = wrapChordLineAtBars(chords, "", 10);
+    for (const row of out) {
+      expect(row.chords.length).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("offsets are monotonically increasing and equal cumulative sub-row lengths", () => {
+    const out = wrapChordLineAtBars(
+      "| Em | Bm | C | D | Em | Bm |",
+      "I miss you my love today friend",
+      10,
+    );
+    let cum = 0;
+    for (const row of out) {
+      expect(row.offset).toBe(cum);
+      cum += Math.max(row.chords.length, row.lyrics.length);
+    }
+  });
+});
+
+describe("wrapChordLineAtBars — defensive inputs", () => {
+  it("returns input as single row when maxChars is 0 or negative", () => {
+    const out = wrapChordLineAtBars("abc", "def", 0);
+    expect(out).toEqual([{ chords: "abc", lyrics: "def", offset: 0 }]);
+  });
+});

--- a/src/lib/chord-line-wrap.ts
+++ b/src/lib/chord-line-wrap.ts
@@ -1,0 +1,96 @@
+/**
+ * Wrap a chord+lyric line pair into sub-rows that each fit within
+ * `maxChars`, preserving the chord/lyric column alignment.
+ *
+ * Used by 2-col perform mode: long lines that overflow the narrow
+ * column are split into multiple visual rows so they display without
+ * being clipped.
+ *
+ * Split priority:
+ *  1. Rightmost `|` in the chord line at column ≤ maxChars — each
+ *     wrapped sub-row starts on a clean bar boundary.
+ *  2. Rightmost whitespace in either chord or lyric ≤ maxChars — break
+ *     between words / chord names. Whitespace is preserved in the next
+ *     sub-row (no character is dropped).
+ *  3. Hard cut at maxChars — last resort for lines with no breakable
+ *     boundary.
+ *
+ * Column alignment is maintained by slicing chords and lyrics at the
+ * SAME character offset every time. The character that sat at column
+ * N in the original pair stays at column N within whichever sub-row
+ * contains it.
+ */
+
+export interface WrappedSubRow {
+  chords: string;
+  lyrics: string;
+  /** Offset in characters from the original line's column 0. Lets a
+   *  caller re-base highlight / underline ranges per sub-row. */
+  offset: number;
+}
+
+export function wrapChordLineAtBars(
+  chords: string,
+  lyrics: string,
+  maxChars: number,
+): WrappedSubRow[] {
+  if (maxChars <= 0) return [{ chords, lyrics, offset: 0 }];
+
+  const rows: WrappedSubRow[] = [];
+  let pos = 0;
+  while (true) {
+    const remC = chords.slice(pos);
+    const remL = lyrics.slice(pos);
+    const remLen = Math.max(remC.length, remL.length);
+    if (remLen <= maxChars) {
+      rows.push({ chords: remC, lyrics: remL, offset: pos });
+      break;
+    }
+    const off = findWrapOffset(remC, remL, maxChars);
+    rows.push({
+      chords: remC.slice(0, off),
+      lyrics: remL.slice(0, off),
+      offset: pos,
+    });
+    pos += off;
+    // Safety: if findWrapOffset ever returns 0 we'd loop forever.
+    if (off <= 0) {
+      rows.push({ chords: remC.slice(1), lyrics: remL.slice(1), offset: pos + 1 });
+      break;
+    }
+  }
+  return rows;
+}
+
+function findWrapOffset(
+  chords: string,
+  lyrics: string,
+  maxChars: number,
+): number {
+  // 1) Rightmost `|` in chords at column 1..maxChars. Split AT the bar
+  //    marker (so the next sub-row begins with `|`, matching how bar
+  //    inventories read the chord chart).
+  let bestBar = -1;
+  const barLimit = Math.min(chords.length, maxChars + 1);
+  for (let i = 1; i < barLimit; i++) {
+    if (chords[i] === "|") bestBar = i;
+  }
+  if (bestBar > 0) return bestBar;
+
+  // 2) Rightmost whitespace in either chord or lyric at column 1..maxChars.
+  //    Walking right-to-left so we naturally find the rightmost match.
+  const scanMax = Math.min(maxChars - 1, Math.max(chords.length, lyrics.length) - 1);
+  for (let i = scanMax; i >= 1; i--) {
+    const c = chords[i];
+    const l = lyrics[i];
+    if ((c !== undefined && /\s/.test(c)) || (l !== undefined && /\s/.test(l))) {
+      // Split AT the whitespace position — the whitespace becomes the
+      // first char of the next sub-row. Keeps the column alignment
+      // invariant intact (no characters dropped or duplicated).
+      return i;
+    }
+  }
+
+  // 3) Hard cut.
+  return maxChars;
+}


### PR DESCRIPTION
## Summary

Long chord lines in 2-col perform mode were clipped horizontally because each column lives inside \`overflow-hidden\` and used \`whitespace-pre\`. On iPad portrait the second half of bar-heavy lines was invisible.

- New pure helper \`wrapChordLineAtBars(chords, lyrics, maxChars)\` splits a chord+lyric pair into sub-rows that each fit. Split priority: rightmost \`|\` in the chord line → rightmost whitespace in either chord or lyric → hard cut. Both strings slice at the SAME column offset so a syllable that sat under a chord at column N stays under it.
- \`PaginatedPerformChart\` measures column width + rendered char width (hidden probe in the same font / size / kerning as visible lines) and computes a per-row character budget. Reflow runs on prefs change or resize.
- Highlight / underline ranges shift into each sub-row's local coordinates so marked lyrics stay marked.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 150 pass (137 + 13 new helper tests)
- [x] \`playwright\` auto-scroll e2e — 2 pass
- [ ] iPad: open Foggy Night in 2-col perform mode, confirm long lines wrap and don't clip
- [ ] iPad: rotate orientation, confirm wrap reflows
- [ ] iPad: change perform font size, confirm wrap reflows
- [ ] iPad: confirm 1-col mode is unchanged (helper only wired into 2-col)