### PR TITLE
Duplicate-song resolver: banner + per-group keep/compare

### DIFF
--- a/src/components/DuplicateResolver.tsx
+++ b/src/components/DuplicateResolver.tsx
@@ -1,0 +1,247 @@
+/**
+ * Duplicate-song resolution panel. Shown inside MySongsModal's right
+ * pane when the user has same-titled song entries (typically the
+ * result of repeated Save-as instead of Save-over).
+ *
+ * Per group:
+ *  - Radio selector for the winner (defaults to richest content).
+ *  - "Compare" toggle expands a side-by-side text preview of each
+ *    entry's chord chart — that's the user's only handle for telling
+ *    near-identical copies apart.
+ *  - "Keep selected, delete N others" actions a single group at a
+ *    time. The list shrinks as groups resolve; pane closes when empty.
+ */
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  type DuplicateGroup,
+  type SongBankEntry,
+  entryContentScore,
+  findDuplicateGroups,
+} from "@/lib/song-bank";
+
+interface Props {
+  songs: ReadonlyArray<SongBankEntry>;
+  onResolve: (keep: SongBankEntry, drop: SongBankEntry[]) => void | Promise<void>;
+  onClose: () => void;
+}
+
+export default function DuplicateResolver({ songs, onResolve, onClose }: Props) {
+  const groups = useMemo(() => findDuplicateGroups(songs), [songs]);
+  // selectedKeepId per canonical key — defaults to the richest-content
+  // entry (groups[*].entries[0] is already sorted that way).
+  const [selectedKeepIds, setSelectedKeepIds] = useState<Record<string, string>>({});
+  const [compareOpen, setCompareOpen] = useState<Record<string, boolean>>({});
+  const [working, setWorking] = useState(false);
+
+  // Initialize / sync selection defaults whenever the groups change
+  // (e.g., after resolving one and the list shrinks).
+  useEffect(() => {
+    setSelectedKeepIds((prev) => {
+      const next = { ...prev };
+      for (const g of groups) {
+        if (!next[g.canonicalKey] || !g.entries.find((e) => e.id === next[g.canonicalKey])) {
+          next[g.canonicalKey] = g.entries[0].id;
+        }
+      }
+      // Drop entries for groups that no longer exist.
+      for (const k of Object.keys(next)) {
+        if (!groups.find((g) => g.canonicalKey === k)) delete next[k];
+      }
+      return next;
+    });
+  }, [groups]);
+
+  // Auto-close once nothing is left to resolve.
+  useEffect(() => {
+    if (groups.length === 0) onClose();
+  }, [groups.length, onClose]);
+
+  const resolveGroup = async (group: DuplicateGroup) => {
+    const keepId = selectedKeepIds[group.canonicalKey] ?? group.entries[0].id;
+    const keep = group.entries.find((e) => e.id === keepId) ?? group.entries[0];
+    const drop = group.entries.filter((e) => e.id !== keep.id);
+    setWorking(true);
+    try {
+      await onResolve(keep, drop);
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  if (groups.length === 0) {
+    return (
+      <div className="p-4 text-sm text-gray-500">
+        No duplicate-titled songs.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-100">
+            Resolve duplicates
+          </h3>
+          <p className="text-[11px] text-gray-500 mt-0.5">
+            {groups.length} {groups.length === 1 ? "title" : "titles"} with more
+            than one copy. Pick which to keep per group.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-200 p-1 rounded hover:bg-white/10"
+          aria-label="Close duplicate resolver"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+        {groups.map((group) => (
+          <DuplicateGroupCard
+            key={group.canonicalKey}
+            group={group}
+            keepId={selectedKeepIds[group.canonicalKey] ?? group.entries[0].id}
+            onSelect={(id) =>
+              setSelectedKeepIds((prev) => ({ ...prev, [group.canonicalKey]: id }))
+            }
+            compareOpen={!!compareOpen[group.canonicalKey]}
+            onToggleCompare={() =>
+              setCompareOpen((prev) => ({
+                ...prev,
+                [group.canonicalKey]: !prev[group.canonicalKey],
+              }))
+            }
+            disabled={working}
+            onResolve={() => resolveGroup(group)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface GroupCardProps {
+  group: DuplicateGroup;
+  keepId: string;
+  onSelect: (id: string) => void;
+  compareOpen: boolean;
+  onToggleCompare: () => void;
+  disabled: boolean;
+  onResolve: () => void;
+}
+
+function DuplicateGroupCard({
+  group,
+  keepId,
+  onSelect,
+  compareOpen,
+  onToggleCompare,
+  disabled,
+  onResolve,
+}: GroupCardProps) {
+  const displayTitle = group.entries[0].title;
+  return (
+    <div className="border border-white/10 rounded-lg overflow-hidden bg-black/20">
+      <div className="flex items-center justify-between px-3 py-2 bg-white/5 border-b border-white/10">
+        <span className="text-sm font-medium text-gray-100 truncate">
+          {displayTitle}
+        </span>
+        <button
+          type="button"
+          onClick={onToggleCompare}
+          className="text-[11px] text-blue-300 hover:text-blue-200 px-2 py-0.5 rounded hover:bg-blue-500/10"
+        >
+          {compareOpen ? "Hide compare" : "Compare"}
+        </button>
+      </div>
+      <div className="divide-y divide-white/5">
+        {group.entries.map((entry) => (
+          <label
+            key={entry.id}
+            className="flex items-start gap-2 px-3 py-2 cursor-pointer hover:bg-white/5"
+          >
+            <input
+              type="radio"
+              name={`keep-${group.canonicalKey}`}
+              checked={keepId === entry.id}
+              onChange={() => onSelect(entry.id)}
+              className="mt-0.5 accent-blue-500"
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 text-[12px] text-gray-200">
+                <span className="font-medium truncate">{entry.title}</span>
+                {entry.folder && (
+                  <span className="text-[9px] uppercase tracking-wider text-gray-500 px-1.5 py-0.5 rounded bg-white/5">
+                    {entry.folder}
+                  </span>
+                )}
+              </div>
+              <div className="text-[10px] text-gray-500 mt-0.5">
+                Saved {formatSavedAt(entry.savedAt)} · {entryContentScore(entry)}{" "}
+                content chars
+              </div>
+              {compareOpen && (
+                <pre className="mt-2 text-[10px] text-gray-400 font-mono whitespace-pre-wrap break-words max-h-48 overflow-y-auto bg-black/30 rounded p-2 border border-white/5">
+                  {chartPreviewText(entry)}
+                </pre>
+              )}
+            </div>
+          </label>
+        ))}
+      </div>
+      <div className="px-3 py-2 border-t border-white/10 bg-white/[0.02]">
+        <button
+          type="button"
+          onClick={onResolve}
+          disabled={disabled}
+          className="w-full text-[12px] px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Keep selected · delete {group.entries.length - 1}{" "}
+          {group.entries.length - 1 === 1 ? "copy" : "copies"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatSavedAt(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "—";
+  try {
+    return new Date(ms).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+/** Render an entry's chord chart as text for the inline compare view —
+ *  section labels + chord row + lyric row per line. Falls back to a
+ *  "(no chord chart content)" placeholder for staff-notation-only scores
+ *  where there's nothing chord-charty to diff. */
+function chartPreviewText(entry: SongBankEntry): string {
+  const sections = entry.score.sections ?? [];
+  if (sections.length === 0) return "(no chord chart content)";
+  const lines: string[] = [];
+  for (const section of sections) {
+    lines.push(`[${section.label || section.id}]`);
+    for (const line of section.lines ?? []) {
+      if (line.chords) lines.push(line.chords);
+      if (line.lyrics) lines.push(line.lyrics);
+      if (!line.chords && !line.lyrics) lines.push("");
+    }
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -9,6 +9,7 @@ import { PickSetBody, PickSongsBody } from "@/components/AddToSetSheet";
 import { getSets, SetsUpdatedEvent, songSetMembership, type SongSet } from "@/lib/song-sets";
 import {
   canonicalSongTitle,
+  findDuplicateGroups,
   getSongs,
   isAliasTitle,
   saveSong,
@@ -19,6 +20,7 @@ import {
   updateSong,
   SongBankEntry,
 } from "@/lib/song-bank";
+import DuplicateResolver from "@/components/DuplicateResolver";
 import {
   CLOUD_ENABLED,
   cloudDeleteSong,
@@ -109,6 +111,7 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     | { kind: "addToSet"; songIds: string[] }
     | { kind: "pickSongs"; targetSetId: string }
     | { kind: "moveFolder"; songIds: string[] }
+    | { kind: "resolveDuplicates" }
     | { kind: null };
   const [rightPane, setRightPane] = useState<RightPaneState>({ kind: null });
   const closeRightPane = () => setRightPane({ kind: null });
@@ -914,6 +917,34 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
           </div>
         ))}
 
+        {/* Duplicate-titled songs detector. When the user has same-
+            titled entries (typically from Save-as instead of Save-over,
+            or from cloud-sync recoveries), surface a banner that opens
+            the per-group resolver in the right pane. This sits above
+            the search box so it's the first thing the user sees when
+            they have a mess to clean up. */}
+        {activeTab === "songs" && !selectMode && rightPane.kind === null && (() => {
+          const dupGroups = findDuplicateGroups(songs);
+          if (dupGroups.length === 0) return null;
+          return (
+            <div className="px-5 py-2 border-b border-amber-500/30 bg-amber-50 text-amber-900 flex items-center gap-3">
+              <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span className="text-[12px] flex-1">
+                {dupGroups.length} duplicate {dupGroups.length === 1 ? "title" : "titles"} —{" "}
+                <button
+                  type="button"
+                  onClick={() => setRightPane({ kind: "resolveDuplicates" })}
+                  className="underline underline-offset-2 hover:text-amber-700"
+                >
+                  Resolve
+                </button>
+              </span>
+            </div>
+          );
+        })()}
+
         {/* Search box — pinned above the list. Hidden in Sets tab and
             in select mode (the bulk-action bar already overloads the
             chrome there). */}
@@ -1331,6 +1362,24 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
                   onPick={(folder) => {
                     void handleBulkMoveToFolderIds(rightPane.songIds, folder);
                     closeRightPane();
+                  }}
+                />
+              )}
+              {rightPane.kind === "resolveDuplicates" && (
+                <DuplicateResolver
+                  songs={songs}
+                  onClose={closeRightPane}
+                  onResolve={async (_keep, drop) => {
+                    // Mirror handleCleanupDuplicates' delete pattern:
+                    // local + cloud delete, then refresh + sync. We
+                    // never touch the kept entry — it stays as-is.
+                    for (const entry of drop) {
+                      deleteSong(entry.id);
+                      if (CLOUD_ENABLED) {
+                        try { await cloudDeleteSong(entry.id); } catch { /* best-effort */ }
+                      }
+                    }
+                    refreshLocal();
                   }}
                 />
               )}

--- a/src/lib/__tests__/song-bank-dedup.test.ts
+++ b/src/lib/__tests__/song-bank-dedup.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  findDuplicateGroups,
+  entryContentScore,
+  type SongBankEntry,
+} from "@/lib/song-bank";
+import type { Score } from "@/lib/schema";
+
+function bareScore(extra: Partial<Score> = {}): Score {
+  return {
+    id: "s",
+    title: "T",
+    composer: "",
+    tempo: 120,
+    timeSignature: "4/4",
+    keySignature: "C",
+    measures: 4,
+    anacrusis: false,
+    staves: [],
+    chordSymbols: [],
+    rehearsalMarks: [],
+    repeats: [],
+    measureChanges: [],
+    sections: [],
+    form: [],
+    metadata: {},
+    annotations: [],
+    ...extra,
+  };
+}
+
+function entry(id: string, title: string, score: Score, savedAt = 0): SongBankEntry {
+  return { id, title, score, savedAt };
+}
+
+describe("findDuplicateGroups", () => {
+  it("returns empty when there are no duplicates", () => {
+    const songs = [
+      entry("a", "Twig", bareScore()),
+      entry("b", "Foggy Night", bareScore()),
+    ];
+    expect(findDuplicateGroups(songs)).toEqual([]);
+  });
+
+  it("groups songs by canonical title (folds case, whitespace, smart quotes)", () => {
+    const songs = [
+      entry("a", "Love Seeking Missiles", bareScore()),
+      entry("b", "love seeking missiles", bareScore()),
+      entry("c", " Love  Seeking  Missiles ", bareScore()),
+      entry("d", "Twig", bareScore()),
+    ];
+    const groups = findDuplicateGroups(songs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].entries.map((e) => e.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("sorts entries within a group by content richness desc (winner first)", () => {
+    const rich = bareScore({
+      sections: [{ id: "v", label: "V", lines: [{ chords: "| Em | Bm | C | D |", lyrics: "a lot of lyric content here" }] }],
+    });
+    const sparse = bareScore({ sections: [{ id: "v", label: "V", lines: [{ chords: "", lyrics: "" }] }] });
+    const songs = [
+      entry("a", "Same Title", sparse, 200),
+      entry("b", "Same Title", rich, 100),
+    ];
+    const groups = findDuplicateGroups(songs);
+    expect(groups).toHaveLength(1);
+    // Richer entry comes first even though it's older.
+    expect(groups[0].entries[0].id).toBe("b");
+  });
+
+  it("breaks content-score ties by newer savedAt", () => {
+    const score = bareScore();
+    const songs = [
+      entry("older", "X", score, 100),
+      entry("newer", "X", score, 500),
+    ];
+    const groups = findDuplicateGroups(songs);
+    expect(groups[0].entries[0].id).toBe("newer");
+  });
+
+  it("groups are alphabetized by canonical key (stable render order)", () => {
+    const songs = [
+      entry("a1", "Zebra", bareScore()),
+      entry("a2", "Zebra", bareScore()),
+      entry("b1", "Apple", bareScore()),
+      entry("b2", "Apple", bareScore()),
+    ];
+    const groups = findDuplicateGroups(songs);
+    expect(groups.map((g) => g.canonicalKey)).toEqual(["apple", "zebra"]);
+  });
+
+  it("ignores singleton entries (no duplicates means no group)", () => {
+    const songs = [
+      entry("a", "Solo Song", bareScore()),
+      entry("b", "Dup Song", bareScore()),
+      entry("c", "Dup Song", bareScore()),
+    ];
+    const groups = findDuplicateGroups(songs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].entries.map((e) => e.title)).toEqual(["Dup Song", "Dup Song"]);
+  });
+});
+
+describe("entryContentScore", () => {
+  it("counts chord + lyric characters in chord chart sections", () => {
+    const e = entry(
+      "x",
+      "X",
+      bareScore({
+        sections: [
+          { id: "v", label: "V", lines: [{ chords: "| C |", lyrics: "hi" }] },
+        ],
+      }),
+    );
+    // "| C |" (5) + "hi" (2) = 7
+    expect(entryContentScore(e)).toBe(7);
+  });
+
+  it("counts notes × 4 in staff-notation scores", () => {
+    const e = entry(
+      "x",
+      "X",
+      bareScore({
+        staves: [
+          {
+            id: "s1",
+            name: "Staff",
+            clef: "treble",
+            voices: [
+              {
+                id: "v1",
+                notes: [
+                  { pitch: "C4", duration: "quarter", measure: 1, beat: 1 },
+                  { pitch: "D4", duration: "quarter", measure: 1, beat: 2 },
+                  { pitch: "rest", duration: "quarter", measure: 1, beat: 3 },
+                ] as Score["staves"][number]["voices"][number]["notes"],
+              },
+            ],
+          },
+        ] as Score["staves"],
+      }),
+    );
+    expect(entryContentScore(e)).toBe(12);
+  });
+
+  it("returns 0 for an empty score", () => {
+    const e = entry("x", "X", bareScore());
+    expect(entryContentScore(e)).toBe(0);
+  });
+});

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -204,3 +204,72 @@ export function setSongFolder(id: string, folder: string | null): SongBankEntry 
   setSongs(songs);
   return next;
 }
+
+/**
+ * Group songs by canonical title and return only the groups with > 1
+ * entry — i.e., duplicates that the user might want to resolve.
+ *
+ * Used by the duplicate-resolver UI in MySongsModal. The canonicalizer
+ * folds smart quotes, case, and whitespace so iPad-typed and Mac-typed
+ * variants of the same song collide.
+ *
+ * Returns groups sorted by their first entry's title (alphabetical) so
+ * the UI shows them in a stable, predictable order. Within each group,
+ * entries are sorted by content richness (most chord+lyric chars
+ * first) so the "kept" radio defaults to the most complete copy.
+ */
+export interface DuplicateGroup {
+  /** Canonical key all entries in this group share. */
+  canonicalKey: string;
+  /** The entries, sorted by content richness desc (winner-candidate first). */
+  entries: SongBankEntry[];
+}
+
+export function findDuplicateGroups(
+  songs: ReadonlyArray<SongBankEntry>,
+): DuplicateGroup[] {
+  const byKey = new Map<string, SongBankEntry[]>();
+  for (const s of songs) {
+    const k = canonicalSongTitle(s.title);
+    const bucket = byKey.get(k);
+    if (bucket) bucket.push(s);
+    else byKey.set(k, [s]);
+  }
+  const groups: DuplicateGroup[] = [];
+  for (const [canonicalKey, entries] of byKey) {
+    if (entries.length <= 1) continue;
+    entries.sort((a, b) => {
+      const sa = entryContentScore(a);
+      const sb = entryContentScore(b);
+      if (sa !== sb) return sb - sa;
+      return b.savedAt - a.savedAt;
+    });
+    groups.push({ canonicalKey, entries });
+  }
+  // Stable order across renders — alphabetical by canonical key.
+  groups.sort((a, b) => a.canonicalKey.localeCompare(b.canonicalKey));
+  return groups;
+}
+
+/**
+ * Heuristic "how much real content does this entry have" score. Counts
+ * chord + lyric characters in a chord chart, and (for staff-notation
+ * scores) note count × 4 as a rough proxy. Higher = more complete.
+ *
+ * Exported because the resolver UI shows this number to the user so
+ * they can see why a particular copy was picked as the default winner.
+ */
+export function entryContentScore(s: SongBankEntry): number {
+  const sections = s.score.sections ?? [];
+  let chars = 0;
+  for (const sec of sections) {
+    for (const line of sec.lines ?? []) {
+      chars += (line.chords ?? "").length;
+      chars += (line.lyrics ?? "").length;
+    }
+  }
+  for (const staff of s.score.staves ?? []) {
+    for (const v of staff.voices ?? []) chars += (v.notes ?? []).length * 4;
+  }
+  return chars;
+}


### PR DESCRIPTION
## Summary

User complaint: "two Love Seeking Missiles" in My Songs, no obvious way to resolve. The existing "Delete duplicate-titled songs" toolbar button auto-picks the richest copy and deletes the rest — fine when you trust the heuristic, less so when you want to see what's about to disappear.

Adds a banner + per-group resolver:

- **Banner** above the My Songs search: "N duplicate titles — Resolve". Opens the resolver in the existing right pane (master/detail collapses on iPad portrait so it gets full width).
- **DuplicateResolver** component: per-group cards with a radio "keep this one", savedAt + content score per entry, and a "Compare" toggle that expands an inline text preview of each entry's chord chart so you can spot which copy has the chord work you want.
- **\`findDuplicateGroups\`** helper in song-bank.ts (extracted + tested): groups by canonical title, sorts within each group by content richness so the richest copy is the default keep-candidate.

Existing one-click auto-cleanup button stays — this is the path when you want eyes on the diff before pulling the trigger.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 180 pass (171 baseline + 9 new dedup specs)
- [x] \`playwright test e2e/auto-scroll.spec.ts\` — 6 pass (unrelated, no regression)
- [x] \`STATIC_EXPORT=1 npm run build\` with API routes stripped — clean