### PR TITLE
DuplicateResolver: full-screen Compare + light-theme contrast fix

### DIFF
--- a/src/components/DuplicateResolver.tsx
+++ b/src/components/DuplicateResolver.tsx
@@ -3,13 +3,19 @@
  * pane when the user has same-titled song entries (typically the
  * result of repeated Save-as instead of Save-over).
  *
+ * The right pane is light-themed (matches MySongsModal's white
+ * background), so the resolver uses dark text on light backgrounds —
+ * the previous iteration assumed PerformView's dark theme and rendered
+ * white text on light grey, which was unreadable.
+ *
  * Per group:
  *  - Radio selector for the winner (defaults to richest content).
- *  - "Compare" toggle expands a side-by-side text preview of each
- *    entry's chord chart — that's the user's only handle for telling
- *    near-identical copies apart.
- *  - "Keep selected, delete N others" actions a single group at a
- *    time. The list shrinks as groups resolve; pane closes when empty.
+ *  - "Compare" button opens a full-screen overlay showing all entries
+ *    side-by-side / stacked so the user can see what's actually
+ *    different. The inline-preview approach was cramped and forced
+ *    horizontal scroll on chord lines.
+ *  - "Keep selected · delete N copies" actions one group at a time.
+ *    The list shrinks as groups resolve; pane closes when empty.
  */
 
 "use client";
@@ -33,7 +39,7 @@ export default function DuplicateResolver({ songs, onResolve, onClose }: Props) 
   // selectedKeepId per canonical key — defaults to the richest-content
   // entry (groups[*].entries[0] is already sorted that way).
   const [selectedKeepIds, setSelectedKeepIds] = useState<Record<string, string>>({});
-  const [compareOpen, setCompareOpen] = useState<Record<string, boolean>>({});
+  const [compareGroupKey, setCompareGroupKey] = useState<string | null>(null);
   const [working, setWorking] = useState(false);
 
   // Initialize / sync selection defaults whenever the groups change
@@ -59,6 +65,14 @@ export default function DuplicateResolver({ songs, onResolve, onClose }: Props) 
     if (groups.length === 0) onClose();
   }, [groups.length, onClose]);
 
+  // Close compare overlay if its group disappeared (e.g. user resolved
+  // it from another path).
+  useEffect(() => {
+    if (compareGroupKey && !groups.find((g) => g.canonicalKey === compareGroupKey)) {
+      setCompareGroupKey(null);
+    }
+  }, [groups, compareGroupKey]);
+
   const resolveGroup = async (group: DuplicateGroup) => {
     const keepId = selectedKeepIds[group.canonicalKey] ?? group.entries[0].id;
     const keep = group.entries.find((e) => e.id === keepId) ?? group.entries[0];
@@ -71,59 +85,75 @@ export default function DuplicateResolver({ songs, onResolve, onClose }: Props) 
     }
   };
 
+  const compareGroup = compareGroupKey
+    ? groups.find((g) => g.canonicalKey === compareGroupKey)
+    : null;
+
   if (groups.length === 0) {
     return (
-      <div className="p-4 text-sm text-gray-500">
+      <div className="p-4 text-sm text-gray-600">
         No duplicate-titled songs.
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
-        <div>
-          <h3 className="text-sm font-semibold text-gray-100">
-            Resolve duplicates
-          </h3>
-          <p className="text-[11px] text-gray-500 mt-0.5">
-            {groups.length} {groups.length === 1 ? "title" : "titles"} with more
-            than one copy. Pick which to keep per group.
-          </p>
+    <>
+      <div className="flex flex-col h-full bg-white text-gray-900">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              Resolve duplicates
+            </h3>
+            <p className="text-[11px] text-gray-600 mt-0.5">
+              {groups.length} {groups.length === 1 ? "title" : "titles"} with more
+              than one copy. Pick which to keep per group.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-800 p-1 rounded hover:bg-gray-100"
+            aria-label="Close duplicate resolver"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="text-gray-400 hover:text-gray-200 p-1 rounded hover:bg-white/10"
-          aria-label="Close duplicate resolver"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4 bg-gray-50">
+          {groups.map((group) => (
+            <DuplicateGroupCard
+              key={group.canonicalKey}
+              group={group}
+              keepId={selectedKeepIds[group.canonicalKey] ?? group.entries[0].id}
+              onSelect={(id) =>
+                setSelectedKeepIds((prev) => ({ ...prev, [group.canonicalKey]: id }))
+              }
+              onOpenCompare={() => setCompareGroupKey(group.canonicalKey)}
+              disabled={working}
+              onResolve={() => resolveGroup(group)}
+            />
+          ))}
+        </div>
       </div>
-      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
-        {groups.map((group) => (
-          <DuplicateGroupCard
-            key={group.canonicalKey}
-            group={group}
-            keepId={selectedKeepIds[group.canonicalKey] ?? group.entries[0].id}
-            onSelect={(id) =>
-              setSelectedKeepIds((prev) => ({ ...prev, [group.canonicalKey]: id }))
-            }
-            compareOpen={!!compareOpen[group.canonicalKey]}
-            onToggleCompare={() =>
-              setCompareOpen((prev) => ({
-                ...prev,
-                [group.canonicalKey]: !prev[group.canonicalKey],
-              }))
-            }
-            disabled={working}
-            onResolve={() => resolveGroup(group)}
-          />
-        ))}
-      </div>
-    </div>
+
+      {compareGroup && (
+        <CompareOverlay
+          group={compareGroup}
+          keepId={selectedKeepIds[compareGroup.canonicalKey] ?? compareGroup.entries[0].id}
+          onSelect={(id) =>
+            setSelectedKeepIds((prev) => ({ ...prev, [compareGroup.canonicalKey]: id }))
+          }
+          onClose={() => setCompareGroupKey(null)}
+          onResolve={async () => {
+            await resolveGroup(compareGroup);
+            setCompareGroupKey(null);
+          }}
+          working={working}
+        />
+      )}
+    </>
   );
 }
 
@@ -131,8 +161,7 @@ interface GroupCardProps {
   group: DuplicateGroup;
   keepId: string;
   onSelect: (id: string) => void;
-  compareOpen: boolean;
-  onToggleCompare: () => void;
+  onOpenCompare: () => void;
   disabled: boolean;
   onResolve: () => void;
 }
@@ -141,62 +170,56 @@ function DuplicateGroupCard({
   group,
   keepId,
   onSelect,
-  compareOpen,
-  onToggleCompare,
+  onOpenCompare,
   disabled,
   onResolve,
 }: GroupCardProps) {
   const displayTitle = group.entries[0].title;
   return (
-    <div className="border border-white/10 rounded-lg overflow-hidden bg-black/20">
-      <div className="flex items-center justify-between px-3 py-2 bg-white/5 border-b border-white/10">
-        <span className="text-sm font-medium text-gray-100 truncate">
+    <div className="border border-gray-300 rounded-lg overflow-hidden bg-white shadow-sm">
+      <div className="flex items-center justify-between px-3 py-2 bg-gray-100 border-b border-gray-200">
+        <span className="text-sm font-medium text-gray-900 truncate">
           {displayTitle}
         </span>
         <button
           type="button"
-          onClick={onToggleCompare}
-          className="text-[11px] text-blue-300 hover:text-blue-200 px-2 py-0.5 rounded hover:bg-blue-500/10"
+          onClick={onOpenCompare}
+          className="text-[12px] font-medium text-blue-700 hover:text-blue-900 px-2 py-0.5 rounded hover:bg-blue-50 border border-blue-200"
         >
-          {compareOpen ? "Hide compare" : "Compare"}
+          Compare
         </button>
       </div>
-      <div className="divide-y divide-white/5">
+      <div className="divide-y divide-gray-200">
         {group.entries.map((entry) => (
           <label
             key={entry.id}
-            className="flex items-start gap-2 px-3 py-2 cursor-pointer hover:bg-white/5"
+            className="flex items-start gap-2 px-3 py-2 cursor-pointer hover:bg-blue-50"
           >
             <input
               type="radio"
               name={`keep-${group.canonicalKey}`}
               checked={keepId === entry.id}
               onChange={() => onSelect(entry.id)}
-              className="mt-0.5 accent-blue-500"
+              className="mt-0.5 accent-blue-600"
             />
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 text-[12px] text-gray-200">
+              <div className="flex items-center gap-2 text-[13px] text-gray-900">
                 <span className="font-medium truncate">{entry.title}</span>
                 {entry.folder && (
-                  <span className="text-[9px] uppercase tracking-wider text-gray-500 px-1.5 py-0.5 rounded bg-white/5">
+                  <span className="text-[9px] uppercase tracking-wider text-gray-600 px-1.5 py-0.5 rounded bg-gray-200">
                     {entry.folder}
                   </span>
                 )}
               </div>
-              <div className="text-[10px] text-gray-500 mt-0.5">
+              <div className="text-[11px] text-gray-600 mt-0.5">
                 Saved {formatSavedAt(entry.savedAt)} · {entryContentScore(entry)}{" "}
                 content chars
               </div>
-              {compareOpen && (
-                <pre className="mt-2 text-[10px] text-gray-400 font-mono whitespace-pre-wrap break-words max-h-48 overflow-y-auto bg-black/30 rounded p-2 border border-white/5">
-                  {chartPreviewText(entry)}
-                </pre>
-              )}
             </div>
           </label>
         ))}
       </div>
-      <div className="px-3 py-2 border-t border-white/10 bg-white/[0.02]">
+      <div className="px-3 py-2 border-t border-gray-200 bg-white">
         <button
           type="button"
           onClick={onResolve}
@@ -206,6 +229,126 @@ function DuplicateGroupCard({
           Keep selected · delete {group.entries.length - 1}{" "}
           {group.entries.length - 1 === 1 ? "copy" : "copies"}
         </button>
+      </div>
+    </div>
+  );
+}
+
+interface CompareOverlayProps {
+  group: DuplicateGroup;
+  keepId: string;
+  onSelect: (id: string) => void;
+  onClose: () => void;
+  onResolve: () => Promise<void> | void;
+  working: boolean;
+}
+
+/** Full-screen compare overlay. The right-pane preview was cramped and
+ *  forced wrapping that scrambled chord/lyric alignment — this gives
+ *  each entry its own column at full reading width. Stacks on narrow
+ *  viewports (iPad portrait). */
+function CompareOverlay({
+  group,
+  keepId,
+  onSelect,
+  onClose,
+  onResolve,
+  working,
+}: CompareOverlayProps) {
+  // Esc closes the overlay.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-[200] bg-white flex flex-col text-gray-900">
+      <div className="flex items-center justify-between px-5 py-3 border-b border-gray-200 bg-gray-50">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-gray-900 truncate">
+            Compare “{group.entries[0].title}”
+          </h2>
+          <p className="text-[12px] text-gray-600 mt-0.5">
+            {group.entries.length} copies side-by-side. Pick a winner to
+            keep; the others get deleted.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onResolve}
+            disabled={working}
+            className="text-sm px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white disabled:opacity-50"
+          >
+            Keep selected · delete {group.entries.length - 1}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-600 hover:text-gray-900 p-2 rounded hover:bg-gray-200"
+            aria-label="Close compare"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-auto p-4 bg-gray-100">
+        <div
+          className="grid gap-4 min-h-full"
+          style={{
+            gridTemplateColumns: `repeat(${Math.min(group.entries.length, 3)}, minmax(0, 1fr))`,
+          }}
+        >
+          {group.entries.map((entry) => {
+            const selected = keepId === entry.id;
+            return (
+              <div
+                key={entry.id}
+                className={`flex flex-col rounded-lg border-2 bg-white shadow-sm overflow-hidden ${
+                  selected
+                    ? "border-blue-500 ring-2 ring-blue-200"
+                    : "border-gray-300"
+                }`}
+              >
+                <label className="flex items-center gap-2 px-3 py-2 bg-gray-50 border-b border-gray-200 cursor-pointer hover:bg-blue-50">
+                  <input
+                    type="radio"
+                    name={`compare-keep-${group.canonicalKey}`}
+                    checked={selected}
+                    onChange={() => onSelect(entry.id)}
+                    className="accent-blue-600"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-semibold text-gray-900 truncate">
+                      {entry.title}
+                      {selected && (
+                        <span className="ml-2 text-[10px] uppercase tracking-wider text-blue-700">
+                          keep
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-[11px] text-gray-600">
+                      Saved {formatSavedAt(entry.savedAt)} ·{" "}
+                      {entryContentScore(entry)} content chars
+                      {entry.folder ? ` · ${entry.folder}` : ""}
+                    </div>
+                  </div>
+                </label>
+                <pre className="flex-1 overflow-auto p-3 m-0 text-[13px] leading-relaxed font-mono text-gray-900 bg-white whitespace-pre">
+                  {chartPreviewText(entry)}
+                </pre>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
@@ -226,10 +369,10 @@ function formatSavedAt(ms: number): string {
   }
 }
 
-/** Render an entry's chord chart as text for the inline compare view —
+/** Render an entry's chord chart as text for the compare view —
  *  section labels + chord row + lyric row per line. Falls back to a
- *  "(no chord chart content)" placeholder for staff-notation-only scores
- *  where there's nothing chord-charty to diff. */
+ *  "(no chord chart content)" placeholder for staff-notation-only
+ *  scores where there's nothing chord-charty to diff. */
 function chartPreviewText(entry: SongBankEntry): string {
   const sections = entry.score.sections ?? [];
   if (sections.length === 0) return "(no chord chart content)";


### PR DESCRIPTION
## Summary

Two regressions from yesterday's PR #154 that the user hit on iPad:

1. **Contrast** — I styled the resolver as dark-on-dark like PerformView, but MySongsModal's right pane is white. Net effect: \`text-gray-100\` on \`bg-black/20\` over white = unreadable light-grey-on-white. Restyled every color to the light theme used by the rest of MySongsModal (dark text on white / gray-50 / gray-100, blue-700 actions, gray-300 visible borders).
2. **Compare was cramped** — the inline preview lived in the ~360px right pane, so each entry's chord chart wrapped at random columns and couldn't actually be compared. Replaced with a full-screen overlay (fixed inset-0, z-[200]) — each entry gets its own column at full reading width, up to 3 side-by-side. Keep-radio + "keep" pill + blue ring on the selected card so the winner is obvious. "Keep selected · delete N" sits in the top bar; Esc closes.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 180 pass (no logic change, just rendering)
- [ ] iPad: open My Songs with duplicate "Love Seeking Missiles" entries, tap "Resolve" banner, tap "Compare", confirm the overlay covers the screen and text is readable.