### PR TITLE
Perform: scroll-mode toggle (bars vs constant) + no-warp on bar-less songs

### DIFF
--- a/src/components/PerformView.tsx
+++ b/src/components/PerformView.tsx
@@ -13,6 +13,7 @@ import {
   activeBarFromElapsed,
   beatsPerBarOf,
   computeBarInventory,
+  hasUsableBarTracking,
 } from "@/lib/chord-bar-inventory";
 import {
   computeLineScrollTarget,
@@ -214,8 +215,16 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
   // null = use song's tempo; otherwise this value drives both the
   // scroll rate AND the bar-highlight advance rate.
   const [performTempoOverride, setPerformTempoOverride] = useState<number | null>(null);
+  // Scroll-mode override for the toolbar toggle. null = use the
+  // auto-detected default (hasUsableBarTracking on score). "bars" =
+  // force bar-driven scroll even if coverage is sparse. "constant" =
+  // force constant-rate scroll even if every line has a barline.
+  // Resets when the score changes (same lifecycle as the tempo
+  // override) so a rehearsal choice doesn't leak into the next song.
+  const [scrollModeOverride, setScrollModeOverride] = useState<"bars" | "constant" | null>(null);
   useEffect(() => {
     setPerformTempoOverride(null);
+    setScrollModeOverride(null);
     // New song = fresh playback state. Without this, switching songs
     // mid-rehearsal would resume the new song from the old song's
     // elapsed time, landing the highlight on a bogus bar.
@@ -223,7 +232,23 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
     setActiveBarIdx(null);
   }, [score?.id]);
   const effectiveTempo = performTempoOverride ?? songTempo;
-  const tempoFactor = effectiveTempo > 0 ? effectiveTempo / 120 : 1;
+  // Auto-detect: if ≥ 80% of chord lines carry a `|`, default to bar-
+  // driven scroll. Bar-less songs (Anywhere had this issue — user got
+  // tired of adding barlines) fall to constant-rate so we don't try
+  // to bar-track sparse coverage and end-of-bar-inventory the user
+  // out of the second half of the song.
+  const autoScrollMode: "bars" | "constant" =
+    score && hasUsableBarTracking(score) ? "bars" : "constant";
+  const effectiveScrollMode: "bars" | "constant" = scrollModeOverride ?? autoScrollMode;
+  // Tempo factor: when bar-tracking, scroll IS bar-driven so the
+  // factor only affects the rare fallback frames. When constant, we
+  // want the user's saved px/sec speed regardless of the song's
+  // tempo — otherwise a 240 BPM song scrolls 2× the saved rate,
+  // which is the "warp speed on a bar-less song" the user hit.
+  const tempoFactor =
+    effectiveScrollMode === "bars" && effectiveTempo > 0
+      ? effectiveTempo / 120
+      : 1;
   const effectiveScrollSpeed = prefs.scrollSpeed * tempoFactor;
 
   // Tempo change without rescaling elapsed would jump the bar index —
@@ -286,7 +311,14 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
       // End-of-song detection: when bars run out, stop the loop and
       // reset elapsed so a fresh tap on Continue starts the song over
       // from bar 0 rather than instantly re-finishing.
-      const tracking = barInventory.length > 0 && effectiveTempo > 0;
+      // Gate bar-driven scroll on three conditions:
+      //  - The user (or the auto-detect) wants "bars" mode.
+      //  - The song has a tempo so we know how fast each bar plays.
+      //  - The bar inventory is non-empty (there's something to track).
+      const tracking =
+        effectiveScrollMode === "bars" &&
+        effectiveTempo > 0 &&
+        barInventory.length > 0;
       if (tracking && nextBarIdx === null && autoScrollElapsedRef.current > 0) {
         setAutoScroll(false);
         autoScrollElapsedRef.current = 0;
@@ -337,7 +369,7 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
       }
       scrollAccumRef.current = 0;
     };
-  }, [autoScroll, effectiveScrollSpeed, prefs.columns, barInventory, effectiveTempo, beatsPerBar]);
+  }, [autoScroll, effectiveScrollSpeed, prefs.columns, barInventory, effectiveTempo, beatsPerBar, effectiveScrollMode]);
 
   // Scroll-on-line-transition. When the active bar moves to a DIFFERENT
   // line, animate the chord chart scroll to position that line 1/3 from
@@ -908,6 +940,34 @@ export default function PerformView({ score, onExit, onOpenMySongs }: PerformVie
             title={`Faster (${Math.min(200, prefs.scrollSpeed + 5)} px/sec)`}
           >
             ⊕
+          </button>
+          {/* Scroll-mode toggle: flip between bar-driven (highlights
+              each bar in tempo) and constant-rate (uses px/sec from
+              prefs, tempo factor clamped). Default is auto-detected
+              from `hasUsableBarTracking(score)`; this button lets the
+              user override when the heuristic guesses wrong — e.g.
+              a song where bars are inconsistent but the user wants
+              to lock in bar-tracking anyway, or vice versa. */}
+          <button
+            type="button"
+            onClick={() =>
+              setScrollModeOverride(
+                effectiveScrollMode === "bars" ? "constant" : "bars",
+              )
+            }
+            className={btn}
+            aria-label={
+              effectiveScrollMode === "bars"
+                ? "Switch to constant-rate scroll"
+                : "Switch to bar-driven scroll"
+            }
+            title={
+              effectiveScrollMode === "bars"
+                ? `Bar-driven (tap to switch to constant rate). Auto-detected from bar coverage.`
+                : `Constant rate at ${prefs.scrollSpeed} px/sec (tap to switch to bar-driven).${songTempo > 0 ? "" : " Song has no tempo set."}`
+            }
+          >
+            {effectiveScrollMode === "bars" ? "🎵" : "🐢"}
           </button>
         </div>
         {/* Perform-tempo override cluster — adjust tempo just for

--- a/src/lib/__tests__/chord-bar-inventory.test.ts
+++ b/src/lib/__tests__/chord-bar-inventory.test.ts
@@ -207,3 +207,143 @@ describe("activeBarFromElapsed", () => {
     expect(activeBarFromElapsed(inv, 4.0, 60, 4)).toBe(1);
   });
 });
+
+import { barCoverageFraction, hasUsableBarTracking } from "@/lib/chord-bar-inventory";
+
+describe("barCoverageFraction", () => {
+  it("returns 0 for a score with no chord-containing lines", () => {
+    expect(barCoverageFraction({})).toBe(0);
+    expect(
+      barCoverageFraction({
+        sections: [{ lines: [{ lyrics: "just lyrics" }] }],
+      }),
+    ).toBe(0);
+  });
+
+  it("returns 1 when every chord line has a `|`", () => {
+    expect(
+      barCoverageFraction({
+        sections: [
+          {
+            lines: [
+              { chords: "| Em | Bm |" },
+              { chords: "| C | D |" },
+            ],
+          },
+        ],
+      }),
+    ).toBe(1);
+  });
+
+  it("returns the right fraction when half the chord lines are bar-less", () => {
+    // 4 chord lines, 2 have `|`.
+    expect(
+      barCoverageFraction({
+        sections: [
+          {
+            lines: [
+              { chords: "| Em |" },
+              { chords: "Em Bm" }, // no pipe
+              { chords: "| C |" },
+              { chords: "G F" },   // no pipe
+            ],
+          },
+        ],
+      }),
+    ).toBe(0.5);
+  });
+
+  it("ignores blank / lyric-only / section-header lines in the denominator", () => {
+    // 2 chord lines (one barred, one not). 0.5 — the blank/lyric lines
+    // don't drag the fraction down.
+    expect(
+      barCoverageFraction({
+        sections: [
+          {
+            lines: [
+              { chords: "| Em |" },           // counts (barred)
+              { lyrics: "lyric only line" },  // ignored
+              { chords: "" },                 // ignored
+              { chords: "G F" },              // counts (not barred)
+            ],
+          },
+        ],
+      }),
+    ).toBe(0.5);
+  });
+
+  it("aggregates across multiple sections", () => {
+    // 3 chord lines total, 2 with bars.
+    expect(
+      barCoverageFraction({
+        sections: [
+          { lines: [{ chords: "| Em |" }] },
+          { lines: [{ chords: "| Bm |" }, { chords: "C" }] },
+        ],
+      }),
+    ).toBeCloseTo(2 / 3, 3);
+  });
+});
+
+describe("hasUsableBarTracking", () => {
+  it("is true when coverage clears the default threshold (0.8)", () => {
+    // 5 chord lines, 4 barred = 0.8 — just meets the bar.
+    expect(
+      hasUsableBarTracking({
+        sections: [
+          {
+            lines: [
+              { chords: "| Em |" }, { chords: "| Bm |" }, { chords: "| C |" }, { chords: "| D |" },
+              { chords: "G" }, // 1 of 5 is unbarred
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when coverage drops below 0.8 (user got tired half way)", () => {
+    // 5 chord lines, 3 barred = 0.6 — below threshold.
+    expect(
+      hasUsableBarTracking({
+        sections: [
+          {
+            lines: [
+              { chords: "| Em |" }, { chords: "| Bm |" }, { chords: "| C |" },
+              { chords: "G" }, { chords: "F" }, // 2 of 5 are unbarred
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a song with zero bars (the warp-speed case)", () => {
+    expect(
+      hasUsableBarTracking({
+        sections: [
+          { lines: [{ chords: "Em Bm" }, { chords: "C G" }] },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("respects a custom threshold", () => {
+    // 5 chord lines, 3 barred = 0.6. Threshold 0.5 → true.
+    expect(
+      hasUsableBarTracking(
+        {
+          sections: [
+            {
+              lines: [
+                { chords: "| Em |" }, { chords: "| Bm |" }, { chords: "| C |" },
+                { chords: "G" }, { chords: "F" },
+              ],
+            },
+          ],
+        },
+        0.5,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/lib/chord-bar-inventory.ts
+++ b/src/lib/chord-bar-inventory.ts
@@ -91,6 +91,47 @@ export function computeBarInventory(score: Score): BarPos[] {
 }
 
 /**
+ * Bar-coverage heuristic for the perform-mode scroll-mode toggle.
+ *
+ * Returns the fraction of CHORD-CONTAINING lines that have at least
+ * one `|` marker. Lines without chord content (blank, lyric-only,
+ * section headers) don't enter the denominator — they couldn't have
+ * bars anyway. Zero chord lines → 0 (defensive; caller treats as
+ * "no usable bar coverage").
+ *
+ * Used by PerformView to decide whether to default to bar-driven
+ * scroll (good coverage) or constant-rate scroll (sparse / no bars).
+ * The user can override the auto-decision with the toolbar toggle.
+ */
+export function barCoverageFraction(score: { sections?: { lines?: { chords?: string; lyrics?: string }[] }[] }): number {
+  const sections = score.sections ?? [];
+  let chordLines = 0;
+  let barredLines = 0;
+  for (const section of sections) {
+    for (const line of section.lines ?? []) {
+      const chords = line.chords ?? "";
+      if (chords.length === 0) continue;
+      chordLines++;
+      if (chords.includes("|")) barredLines++;
+    }
+  }
+  if (chordLines === 0) return 0;
+  return barredLines / chordLines;
+}
+
+/**
+ * Convenience predicate: is bar coverage good enough to use the
+ * bar-tracked scroll model by default? Threshold defaults to 0.8
+ * (80% of chord-containing lines have at least one `|`).
+ */
+export function hasUsableBarTracking(
+  score: { sections?: { lines?: { chords?: string; lyrics?: string }[] }[] },
+  threshold = 0.8,
+): boolean {
+  return barCoverageFraction(score) >= threshold;
+}
+
+/**
  * Parse a time-signature string like "4/4" / "6/8" / "12/8". Returns
  * the numerator (beats per bar). Defaults to 4 on parse failure so
  * autoscroll never explodes on weird input.


### PR DESCRIPTION
**User report:** rehearsing "Anywhere" — a song they hadn't barlined — auto-scroll raced at warp speed. Constant-rate path multiplied \`prefs.scrollSpeed\` by \`effectiveTempo / 120\`, so a 240 BPM song with no bars scrolled 2× the saved px/sec. They also asked: what if you got tired of adding barlines halfway through?

**Two-part fix:**

1. **Auto-detect** — new helpers \`barCoverageFraction(score)\` and \`hasUsableBarTracking(score, t=0.8)\` in chord-bar-inventory.ts. PerformView defaults to bar-driven scroll when ≥ 80% of chord-containing lines have a \`|\`, constant-rate otherwise.
2. **Manual override + warp clamp** — new toolbar button next to the scroll-speed cluster: 🎵 (bars) ↔ 🐢 (constant). State resets on song change. When constant mode is active, \`tempoFactor\` clamps to 1.0 so a bar-less song no longer warps.

10 new unit tests for the coverage helpers + full auto-scroll suite green across chromium, webkit, webkit-ipad (18 tests).