### PR TITLE
Compare overlay: per-line diff highlighting + 'only diffs' toggle

### DIFF
--- a/src/components/DuplicateResolver.tsx
+++ b/src/components/DuplicateResolver.tsx
@@ -27,6 +27,11 @@ import {
   entryContentScore,
   findDuplicateGroups,
 } from "@/lib/song-bank";
+import {
+  chordChartLines,
+  diffClassifyRows,
+  planCompareRows,
+} from "@/lib/chord-chart-diff";
 
 interface Props {
   songs: ReadonlyArray<SongBankEntry>;
@@ -255,6 +260,8 @@ function CompareOverlay({
   onResolve,
   working,
 }: CompareOverlayProps) {
+  const [showOnlyDiffs, setShowOnlyDiffs] = useState(false);
+
   // Esc closes the overlay.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -267,6 +274,21 @@ function CompareOverlay({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  // Flatten each entry to its array of text rows, then classify each
+  // row position as same / diff across all entries. Memoize so toggling
+  // showOnlyDiffs doesn't redo the work.
+  const { entryRows, classifications, diffCount } = useMemo(() => {
+    const rows = group.entries.map(chordChartLines);
+    const cls = diffClassifyRows(rows);
+    const diffs = cls.filter((k) => k === "diff").length;
+    return { entryRows: rows, classifications: cls, diffCount: diffs };
+  }, [group]);
+
+  const plan = useMemo(
+    () => planCompareRows(classifications, showOnlyDiffs, 1),
+    [classifications, showOnlyDiffs],
+  );
+
   return (
     <div className="fixed inset-0 z-[200] bg-white flex flex-col text-gray-900">
       <div className="flex items-center justify-between px-5 py-3 border-b border-gray-200 bg-gray-50">
@@ -275,11 +297,22 @@ function CompareOverlay({
             Compare “{group.entries[0].title}”
           </h2>
           <p className="text-[12px] text-gray-600 mt-0.5">
-            {group.entries.length} copies side-by-side. Pick a winner to
-            keep; the others get deleted.
+            {group.entries.length} copies · {diffCount}{" "}
+            {diffCount === 1 ? "row differs" : "rows differ"}. Pick a
+            winner; the others get deleted.
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <label className="flex items-center gap-1.5 text-[12px] text-gray-700 px-2 py-1 rounded hover:bg-gray-200 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showOnlyDiffs}
+              onChange={(e) => setShowOnlyDiffs(e.target.checked)}
+              className="accent-blue-600"
+              disabled={diffCount === 0}
+            />
+            Only diffs
+          </label>
           <button
             type="button"
             onClick={onResolve}
@@ -307,8 +340,9 @@ function CompareOverlay({
             gridTemplateColumns: `repeat(${Math.min(group.entries.length, 3)}, minmax(0, 1fr))`,
           }}
         >
-          {group.entries.map((entry) => {
+          {group.entries.map((entry, entryIdx) => {
             const selected = keepId === entry.id;
+            const rows = entryRows[entryIdx];
             return (
               <div
                 key={entry.id}
@@ -342,9 +376,42 @@ function CompareOverlay({
                     </div>
                   </div>
                 </label>
-                <pre className="flex-1 overflow-auto p-3 m-0 text-[13px] leading-relaxed font-mono text-gray-900 bg-white whitespace-pre">
-                  {chartPreviewText(entry)}
-                </pre>
+                <div className="flex-1 overflow-auto text-[13px] leading-relaxed font-mono bg-white">
+                  {plan.map((slot, slotIdx) => {
+                    if (slot.kind === "gap") {
+                      return (
+                        <div
+                          key={`gap-${slotIdx}`}
+                          className="px-3 py-1 text-[11px] italic text-gray-500 bg-gray-50 border-y border-gray-100 select-none"
+                        >
+                          ··· {slot.count} unchanged{" "}
+                          {slot.count === 1 ? "row" : "rows"} ···
+                        </div>
+                      );
+                    }
+                    const text = rows[slot.index];
+                    const isDiff = classifications[slot.index] === "diff";
+                    // `missing` styles the slot where THIS entry has no
+                    // row at this index but the longer entries do —
+                    // shown as an empty dashed row so the diff column
+                    // count stays aligned across the grid.
+                    const missing = text === undefined;
+                    return (
+                      <div
+                        key={slot.index}
+                        className={`px-3 whitespace-pre min-h-[1.4em] ${
+                          missing
+                            ? "bg-amber-50 text-gray-400 italic border-l-2 border-amber-300"
+                            : isDiff
+                            ? "bg-amber-100 text-amber-900 border-l-2 border-amber-400"
+                            : "text-gray-900"
+                        }`}
+                      >
+                        {missing ? "— (no row in this copy)" : text === "" ? " " : text}
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             );
           })}
@@ -369,22 +436,3 @@ function formatSavedAt(ms: number): string {
   }
 }
 
-/** Render an entry's chord chart as text for the compare view —
- *  section labels + chord row + lyric row per line. Falls back to a
- *  "(no chord chart content)" placeholder for staff-notation-only
- *  scores where there's nothing chord-charty to diff. */
-function chartPreviewText(entry: SongBankEntry): string {
-  const sections = entry.score.sections ?? [];
-  if (sections.length === 0) return "(no chord chart content)";
-  const lines: string[] = [];
-  for (const section of sections) {
-    lines.push(`[${section.label || section.id}]`);
-    for (const line of section.lines ?? []) {
-      if (line.chords) lines.push(line.chords);
-      if (line.lyrics) lines.push(line.lyrics);
-      if (!line.chords && !line.lyrics) lines.push("");
-    }
-    lines.push("");
-  }
-  return lines.join("\n").trimEnd();
-}

--- a/src/lib/__tests__/chord-chart-diff.test.ts
+++ b/src/lib/__tests__/chord-chart-diff.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  diffClassifyRows,
+  chordChartLines,
+  planCompareRows,
+} from "@/lib/chord-chart-diff";
+import type { SongBankEntry } from "@/lib/song-bank";
+import type { Score } from "@/lib/schema";
+
+function bareScore(extra: Partial<Score> = {}): Score {
+  return {
+    id: "s",
+    title: "T",
+    composer: "",
+    tempo: 120,
+    timeSignature: "4/4",
+    keySignature: "C",
+    measures: 4,
+    anacrusis: false,
+    staves: [],
+    chordSymbols: [],
+    rehearsalMarks: [],
+    repeats: [],
+    measureChanges: [],
+    sections: [],
+    form: [],
+    metadata: {},
+    annotations: [],
+    ...extra,
+  };
+}
+
+function entry(id: string, sections: Score["sections"]): SongBankEntry {
+  return { id, title: "T", score: bareScore({ sections }), savedAt: 0 };
+}
+
+describe("diffClassifyRows", () => {
+  it("returns [] for an empty input", () => {
+    expect(diffClassifyRows([])).toEqual([]);
+  });
+
+  it("marks every position as same when entries are identical", () => {
+    const rows = [
+      ["a", "b", "c"],
+      ["a", "b", "c"],
+    ];
+    expect(diffClassifyRows(rows)).toEqual(["same", "same", "same"]);
+  });
+
+  it("marks a position as diff when entries disagree there", () => {
+    const rows = [
+      ["a", "b", "c"],
+      ["a", "X", "c"],
+    ];
+    expect(diffClassifyRows(rows)).toEqual(["same", "diff", "same"]);
+  });
+
+  it("marks trailing positions diff when an entry is shorter", () => {
+    const rows = [
+      ["a", "b", "c"],
+      ["a", "b"],
+    ];
+    expect(diffClassifyRows(rows)).toEqual(["same", "same", "diff"]);
+  });
+
+  it("requires every entry to agree (any disagreement → diff)", () => {
+    const rows = [
+      ["a", "b"],
+      ["a", "X"],
+      ["a", "Y"],
+    ];
+    expect(diffClassifyRows(rows)).toEqual(["same", "diff"]);
+  });
+});
+
+describe("chordChartLines", () => {
+  it("returns a placeholder row for staff-notation-only scores", () => {
+    const e = entry("x", []);
+    expect(chordChartLines(e)).toEqual(["(no chord chart content)"]);
+  });
+
+  it("emits section headers, chord rows, lyric rows, and a between-section blank", () => {
+    const e = entry("x", [
+      { id: "v", label: "Verse", lines: [{ chords: "| C |", lyrics: "hi" }] },
+      { id: "c", label: "Chorus", lines: [{ chords: "| G |", lyrics: "" }] },
+    ]);
+    expect(chordChartLines(e)).toEqual([
+      "[Verse]",
+      "| C |",
+      "hi",
+      "",
+      "[Chorus]",
+      "| G |",
+    ]);
+  });
+
+  it("emits a blank row when a line has neither chords nor lyrics", () => {
+    const e = entry("x", [
+      { id: "v", label: "V", lines: [{ chords: "", lyrics: "" }] },
+    ]);
+    expect(chordChartLines(e)).toEqual(["[V]", ""]);
+  });
+
+  it("trims trailing blanks so entries don't share dead-tail rows", () => {
+    const e = entry("x", [
+      { id: "v", label: "V", lines: [{ chords: "| C |", lyrics: "" }] },
+    ]);
+    // After the section we'd otherwise push a "" — make sure it's trimmed.
+    const out = chordChartLines(e);
+    expect(out[out.length - 1]).not.toBe("");
+  });
+});
+
+describe("planCompareRows", () => {
+  it("returns every row index when showOnlyDiffs is false", () => {
+    const plan = planCompareRows(["same", "diff", "same", "same", "diff"], false);
+    expect(plan).toEqual([
+      { kind: "row", index: 0 },
+      { kind: "row", index: 1 },
+      { kind: "row", index: 2 },
+      { kind: "row", index: 3 },
+      { kind: "row", index: 4 },
+    ]);
+  });
+
+  it("collapses runs of same rows into a gap when showOnlyDiffs is true", () => {
+    const plan = planCompareRows(
+      ["same", "same", "diff", "same", "same", "same", "diff", "same"],
+      true,
+      // collapseThreshold default = 1 (collapse any run of consecutive same rows)
+    );
+    expect(plan).toEqual([
+      { kind: "gap", count: 2 },
+      { kind: "row", index: 2 },
+      { kind: "gap", count: 3 },
+      { kind: "row", index: 6 },
+      { kind: "gap", count: 1 },
+    ]);
+  });
+
+  it("keeps short runs of same rows inline when below the collapse threshold", () => {
+    // threshold=3: runs shorter than 3 stay inline; longer runs collapse
+    const plan = planCompareRows(
+      ["same", "same", "diff", "same", "same", "same", "same", "diff"],
+      true,
+      3,
+    );
+    // Leading run length 2 < 3 → kept inline as two row entries.
+    // Then "diff" at 2.
+    // Middle run length 4 ≥ 3 → collapsed.
+    // Then "diff" at 7.
+    expect(plan).toEqual([
+      { kind: "row", index: 0 },
+      { kind: "row", index: 1 },
+      { kind: "row", index: 2 },
+      { kind: "gap", count: 4 },
+      { kind: "row", index: 7 },
+    ]);
+  });
+
+  it("emits no slots when all rows are same and showOnlyDiffs is on (threshold 1)", () => {
+    const plan = planCompareRows(["same", "same", "same"], true, 1);
+    expect(plan).toEqual([{ kind: "gap", count: 3 }]);
+  });
+});

--- a/src/lib/chord-chart-diff.ts
+++ b/src/lib/chord-chart-diff.ts
@@ -1,0 +1,129 @@
+/**
+ * Row-level diff classification for the duplicate-song compare view.
+ *
+ * Each entry's chord chart is flattened to an array of text rows
+ * (section headings, chord lines, lyric lines, blanks) via
+ * `chordChartLines` below. The classifier walks position-by-position
+ * across N entries and marks each row "same" (every entry has the
+ * exact same text at that index) or "diff" (they differ, or one is
+ * missing).
+ *
+ * This is intentionally a simple per-position comparison rather than
+ * a Myers / LCS diff — it works perfectly when entries are
+ * save-twice duplicates (1:1 row alignment), and a single inserted
+ * line cascades into a run of diffs that the user can read past with
+ * the "show only differences" toggle. If we later need true edit-
+ * distance alignment we can swap the algorithm without touching the
+ * UI shape (the return type is just `RowKind[]`).
+ */
+
+import type { SongBankEntry } from "@/lib/song-bank";
+
+export type RowKind = "same" | "diff";
+
+/**
+ * Walk position-by-position across all entries' row arrays. Returns
+ * one RowKind per row index in the longest entry; entries shorter
+ * than the longest get a "diff" classification for the trailing
+ * positions (they're missing those rows).
+ */
+export function diffClassifyRows(entryRows: ReadonlyArray<ReadonlyArray<string>>): RowKind[] {
+  if (entryRows.length === 0) return [];
+  const maxLen = entryRows.reduce((m, e) => Math.max(m, e.length), 0);
+  const out: RowKind[] = [];
+  for (let i = 0; i < maxLen; i++) {
+    const first = entryRows[0][i];
+    let allSame = true;
+    for (let j = 0; j < entryRows.length; j++) {
+      if (entryRows[j][i] !== first) {
+        allSame = false;
+        break;
+      }
+    }
+    out.push(allSame ? "same" : "diff");
+  }
+  return out;
+}
+
+/**
+ * Flatten a SongBankEntry's chord chart into a text-row array suitable
+ * for diffing. One row per section header / chord line / lyric line /
+ * blank. Section dividers are emitted as a blank row so visual blocks
+ * stay readable in the side-by-side view.
+ *
+ * Staff-notation-only scores (no `sections`) get a single
+ * "(no chord chart content)" row.
+ */
+export function chordChartLines(entry: SongBankEntry): string[] {
+  const sections = entry.score.sections ?? [];
+  if (sections.length === 0) return ["(no chord chart content)"];
+  const rows: string[] = [];
+  for (let si = 0; si < sections.length; si++) {
+    const section = sections[si];
+    rows.push(`[${section.label || section.id}]`);
+    for (const line of section.lines ?? []) {
+      if (line.chords) rows.push(line.chords);
+      if (line.lyrics) rows.push(line.lyrics);
+      if (!line.chords && !line.lyrics) rows.push("");
+    }
+    // Blank divider BETWEEN sections (not after the last) so intentional
+    // blank lines INSIDE a section are preserved verbatim in the diff
+    // view, while the trailing tail doesn't pad it with a same-classified
+    // row that everyone agrees on but nobody cares about.
+    if (si < sections.length - 1) rows.push("");
+  }
+  return rows;
+}
+
+/**
+ * Build a "with collapsed runs of same rows" row plan for the compare
+ * view. When `showOnlyDiffs` is off, returns every row index in order.
+ * When on, collapses runs of ≥ `collapseThreshold` consecutive same
+ * rows into a single "ellipsis" placeholder so the user sees only the
+ * interesting parts.
+ */
+export interface VisibleRow {
+  kind: "row";
+  index: number;
+}
+export interface CollapsedGap {
+  kind: "gap";
+  /** How many consecutive same rows this gap represents. */
+  count: number;
+}
+export type CompareRowSlot = VisibleRow | CollapsedGap;
+
+export function planCompareRows(
+  classifications: ReadonlyArray<RowKind>,
+  showOnlyDiffs: boolean,
+  collapseThreshold = 1,
+): CompareRowSlot[] {
+  if (!showOnlyDiffs) {
+    return classifications.map((_, index) => ({ kind: "row", index } as CompareRowSlot));
+  }
+  const out: CompareRowSlot[] = [];
+  let runStart = -1;
+  const flushSameRun = (endExclusive: number) => {
+    if (runStart < 0) return;
+    const count = endExclusive - runStart;
+    if (count >= collapseThreshold) {
+      out.push({ kind: "gap", count });
+    } else {
+      // Short run — keep the rows inline so the user has context.
+      for (let i = runStart; i < endExclusive; i++) {
+        out.push({ kind: "row", index: i });
+      }
+    }
+    runStart = -1;
+  };
+  for (let i = 0; i < classifications.length; i++) {
+    if (classifications[i] === "same") {
+      if (runStart < 0) runStart = i;
+    } else {
+      flushSameRun(i);
+      out.push({ kind: "row", index: i });
+    }
+  }
+  flushSameRun(classifications.length);
+  return out;
+}


### PR DESCRIPTION
## Summary

User: \"you should also highlight differences & be able to filter on diffs only (like *nix diff).\"

- **\`chord-chart-diff.ts\`** — new helpers: \`chordChartLines\` flattens a score to text rows; \`diffClassifyRows\` returns RowKind[] (\"same\" if every entry has identical text at that index, \"diff\" otherwise); \`planCompareRows\` returns a render plan that collapses runs of same rows into \"··· N unchanged rows ···\" placeholders when the toggle is on.
- **CompareOverlay** — each column now renders as a stack of styled divs (not a single \`<pre>\`), so per-row coloring works. Diff rows are amber background + amber text + left border accent. Rows missing from a shorter entry render as dashed \"— (no row in this copy)\" italic placeholders in amber-50, keeping the grid aligned.
- **\"Only diffs\" checkbox** in the header — disables when there are no diffs.

Per-position comparison rather than Myers/LCS — works perfectly on save-twice dups. A single inserted line cascades into a run of diffs that the toggle can hide. Swappable later without touching the UI.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 193 pass (180 baseline + 13 new diff specs)
- [x] \`STATIC_EXPORT=1 npm run build\` with API routes stripped — clean
- [ ] iPad: open Compare on the two \"Love Seeking Missiles\" copies, confirm diff rows are highlighted amber, toggle \"Only diffs\" and confirm the unchanged blocks collapse.