### PR TITLE
BYOK on the static deploy: AI calls go direct from browser

### DIFF
--- a/src/components/InlineAIPrompt.tsx
+++ b/src/components/InlineAIPrompt.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useScoreStore } from "@/store/score-store";
-import { IS_STATIC_EXPORT, STATIC_FEATURE_DISABLED_MESSAGE } from "@/lib/api-availability";
-import { getByokHeaders } from "@/lib/api-key-store";
+import { requestReviseScore, aiAvailable, aiUnavailableMessage } from "@/lib/score-client";
 import { v4 as uuidv4 } from "uuid";
 
 interface InlineAIPromptProps {
@@ -38,8 +37,8 @@ export default function InlineAIPrompt({ note, position, onClose }: InlineAIProm
     if (!input.trim() || !score || loading) return;
 
     const prompt = input.trim();
-    if (IS_STATIC_EXPORT) {
-      addMessage({ id: uuidv4(), role: "assistant", content: STATIC_FEATURE_DISABLED_MESSAGE, timestamp: Date.now() });
+    if (!aiAvailable()) {
+      addMessage({ id: uuidv4(), role: "assistant", content: aiUnavailableMessage(), timestamp: Date.now() });
       onClose();
       return;
     }
@@ -52,7 +51,6 @@ export default function InlineAIPrompt({ note, position, onClose }: InlineAIProm
         .filter(n => n.pitch !== "rest")
         .sort((a, b) => a.measure - b.measure || a.beat - b.beat) || [];
       const idx = sorted.findIndex(n => n.measure === note.measure && Math.abs(n.beat - note.beat) < 0.05);
-      const curNote = idx >= 0 ? sorted[idx] : null;
       const prev = idx > 0 ? sorted[idx - 1] : null;
       const next = idx < sorted.length - 1 ? sorted[idx + 1] : null;
 
@@ -60,27 +58,15 @@ export default function InlineAIPrompt({ note, position, onClose }: InlineAIProm
       if (prev) selectedNoteInfo += `. Previous note: ${prev.pitch} m${prev.measure} b${prev.beat}`;
       if (next) selectedNoteInfo += `. Next note: ${next.pitch} m${next.measure} b${next.beat}`;
 
-      const res = await fetch("/api/score/revise", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...getByokHeaders() },
-        body: JSON.stringify({
-          prompt,
-          currentScore: score,
-          selection: {
-            startMeasure: note.measure,
-            endMeasure: note.measure,
-            staffIds: staff ? [staff.id] : undefined,
-          },
-          selectedNote: selectedNoteInfo,
-        }),
-      });
-
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Failed");
+      const data = await requestReviseScore(prompt, score, {
+        startMeasure: note.measure,
+        endMeasure: note.measure,
+        staffIds: staff ? [staff.id] : undefined,
+      }, selectedNoteInfo);
 
       if (data.score) {
         setScore(data.score);
-      } else if (data.patches?.length) {
+      } else if (data.patches.length) {
         applyPatches(data.patches);
       }
 

--- a/src/components/PromptPanel.tsx
+++ b/src/components/PromptPanel.tsx
@@ -3,8 +3,15 @@
 import { useState, useRef, useEffect } from "react";
 import { useScoreStore, ChatMessage, RecordedOperation } from "@/store/score-store";
 import { matchBuiltinCommand, BUILTIN_COMMANDS } from "@/lib/transforms";
-import { IS_STATIC_EXPORT, STATIC_FEATURE_DISABLED_MESSAGE } from "@/lib/api-availability";
-import { getApiKey, getByokHeaders } from "@/lib/api-key-store";
+import { IS_STATIC_EXPORT } from "@/lib/api-availability";
+import { getApiKey } from "@/lib/api-key-store";
+import type { Score, ScorePatch } from "@/lib/schema";
+import {
+  requestCreateScore,
+  requestReviseScore,
+  aiAvailable,
+  aiUnavailableMessage,
+} from "@/lib/score-client";
 import { v4 as uuidv4 } from "uuid";
 import { logEvent, scoreTypeOf } from "@/lib/analytics";
 
@@ -132,19 +139,21 @@ export default function PromptPanel({ onOpenApiKeys }: PromptPanelProps = {}) {
       }
     }
 
-    // AI request
-    if (IS_STATIC_EXPORT) {
+    // AI request — needs either a server-side default key (npm run dev)
+    // or a BYOK key in localStorage (static deploy). aiAvailable() covers
+    // both. The aiUnavailableMessage steers static-deploy users to enter
+    // a key rather than pointing them at local dev.
+    if (!aiAvailable()) {
       addMessage({
         id: crypto.randomUUID(),
         role: "assistant",
-        content: STATIC_FEATURE_DISABLED_MESSAGE,
+        content: aiUnavailableMessage(),
         timestamp: Date.now(),
       });
       return;
     }
     setIsGenerating(true);
     try {
-      const endpoint = score ? "/api/score/revise" : "/api/score/create";
       // Build selection context: use explicit selection range, or derive from stepEntry (selected note)
       let effectiveSelection = selection ?? undefined;
       if (!effectiveSelection && stepEntry && score) {
@@ -176,40 +185,43 @@ export default function PromptPanel({ onOpenApiKeys }: PromptPanelProps = {}) {
           }
         }
       }
-      const body = score
-        ? { prompt, currentScore: score, selection: effectiveSelection, selectedNote: selectedNoteInfo }
-        : { prompt };
-
-      const res = await fetch(endpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...getByokHeaders() },
-        body: JSON.stringify(body),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        throw new Error(data.error || "Failed to process request");
+      // Branch on whether we have a score to revise. Splitting the call
+      // here (vs. accessing a union after) keeps `patches` strongly typed
+      // on the revise path without union-narrowing acrobatics.
+      let resultScore: Score | undefined;
+      let resultPatches: ScorePatch[] = [];
+      let resultMessage = "";
+      let resultWarnings: string[] = [];
+      if (score) {
+        const r = await requestReviseScore(prompt, score, effectiveSelection, selectedNoteInfo);
+        resultScore = r.score;
+        resultPatches = r.patches;
+        resultMessage = r.message;
+        resultWarnings = r.warnings;
+      } else {
+        const r = await requestCreateScore(prompt);
+        resultScore = r.score;
+        resultMessage = r.message;
+        resultWarnings = r.warnings;
       }
 
-      const hasChanges = data.score || (data.patches && data.patches.length > 0);
+      const hasChanges = !!resultScore || resultPatches.length > 0;
 
-      if (data.score) {
-        setScore(data.score);
-      } else if (data.patches && data.patches.length > 0) {
-        applyPatches(data.patches);
+      if (resultScore) {
+        setScore(resultScore);
+      } else if (resultPatches.length > 0) {
+        applyPatches(resultPatches);
       }
 
-      if (data.warnings?.length) {
-        setWarnings(data.warnings);
+      if (resultWarnings.length) {
+        setWarnings(resultWarnings);
       }
 
-      // Only record operation for replay if there were actual changes
       if (hasChanges) {
         setLastOperation({
           prompt,
           type: "ai",
-          patches: data.patches,
+          patches: resultPatches.length > 0 ? resultPatches : undefined,
           selection: selection ?? undefined,
         });
       }
@@ -217,7 +229,7 @@ export default function PromptPanel({ onOpenApiKeys }: PromptPanelProps = {}) {
       addMessage({
         id: uuidv4(),
         role: "assistant",
-        content: data.message || (score ? "Score updated." : "Score created."),
+        content: resultMessage || (score ? "Score updated." : "Score created."),
         timestamp: Date.now(),
       });
     } catch (err: any) {
@@ -256,29 +268,19 @@ export default function PromptPanel({ onOpenApiKeys }: PromptPanelProps = {}) {
       return;
     }
 
-    // Replay AI operation with new selection
-    if (IS_STATIC_EXPORT) {
-      addMessage({ id: uuidv4(), role: "assistant", content: STATIC_FEATURE_DISABLED_MESSAGE, timestamp: Date.now() });
+    // Replay AI operation with new selection — same dispatcher as the
+    // first run (server route in dev, direct browser call on static).
+    if (!aiAvailable()) {
+      addMessage({ id: uuidv4(), role: "assistant", content: aiUnavailableMessage(), timestamp: Date.now() });
       return;
     }
     setIsGenerating(true);
     try {
-      const res = await fetch("/api/score/revise", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...getByokHeaders() },
-        body: JSON.stringify({
-          prompt: lastOperation.prompt,
-          currentScore: score,
-          selection: sel,
-        }),
-      });
-
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Replay failed");
+      const data = await requestReviseScore(lastOperation.prompt, score, sel);
 
       if (data.score) {
         setScore(data.score);
-      } else if (data.patches) {
+      } else if (data.patches.length > 0) {
         applyPatches(data.patches);
       }
 

--- a/src/lib/ai-logger.ts
+++ b/src/lib/ai-logger.ts
@@ -1,21 +1,12 @@
-import fs from "fs";
-import path from "path";
-
-const LOG_DIR = path.join(process.cwd(), ".ai-logs");
-
-function ensureLogDir() {
-  try {
-    if (!fs.existsSync(LOG_DIR)) {
-      fs.mkdirSync(LOG_DIR, { recursive: true });
-    }
-  } catch {
-    // If we can't create the dir, we'll just log to console
-  }
-}
-
-function timestamp(): string {
-  return new Date().toISOString().replace(/[:.]/g, "-");
-}
+/**
+ * AI request/response logging — console only.
+ *
+ * Used to write each request to `.ai-logs/*.json` as well, but that
+ * required `fs`/`path` which broke client bundling once score-client
+ * started importing ai-provider for the BYOK-from-browser path. The
+ * console summary covers debugging needs in both runtimes (devtools
+ * Network tab gives the full request/response payload anyway).
+ */
 
 export interface AILogEntry {
   id: string;
@@ -35,22 +26,14 @@ export interface AILogEntry {
   durationMs: number;
 }
 
-let logCounter = 0;
-
 export function logAIRequest(entry: AILogEntry): void {
-  const ts = entry.timestamp;
   const status = entry.error ? "ERROR" : "OK";
-
-  // Always log summary to console
   console.log(
-    `[AI ${entry.operation.toUpperCase()}] ${status} | ${entry.provider}/${entry.model} | ${entry.durationMs}ms | prompt: "${entry.prompt.slice(0, 80)}${entry.prompt.length > 80 ? "..." : ""}"`
+    `[AI ${entry.operation.toUpperCase()}] ${status} | ${entry.provider}/${entry.model} | ${entry.durationMs}ms | prompt: "${entry.prompt.slice(0, 80)}${entry.prompt.length > 80 ? "..." : ""}"`,
   );
-
   if (entry.error) {
     console.error(`[AI ERROR] ${entry.error}`);
   }
-
-  // Log raw response to console (truncated)
   if (entry.rawResponse) {
     const raw = entry.rawResponse;
     if (raw.length > 500) {
@@ -58,17 +41,5 @@ export function logAIRequest(entry: AILogEntry): void {
     } else {
       console.log(`[AI RAW] ${raw}`);
     }
-  }
-
-  // Write full log to file
-  ensureLogDir();
-  try {
-    logCounter++;
-    const filename = `${ts}-${entry.operation}-${logCounter}.json`;
-    const filepath = path.join(LOG_DIR, filename);
-    fs.writeFileSync(filepath, JSON.stringify(entry, null, 2));
-    console.log(`[AI LOG] Written to ${filepath}`);
-  } catch (err) {
-    console.error("[AI LOG] Failed to write log file:", err);
   }
 }

--- a/src/lib/ai-provider.ts
+++ b/src/lib/ai-provider.ts
@@ -196,6 +196,12 @@ export class ClaudeProvider implements ScoreIntentProvider {
           "Content-Type": "application/json",
           "x-api-key": this.apiKey,
           "anthropic-version": "2023-06-01",
+          // Allow this call from a browser context (BYOK on the static
+          // GitHub Pages deploy). Anthropic requires this header for
+          // any direct-from-browser request; without it the SDK fetch
+          // is rejected by CORS preflight. On a server runtime the
+          // header is a no-op.
+          "anthropic-dangerous-direct-browser-access": "true",
         },
         body: JSON.stringify({
           model: this.model,
@@ -257,6 +263,12 @@ export class ClaudeProvider implements ScoreIntentProvider {
           "Content-Type": "application/json",
           "x-api-key": this.apiKey,
           "anthropic-version": "2023-06-01",
+          // Allow this call from a browser context (BYOK on the static
+          // GitHub Pages deploy). Anthropic requires this header for
+          // any direct-from-browser request; without it the SDK fetch
+          // is rejected by CORS preflight. On a server runtime the
+          // header is a no-op.
+          "anthropic-dangerous-direct-browser-access": "true",
         },
         body: JSON.stringify({
           model: this.model,

--- a/src/lib/score-client.ts
+++ b/src/lib/score-client.ts
@@ -1,0 +1,173 @@
+/**
+ * Client-side dispatcher for AI score operations (create, revise).
+ *
+ * In a normal `npm run dev` environment, score requests go through
+ * Next.js API routes at `/api/score/*` which read BYOK headers from the
+ * client and call Anthropic / OpenAI server-side. In the static
+ * GitHub Pages build (`STATIC_EXPORT=1`), those routes don't exist —
+ * so this module short-circuits the round-trip and calls the provider
+ * directly from the browser using the BYOK key from localStorage.
+ *
+ * Callers don't need to know which path executed: they get the same
+ * shape back either way. Errors thrown contain user-displayable
+ * messages so UI layers can surface them directly.
+ */
+
+import { IS_STATIC_EXPORT } from "@/lib/api-availability";
+import { createProvider } from "@/lib/ai-provider";
+import { getApiKey, getByokHeaders } from "@/lib/api-key-store";
+import {
+  expandIntentToScore,
+  validateScore,
+  validateScoreIntent,
+} from "@/lib/validation";
+import { applyPatch } from "@/lib/patches";
+import type { Score } from "@/lib/schema";
+import type { ScorePatch } from "@/lib/schema";
+import type { NoteSelection } from "@/lib/transforms";
+
+export interface CreateScoreResult {
+  score: Score;
+  message: string;
+  warnings: string[];
+}
+
+export interface ReviseScoreResult {
+  score: Score;
+  patches: ScorePatch[];
+  message: string;
+  warnings: string[];
+}
+
+/**
+ * True when the running build can dispatch AI calls (either via the
+ * server route OR via a BYOK key in browser localStorage). UI gates
+ * should check THIS, not IS_STATIC_EXPORT — a static deploy with a
+ * stored key is perfectly capable of running AI requests.
+ */
+export function aiAvailable(): boolean {
+  if (!IS_STATIC_EXPORT) return true;
+  return !!(getApiKey("anthropic") || getApiKey("openai"));
+}
+
+/** User-facing message for the case where AI is gated. */
+export function aiUnavailableMessage(): string {
+  if (!IS_STATIC_EXPORT) {
+    return "AI is not configured on this server. Set ANTHROPIC_API_KEY (or OPENAI_API_KEY) in .env.local, or open API Keys settings to add one.";
+  }
+  return "Add an Anthropic or OpenAI API key under Settings → API Keys to use AI on this deploy. Keys live only in your browser.";
+}
+
+export async function requestCreateScore(prompt: string): Promise<CreateScoreResult> {
+  if (IS_STATIC_EXPORT) {
+    return createScoreDirect(prompt);
+  }
+  const res = await fetch("/api/score/create", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...getByokHeaders() },
+    body: JSON.stringify({ prompt }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Score create failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function requestReviseScore(
+  prompt: string,
+  currentScore: Score,
+  selection?: NoteSelection,
+  selectedNote?: string,
+): Promise<ReviseScoreResult> {
+  if (IS_STATIC_EXPORT) {
+    return reviseScoreDirect(prompt, currentScore, selection, selectedNote);
+  }
+  const res = await fetch("/api/score/revise", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...getByokHeaders() },
+    body: JSON.stringify({ prompt, currentScore, selection, selectedNote }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Score revise failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+// ── Direct-from-browser implementations ───────────────────────────────────
+// These mirror the logic in src/app/api/score/{create,revise}/route.ts but
+// run client-side using the BYOK key. Any future change to a route's
+// semantics needs a matching change here.
+
+async function createScoreDirect(prompt: string): Promise<CreateScoreResult> {
+  const provider = createProvider({
+    anthropic: getApiKey("anthropic") ?? undefined,
+    openai: getApiKey("openai") ?? undefined,
+  });
+  const { intent, message } = await provider.createScoreFromPrompt(prompt);
+
+  const intentValidation = validateScoreIntent(intent);
+  if (!intentValidation.valid) {
+    throw new Error(
+      `AI generated invalid score structure: ${intentValidation.errors.join("; ")}`,
+    );
+  }
+  const score = expandIntentToScore(intent);
+  const validation = validateScore(score);
+  return {
+    score,
+    message,
+    warnings: [...intentValidation.warnings, ...validation.warnings],
+  };
+}
+
+async function reviseScoreDirect(
+  prompt: string,
+  currentScore: Score,
+  selection?: NoteSelection,
+  selectedNote?: string,
+): Promise<ReviseScoreResult> {
+  // Mirror the server route's chord-chart-vs-staff augmentation.
+  const isChordChart =
+    Array.isArray(currentScore.sections) && currentScore.sections.length > 0;
+  let augmentedPrompt = prompt;
+  if (!isChordChart) {
+    if (selection) {
+      const range =
+        selection.startMeasure === selection.endMeasure
+          ? `measure ${selection.startMeasure}`
+          : `measures ${selection.startMeasure}-${selection.endMeasure}`;
+      const staffNote = selection.staffIds
+        ? ` on staves: ${selection.staffIds.join(", ")}`
+        : "";
+      const noteInfo = selectedNote ? ` (selected note: ${selectedNote})` : "";
+      augmentedPrompt = `[SELECTION: ${range}${staffNote}${noteInfo}] ${prompt}`;
+    } else if (selectedNote) {
+      augmentedPrompt = `[SELECTED NOTE: ${selectedNote}] ${prompt}`;
+    }
+  }
+
+  const provider = createProvider({
+    anthropic: getApiKey("anthropic") ?? undefined,
+    openai: getApiKey("openai") ?? undefined,
+  });
+  const { patches, message } = await provider.reviseScoreFromPrompt(
+    augmentedPrompt,
+    currentScore,
+    selection,
+  );
+
+  let updatedScore = currentScore;
+  for (const patch of patches) {
+    updatedScore = applyPatch(updatedScore, patch);
+  }
+  const validation = validateScore(updatedScore);
+
+  return {
+    score: updatedScore,
+    patches,
+    message,
+    warnings: validation.warnings,
+  };
+}


### PR DESCRIPTION
## Summary

The GitHub Pages deploy had AI features fully gated off — even though BYOK key storage was already in place (PR #55), there was no way to actually use it because the click handler hit a hard "feature requires local dev" message. This unlocks AI generation + revision on the static deploy by routing those calls directly from the browser to Anthropic / OpenAI with the user's stored key.

- New \`src/lib/score-client.ts\` dispatches each request: on \`npm run dev\` it still POSTs to \`/api/score/*\` with BYOK headers; on a static export it calls the provider in-process from the browser, doing the same intent/patch expansion + validation the API route used to do.
- Anthropic fetch sends \`anthropic-dangerous-direct-browser-access: true\` so the CORS preflight passes. No-op on a server runtime.
- \`ai-logger\` had been pulling \`fs\` / \`path\` at the top — that broke client bundling the moment ai-provider became reachable from a client component. Replaced with console-only logging (devtools Network tab covers the full payload).
- UI gates \`aiAvailable()\` / \`aiUnavailableMessage()\` work for both runtimes — no more "clone the repo" dead-end on a static deploy with a stored key.

## Security note (per the convo)

Keys live in localStorage, siloed per-origin per-browser. A static deploy has no shared state, so blast radius is the user's own browser. Anthropic's "dangerously allow browser" header is aimed at SaaS operators who'd ship a single key to every visitor — irrelevant when each user supplies their own key.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 150 pass
- [x] \`playwright\` auto-scroll e2e — 2 pass
- [x] \`STATIC_EXPORT=1 npm run build\` with API routes stripped (mirrors CI) — succeeds
- [ ] iPad: open the deployed site, add Anthropic key under Settings → API Keys, run an AI revise ("shorten this line"), confirm it completes
- [ ] Local \`npm run dev\`: confirm AI calls still hit \`/api/score/*\` (server-side) and still work with env-var key