### PR TITLE
Playwright: add WebKit + WebKit-iPad projects; tighten 2-col wrap test scope

### DIFF
--- a/e2e/auto-scroll.spec.ts
+++ b/e2e/auto-scroll.spec.ts
@@ -421,14 +421,21 @@ test.describe("Auto-scroll: 2-col line wrap", () => {
 
     // Count the visible chord-row sub-rows for the one seeded chord
     // line. The yellow-300 class identifies chord rows; we filter to
-    // those that aren't in the hidden measure column.
+    // those that aren't in the hidden measure column AND scope to
+    // PerformView (z-50 overlay) — the editor's ChordChartView stays
+    // mounted underneath the fixed-inset perform overlay and renders
+    // its OWN chord row at the editor's main-area width, which on
+    // narrow viewports overflows visually-clipped by overlap (caught
+    // by webkit-ipad but invisible to the user).
     const result = await page.evaluate(() => {
+      const performRoot = document.querySelector<HTMLElement>(".fixed.inset-0.z-50");
+      if (!performRoot) return [];
       const all = Array.from(
-        document.querySelectorAll<HTMLElement>(".text-yellow-300.whitespace-pre"),
+        performRoot.querySelectorAll<HTMLElement>(".text-yellow-300.whitespace-pre"),
       );
       const visible = all.filter((el) => {
         let cur: HTMLElement | null = el;
-        while (cur && cur !== document.body) {
+        while (cur && cur !== performRoot) {
           if (cur.getAttribute("aria-hidden") === "true") return false;
           cur = cur.parentElement;
         }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,5 +17,24 @@ export default defineConfig({
   },
   projects: [
     { name: "chromium", use: { browserName: "chromium" } },
+    // Run the same specs against WebKit too. The user has reported
+    // PerformView's cursor-to-top-on-resume regression only on iPad
+    // Safari (chromium passes the scrollTop-preservation test). Having
+    // CI exercise WebKit catches Safari-specific regressions going
+    // forward — the engine differs in rAF throttling, scroll-anchoring,
+    // and subpixel rounding, any of which could surface a bug chromium
+    // misses.
+    { name: "webkit", use: { browserName: "webkit" } },
+    // WebKit at iPad-portrait dimensions — closer to what the user
+    // actually sees. Catches viewport-dependent regressions
+    // (toolbar wrap, scroll-anchoring at small widths, etc.) that
+    // desktop-sized WebKit might miss.
+    {
+      name: "webkit-ipad",
+      use: {
+        browserName: "webkit",
+        viewport: { width: 810, height: 1080 },
+      },
+    },
   ],
 });


### PR DESCRIPTION
Adds \`webkit\` (desktop) and \`webkit-ipad\` (810×1080) projects to \`playwright.config.ts\` so CI exercises the Safari engine. The user's long-standing iPad cursor-to-top-on-resume report does NOT reproduce under either WebKit project — bug is likely a stale service-worker bundle on the iPad rather than an engine quirk.

WebKit-iPad immediately surfaced a real testing bug: the 2-col wrap assertion in \`e2e/auto-scroll.spec.ts\` was querying \`.text-yellow-300.whitespace-pre\` across the whole document. The editor's ChordChartView stays mounted underneath the fixed-inset perform overlay (same overlap that bit #143's auto-scroll querySelector) and renders its own chord row at the editor's main-area width — on iPad-portrait widths the editor row overflows even though the USER-VISIBLE PerformView 2-col chart wraps correctly.

Fix: scope the query to PerformView's \`fixed.inset-0.z-50\` root.

## Test plan

- [x] \`playwright test e2e/auto-scroll.spec.ts\` — 18 pass (6 × {chromium, webkit, webkit-ipad}).
- [x] \`tsc --noEmit\` clean.

Note: GitHub Actions still in major outage so CI won't run on this PR yet.