### PR TITLE
Update AI model to claude-sonnet-4-6 (Sonnet 4.0 retired)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,6 @@
 # AI Provider — set ONE of the following:
 ANTHROPIC_API_KEY=sk-ant-...
-# ANTHROPIC_MODEL=claude-sonnet-4-20250514
+# ANTHROPIC_MODEL=claude-sonnet-4-6
 
 # OPENAI_API_KEY=sk-...
 # OPENAI_MODEL=gpt-4o

--- a/src/lib/ai-provider.ts
+++ b/src/lib/ai-provider.ts
@@ -171,7 +171,7 @@ export class ClaudeProvider implements ScoreIntentProvider {
   private apiKey: string;
   private model: string;
 
-  constructor(apiKey: string, model = "claude-sonnet-4-20250514") {
+  constructor(apiKey: string, model = "claude-sonnet-4-6") {
     this.apiKey = apiKey;
     this.model = model;
   }
@@ -479,7 +479,7 @@ export function createProvider(byok?: ByokOverrides): ScoreIntentProvider {
   if (anthropicKey) {
     return new ClaudeProvider(
       anthropicKey,
-      process.env.ANTHROPIC_MODEL || "claude-sonnet-4-20250514"
+      process.env.ANTHROPIC_MODEL || "claude-sonnet-4-6"
     );
   }
 


### PR DESCRIPTION
## Why
`claude-sonnet-4-20250514` (Sonnet 4.0) **retired 2026-06-15** and now returns 404, breaking AI create/revise — including the BYOK browser path on the static GitHub Pages build. This is the live "AI API error" the user is hitting.

## Change
Swap the model ID to the current **`claude-sonnet-4-6`** in:
- `src/lib/ai-provider.ts` — `ClaudeProvider` default + `createProvider()` fallback
- `.env.local.example` — documented `ANTHROPIC_MODEL` override

No request-shape changes required: the calls send only `model`/`max_tokens`/`system`/`messages` — none of the 4.x breaking-change surface (no `budget_tokens`, sampling params, assistant prefills, or `output_format`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)