### PR TITLE
Persistent reflow: reflow_section patch + section-header command

### DIFF
--- a/src/components/ChordChartView.tsx
+++ b/src/components/ChordChartView.tsx
@@ -1136,6 +1136,32 @@ export default function ChordChartView({ score, performMode = false, performColu
         onClick: () => setSectionField("navMark", section?.navMark === "d.c. al fine" ? null : "d.c. al fine") },
       { label: section?.navMark === "d.s. al coda" ? "Remove D.S. al Coda" : "Set D.S. al Coda",
         onClick: () => setSectionField("navMark", section?.navMark === "d.s. al coda" ? null : "d.s. al coda") },
+      // Reflow: split each line in this section into chunks of N bars
+      // per line. Useful when a long line is overflowing the column
+      // (2-col perform mode clips it, 1-col makes the user scroll
+      // horizontally). Idempotent — running again on an already-
+      // reflowed section is a no-op for conforming lines.
+      {
+        divider: true,
+        label: "Reflow to N bars per line…",
+        onClick: () => {
+          const raw = window.prompt(
+            "Bars per line (1-32):",
+            "4",
+          );
+          if (!raw) return;
+          const n = parseInt(raw.trim(), 10);
+          if (!Number.isFinite(n) || n < 1 || n > 32) {
+            window.alert("Please enter a number between 1 and 32.");
+            return;
+          }
+          applyPatches([{
+            op: "reflow_section",
+            sectionId: ctx.sectionId,
+            barsPerLine: n,
+          }]);
+        },
+      },
       {
         divider: true,
         label: "Delete section",

--- a/src/lib/__tests__/chord-line-wrap.test.ts
+++ b/src/lib/__tests__/chord-line-wrap.test.ts
@@ -138,3 +138,121 @@ describe("wrapChordLineAtBars — defensive inputs", () => {
     expect(out).toEqual([{ chords: "abc", lyrics: "def", offset: 0 }]);
   });
 });
+
+import { reflowChordLine, computeBarBoundaries } from "@/lib/chord-line-wrap";
+
+describe("computeBarBoundaries", () => {
+  it("returns [] for lines without `|`", () => {
+    expect(computeBarBoundaries("Em Bm C")).toEqual([]);
+    expect(computeBarBoundaries("")).toEqual([]);
+  });
+
+  it("returns pipe positions for fully-bar-delimited lines", () => {
+    expect(computeBarBoundaries("| Em | Bm | C |")).toEqual([0, 5, 10, 14]);
+  });
+
+  it("prepends firstNonSpace when line has leading content before the first `|`", () => {
+    expect(computeBarBoundaries("Em | Bm | C |")).toEqual([0, 3, 8, 12]);
+  });
+
+  it("appends end-of-content when line has trailing content after the last `|`", () => {
+    expect(computeBarBoundaries("| C | G")).toEqual([0, 4, 7]);
+  });
+});
+
+describe("reflowChordLine — basics", () => {
+  it("returns input unchanged when bar count <= barsPerLine (idempotent)", () => {
+    const out = reflowChordLine("| Em | Bm |", "ok", 4);
+    expect(out).toEqual([{ chords: "| Em | Bm |", lyrics: "ok" }]);
+  });
+
+  it("returns input unchanged when there are no `|` markers", () => {
+    const out = reflowChordLine("Em Bm C", "lyric", 4);
+    expect(out).toEqual([{ chords: "Em Bm C", lyrics: "lyric" }]);
+  });
+
+  it("splits 8 bars into two lines of 4 bars each", () => {
+    const out = reflowChordLine(
+      "| Em | Bm | C | D | Em | Bm | C | D |",
+      "",
+      4,
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0].chords).toBe("| Em | Bm | C | D |");
+    expect(out[1].chords).toBe("| Em | Bm | C | D |");
+  });
+
+  it("splits 6 bars into three lines of 2 bars each", () => {
+    const out = reflowChordLine(
+      "| Em | Bm | C | D | E | F |",
+      "",
+      2,
+    );
+    expect(out).toHaveLength(3);
+    for (const line of out) {
+      // Each sub-line should start AND end with `|` (clean barlines).
+      expect(line.chords.startsWith("|")).toBe(true);
+      expect(line.chords.endsWith("|")).toBe(true);
+    }
+  });
+
+  it("preserves lyrics aligned to chord columns across the split", () => {
+    // 4 bars, lyric chars under specific chord cols.
+    const chords = "| Em | Bm | C | D |";
+    const lyrics = "ABCDEFGHIJKLMNOPQRS"; // unique chars per col
+    const out = reflowChordLine(chords, lyrics, 2);
+    expect(out).toHaveLength(2);
+    // Rejoining lyric slices must reproduce the original lyrics (the
+    // SAME col stays under the SAME chord char on whichever sub-line).
+    const rejoined = out.map((r) => r.lyrics).join("");
+    expect(rejoined).toBe(lyrics);
+  });
+
+  it("handles leading content (no opening `|` on the first bar)", () => {
+    // 3 bars: "Em" (leading), "Bm", "C". Reflow to 1 bar/line.
+    const out = reflowChordLine("Em | Bm | C |", "", 1);
+    expect(out).toHaveLength(3);
+    expect(out[0].chords).toBe("Em |"); // leading bar keeps its style
+    expect(out[1].chords).toBe("| Bm |");
+    expect(out[2].chords).toBe("| C |");
+  });
+
+  it("handles trailing content (no closing `|` on the last bar)", () => {
+    // 2 bars: "| C ", "| G" (trailing, no closing `|`).
+    const out = reflowChordLine("| C | G", "", 1);
+    expect(out).toHaveLength(2);
+    expect(out[0].chords).toBe("| C |");
+    expect(out[1].chords).toBe("| G"); // no closing `|` because there wasn't one
+  });
+});
+
+describe("reflowChordLine — invariants", () => {
+  it("idempotent: running reflow twice with the same N yields the same per-line result", () => {
+    const chords = "| Em | Bm | C | D | E | F |";
+    const once = reflowChordLine(chords, "", 2);
+    const twice = once.flatMap((r) => reflowChordLine(r.chords, r.lyrics, 2));
+    expect(twice).toEqual(once);
+  });
+
+  it("preserves total bar count: sum of bars across sub-lines equals original", () => {
+    const cases: [string, number][] = [
+      ["| Em | Bm | C | D | E | F |", 2],
+      ["| C | F | G | Am | F | G | C | F |", 3],
+      ["Em | Bm | C |", 1],
+    ];
+    for (const [chords, barsPerLine] of cases) {
+      const origBars = Math.max(0, computeBarBoundaries(chords).length - 1);
+      const out = reflowChordLine(chords, "", barsPerLine);
+      const newBars = out.reduce(
+        (sum, r) => sum + Math.max(0, computeBarBoundaries(r.chords).length - 1),
+        0,
+      );
+      expect(newBars).toBe(origBars);
+    }
+  });
+
+  it("returns barsPerLine <= 0 input as a single-line pass-through (defensive)", () => {
+    expect(reflowChordLine("| C |", "", 0)).toEqual([{ chords: "| C |", lyrics: "" }]);
+    expect(reflowChordLine("| C |", "", -3)).toEqual([{ chords: "| C |", lyrics: "" }]);
+  });
+});

--- a/src/lib/__tests__/patches-reflow.test.ts
+++ b/src/lib/__tests__/patches-reflow.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { applyPatch } from "@/lib/patches";
+import type { Score } from "@/lib/schema";
+
+// Minimum-fields fixture — applyPatch only reaches into score.sections
+// for the reflow_section path, but the score still needs the full
+// shape so type-checks line up.
+function fixtureScore(sections: Score["sections"]): Score {
+  return {
+    id: "s1",
+    title: "Test",
+    composer: "",
+    tempo: 120,
+    timeSignature: "4/4",
+    keySignature: "C",
+    measures: 8,
+    anacrusis: false,
+    staves: [],
+    chordSymbols: [],
+    rehearsalMarks: [],
+    repeats: [],
+    measureChanges: [],
+    sections,
+    form: [],
+    metadata: {},
+    annotations: [],
+  };
+}
+
+describe("applyPatch: reflow_section", () => {
+  it("leaves the target section's other fields alone (only `lines` changes)", () => {
+    const score = fixtureScore([
+      {
+        id: "v",
+        label: "Verse",
+        lines: [{ chords: "| Em | Bm | C | D | E | F |", lyrics: "" }],
+      },
+    ]);
+    const out = applyPatch(score, { op: "reflow_section", sectionId: "v", barsPerLine: 2 });
+    expect(out.sections[0].id).toBe("v");
+    expect(out.sections[0].label).toBe("Verse");
+    expect(out.sections[0].lines).toHaveLength(3);
+  });
+
+  it("only touches the named section — others pass through untouched", () => {
+    const score = fixtureScore([
+      {
+        id: "a",
+        label: "Section A",
+        lines: [{ chords: "| Em | Bm | C | D | E | F |", lyrics: "" }],
+      },
+      {
+        id: "b",
+        label: "Section B",
+        lines: [{ chords: "| Em | Bm | C | D | E | F |", lyrics: "" }],
+      },
+    ]);
+    const out = applyPatch(score, { op: "reflow_section", sectionId: "a", barsPerLine: 2 });
+    expect(out.sections[0].lines).toHaveLength(3); // reflowed
+    expect(out.sections[1].lines).toHaveLength(1); // untouched
+    expect(out.sections[1].lines[0].chords).toBe("| Em | Bm | C | D | E | F |");
+  });
+
+  it("is a no-op when no section matches the id", () => {
+    const score = fixtureScore([
+      { id: "v", label: "Verse", lines: [{ chords: "| Em | Bm |", lyrics: "" }] },
+    ]);
+    const out = applyPatch(score, { op: "reflow_section", sectionId: "missing", barsPerLine: 1 });
+    expect(out.sections).toEqual(score.sections);
+  });
+
+  it("idempotent: reflowing the same section with the same barsPerLine twice equals once", () => {
+    const score = fixtureScore([
+      {
+        id: "v",
+        label: "Verse",
+        lines: [{ chords: "| Em | Bm | C | D | E | F | G | A |", lyrics: "" }],
+      },
+    ]);
+    const once = applyPatch(score, { op: "reflow_section", sectionId: "v", barsPerLine: 4 });
+    const twice = applyPatch(once, { op: "reflow_section", sectionId: "v", barsPerLine: 4 });
+    expect(twice.sections[0].lines).toEqual(once.sections[0].lines);
+  });
+
+  it("drops highlight/underline ranges on reflowed lines (v1 documented limitation)", () => {
+    const score = fixtureScore([
+      {
+        id: "v",
+        label: "Verse",
+        lines: [
+          {
+            chords: "| Em | Bm | C | D | E | F |",
+            lyrics: "abc def ghi jkl mno pqr stu",
+            highlightRanges: [[0, 3]] as [number, number][],
+            underlineRanges: [[4, 7]] as [number, number][],
+          },
+        ],
+      },
+    ]);
+    const out = applyPatch(score, { op: "reflow_section", sectionId: "v", barsPerLine: 2 });
+    for (const line of out.sections[0].lines) {
+      expect(line.highlightRanges).toBeUndefined();
+      expect(line.underlineRanges).toBeUndefined();
+    }
+  });
+
+  it("leaves lyric-only / no-bar lines unchanged", () => {
+    const score = fixtureScore([
+      {
+        id: "v",
+        label: "Verse",
+        lines: [
+          { chords: "", lyrics: "this is a lyric-only line" },
+          { chords: "Em Bm C", lyrics: "no bars here" },
+          { chords: "| Em | Bm | C | D | E | F |", lyrics: "" },
+        ],
+      },
+    ]);
+    const out = applyPatch(score, { op: "reflow_section", sectionId: "v", barsPerLine: 2 });
+    // First two pass through; third splits into 3.
+    expect(out.sections[0].lines).toHaveLength(2 + 3);
+    expect(out.sections[0].lines[0].lyrics).toBe("this is a lyric-only line");
+    expect(out.sections[0].lines[1].chords).toBe("Em Bm C");
+  });
+
+  it("preserves total bar content across the split", () => {
+    const score = fixtureScore([
+      {
+        id: "v",
+        label: "Verse",
+        lines: [{ chords: "| C | F | G | Am | F | G | C | F |", lyrics: "" }],
+      },
+    ]);
+    const out = applyPatch(score, { op: "reflow_section", sectionId: "v", barsPerLine: 4 });
+    // Two output lines × 4 bars each = 8 bars total (matches original).
+    expect(out.sections[0].lines).toHaveLength(2);
+    for (const line of out.sections[0].lines) {
+      const pipeCount = (line.chords?.match(/\|/g) ?? []).length;
+      // Each new 4-bar line should have 5 pipes (one per bar boundary).
+      expect(pipeCount).toBe(5);
+    }
+  });
+});

--- a/src/lib/ai-provider.ts
+++ b/src/lib/ai-provider.ts
@@ -131,6 +131,7 @@ Chord-chart (songbook) patches — prefer these over \`replace_score\` when the 
 - { "op": "remove_section_line", "sectionId": string, "lineIdx": number }
 - { "op": "set_form", "form": [section ids in order] }
 - { "op": "split_section", "sectionId": string, "atLineIdx": number, "newSection": { "id": string, "label": string } }  (split a section into two — lines from atLineIdx onward move to the new section)
+- { "op": "reflow_section", "sectionId": string, "barsPerLine": number }  (split each line in a section into chunks of N bars per line — for "shorten these lines" / "rewrap to 4 bars per line" requests)
 
 - { "op": "replace_score", "score": { full score intent object } }  (only if you're rewriting most of the song)
 

--- a/src/lib/chord-line-wrap.ts
+++ b/src/lib/chord-line-wrap.ts
@@ -62,6 +62,87 @@ export function wrapChordLineAtBars(
   return rows;
 }
 
+/**
+ * Compute the column positions that separate bars in a chord line.
+ * Matches the boundary logic in `chord-bar-inventory.ts` so consumers
+ * of this helper see the same bar count as the active-bar overlay.
+ *
+ * Returns `[]` when the line has no `|` markers (the line contributes
+ * no addressable bars). Otherwise the returned array describes
+ * `boundaries.length - 1` bars: bar K spans columns
+ * `[boundaries[K], boundaries[K+1])`.
+ */
+export function computeBarBoundaries(chords: string): number[] {
+  const pipes: number[] = [];
+  for (let c = 0; c < chords.length; c++) {
+    if (chords[c] === "|") pipes.push(c);
+  }
+  if (pipes.length === 0) return [];
+  const firstNonSpace = chords.search(/\S/);
+  const lastNonSpaceEnd = chords.replace(/\s+$/, "").length;
+  const hasLeadingContent = firstNonSpace !== -1 && firstNonSpace < pipes[0];
+  const hasTrailingContent = lastNonSpaceEnd > pipes[pipes.length - 1] + 1;
+  const out: number[] = [];
+  if (hasLeadingContent) out.push(firstNonSpace);
+  for (const p of pipes) out.push(p);
+  if (hasTrailingContent) out.push(lastNonSpaceEnd);
+  return out;
+}
+
+/**
+ * Persistent reflow: split a chord+lyric line into multiple lines of
+ * `barsPerLine` bars each, slicing both strings at the SAME column
+ * positions to preserve chord/lyric alignment.
+ *
+ * Differs from `wrapChordLineAtBars` (which is display-time): this is
+ * the building block for the `reflow_section` patch op that writes
+ * back into the score, so the LLM, editor, 1-col view, and print
+ * surface all see the same shorter lines.
+ *
+ * Idempotency: if the line already has ≤ `barsPerLine` bars, returns
+ * a single sub-line equal to the input. Lines without `|` markers
+ * pass through unchanged.
+ *
+ * Each sub-line's chord slice is extended by 1 char IF the next
+ * column is `|`, so each output sub-line carries its own closing
+ * barline (matching how users typically format chord charts —
+ * "| Em | Bm |" not "| Em | Bm").
+ */
+export function reflowChordLine(
+  chords: string,
+  lyrics: string,
+  barsPerLine: number,
+): { chords: string; lyrics: string }[] {
+  if (barsPerLine <= 0) return [{ chords, lyrics }];
+  const boundaries = computeBarBoundaries(chords);
+  if (boundaries.length === 0) return [{ chords, lyrics }];
+  const barCount = boundaries.length - 1;
+  if (barCount <= barsPerLine) return [{ chords, lyrics }];
+
+  const out: { chords: string; lyrics: string }[] = [];
+  for (let i = 0; i < barCount; i += barsPerLine) {
+    const endBar = Math.min(i + barsPerLine, barCount);
+    const isLastChunk = endBar === barCount;
+    const startCol = boundaries[i];
+    const endCol = boundaries[endBar];
+    // Trailing-pipe extension: if the char AT endCol is `|`, include
+    // it so this sub-line shows a clean closing barline. The pipe
+    // also appears as the leading `|` of the next sub-line (the
+    // chord-chart convention is that consecutive bars share a barline).
+    const chordEnd = chords[endCol] === "|" ? endCol + 1 : endCol;
+    // Lyric ownership: intermediate chunks cut at endCol (so the col
+    // shared as the next chunk's opening barline isn't duplicated).
+    // The LAST chunk extends to the full lyric length — anything past
+    // the last bar boundary (e.g., a trailing syllable) belongs there.
+    const lyricEnd = isLastChunk ? lyrics.length : endCol;
+    out.push({
+      chords: chords.slice(startCol, chordEnd),
+      lyrics: lyrics.slice(startCol, Math.min(lyricEnd, lyrics.length)),
+    });
+  }
+  return out;
+}
+
 function findWrapOffset(
   chords: string,
   lyrics: string,

--- a/src/lib/patches.ts
+++ b/src/lib/patches.ts
@@ -2,6 +2,7 @@ import { Score, ScorePatch } from "./schema";
 import { expandIntentToScore } from "./validation";
 import { debugLog } from "./debug-log";
 import { expandTabs } from "./chord-line";
+import { reflowChordLine } from "./chord-line-wrap";
 
 const DURATION_BEATS: Record<string, number> = {
   whole: 4, half: 2, quarter: 1, eighth: 0.5, sixteenth: 0.25,
@@ -371,6 +372,39 @@ export function applyPatch(score: Score, patch: ScorePatch): Score {
 
     case "set_form": {
       return { ...score, form: patch.form };
+    }
+
+    case "reflow_section": {
+      // Persistent reflow: walk the section's lines and split any line
+      // with more than `barsPerLine` bars into multiple lines, slicing
+      // chords and lyrics at the same column positions so alignment
+      // stays intact. Lines without `|` markers pass through untouched.
+      //
+      // Highlight / underline ranges are dropped on reflow — they're
+      // column-indexed and would need careful per-sub-row reshifting.
+      // The user can re-apply via the existing annotation flow.
+      return {
+        ...score,
+        sections: score.sections.map((s) => {
+          if (s.id !== patch.sectionId) return s;
+          const newLines: typeof s.lines = [];
+          for (const line of s.lines) {
+            const chords = line.chords ?? "";
+            const lyrics = line.lyrics ?? "";
+            const reflowed = reflowChordLine(chords, lyrics, patch.barsPerLine);
+            for (const r of reflowed) {
+              newLines.push({
+                ...line,
+                chords: r.chords,
+                lyrics: r.lyrics,
+                highlightRanges: undefined,
+                underlineRanges: undefined,
+              });
+            }
+          }
+          return { ...s, lines: newLines };
+        }),
+      };
     }
 
     case "split_section": {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -495,6 +495,22 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
    * section keeps the lines before that. Used when the user realizes some
    * lines they've been editing are conceptually a separate section.
    */
+  /**
+   * Persistent auto-reflow: takes every line in `sectionId` and
+   * splits any line with > `barsPerLine` bars into multiple new
+   * lines of `barsPerLine` bars each. Chords + lyrics slice at the
+   * same column positions so alignment is preserved. Lines without
+   * `|` markers (lyric-only) are passed through unchanged. Highlight
+   * / underline ranges are dropped (would need column reshifting).
+   *
+   * Idempotent — running with the section's current bars-per-line
+   * is a no-op for already-conforming lines.
+   */
+  z.object({
+    op: z.literal("reflow_section"),
+    sectionId: z.string(),
+    barsPerLine: z.number().int().min(1).max(32),
+  }),
   z.object({
     op: z.literal("split_section"),
     sectionId: z.string(),


### PR DESCRIPTION
## Summary

Your standing complaint — "manually cleaning up the bar spacing is like combing your hair with tweezers" — gets a command. New patch op \`reflow_section({ sectionId, barsPerLine })\` that splits every line in a section into chunks of N bars per line. Chord and lyric strings slice at the same column positions so alignment stays intact.

**Why a new patch op vs. emitting a cascade of \`set_line\` patches:** undo. The reflow is one undo step instead of N.

## What's in this PR

- \`src/lib/chord-line-wrap.ts\` — new \`reflowChordLine\` helper alongside the existing \`wrapChordLineAtBars\` (display-time wrap from PR #146). Reuses the implicit-start/end bar-boundary logic so the bar count matches the active-bar overlay.
- \`src/lib/patches.ts\` — \`reflow_section\` case applies the helper to each line in the named section.
- \`src/lib/schema.ts\` — adds the op to the discriminated union.
- \`src/components/ChordChartView.tsx\` — section-header context menu gets "Reflow to N bars per line…" (prompts via \`window.prompt\`, matching the MySongsModal "new folder" precedent).
- \`src/lib/ai-provider.ts\` — LLM-facing patch docs updated so AI revise can emit \`reflow_section\` for "shorten these lines" / "rewrap to 4 bars per line" prompts.

## Invariants tested (20 new specs)

- Idempotent (running twice with same N equals once).
- Total bar count preserved across the split.
- Each output sub-line starts and ends with \`|\` when the original did (closing-barline extension).
- Leading content (\`Em | Bm |\`) and trailing content (\`| C | G\`) handled correctly.
- Lyric chars rejoin to the original exactly — alignment preserved bit-for-bit.
- Lines without \`|\` (lyric-only) pass through unchanged.
- Highlight/underline ranges are **dropped** on reflowed lines (v1 limitation — they're column-indexed and would need per-sub-row reshifting; the patch comment + schema comment document this so you can grep for it later).

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 171 pass (150 baseline + 13 wrap-helper + 7 patch + 1 boundary)
- [x] \`playwright test e2e/auto-scroll.spec.ts\` — 6 pass (no regression)
- [x] \`STATIC_EXPORT=1 npm run build\` with API routes stripped (mirrors CI) — builds clean
- [ ] iPad: open Foggy Night, right-click a section header, "Reflow to 4 bars per line…", confirm lines split cleanly with chord/lyric alignment preserved
- [ ] iPad: run reflow twice with same N — second run should be a no-op
- [ ] iPad: try on a lyric-only section — should pass through unchanged

**Not auto-merging** — this mutates score structure across multiple lines, want your eyes on iPad before it lands.