### PR TITLE
Sync: never tombstone a song with unpushed local edits

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ import JoinSongbookModal from "@/components/JoinSongbookModal";
 import PerformView from "@/components/PerformView";
 import PersistFailureBanner from "@/components/PersistFailureBanner";
 import FeedbackModal from "@/components/FeedbackModal";
-import { CLOUD_ENABLED, getDeviceId, setDeviceId, cloudPutSong, syncSongbook } from "@/lib/song-cloud";
+import { CLOUD_ENABLED, getDeviceId, setDeviceId, cloudPutSong, syncSongbook, enqueueOffline } from "@/lib/song-cloud";
 import { setSongs as writeLocalSongs, type SongBankEntry } from "@/lib/song-bank";
 import ImportSongbookDialog, { type ImportSongbookPayload } from "@/components/ImportSongbookDialog";
 import { autosaveToCloud, CloudSaveEvents } from "@/lib/cloud-autosave";
@@ -1619,9 +1619,21 @@ export default function Home() {
                 score: conflict.local!,
                 cloudVersion: dto.version,
                 savedAt: dto.savedAt,
+                pendingSync: false,
               });
             } catch (err) {
+              // Don't swallow: the song still has unpushed edits. Keep it
+              // marked dirty (so sync won't tombstone it) and queue a retry
+              // so the work reaches cloud — and the other device — later.
               console.warn("[conflict] keep-mine save failed", err);
+              updateSong(conflict.songId, { pendingSync: true });
+              enqueueOffline({
+                type: "put",
+                id: conflict.songId,
+                title: conflict.current.title,
+                score: conflict.local!,
+                savedAt: Date.now(),
+              });
             }
             setConflict(null);
           }}
@@ -1633,6 +1645,7 @@ export default function Home() {
               score: conflict.current.score,
               cloudVersion: conflict.current.version,
               savedAt: conflict.current.savedAt,
+              pendingSync: false,
             });
             setConflict(null);
           }}

--- a/src/lib/__tests__/cloud-autosave.test.ts
+++ b/src/lib/__tests__/cloud-autosave.test.ts
@@ -289,6 +289,33 @@ describe("syncSongbook — tombstone deletion", () => {
     expect(getSongs()).toHaveLength(0);
   });
 
+  it("does NOT tombstone an entry with unpushed local edits — re-pushes it instead", async () => {
+    // Regression: a song edited on this device (pendingSync) whose id is
+    // missing from the cloud list must be re-pushed, not dropped. Otherwise
+    // an edit-then-vanish happens when a prior push didn't land.
+    const { syncSongbook } = await import("../song-cloud");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    saveSong("Dirty", buildScore({ title: "Dirty" }));
+    const id = getSongs()[0].id;
+    updateSong(id, { cloudVersion: "v9", pendingSync: true });
+
+    let pushed = false;
+    mockFetch({
+      "GET /songs": () => ({ songs: [] }),
+      [`PUT /songs/${id}`]: () => {
+        pushed = true;
+        return dto(buildScore({ id, title: "Dirty" }), "rescued");
+      },
+    });
+
+    const merged = await syncSongbook();
+    expect(pushed).toBe(true);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].cloudVersion).toBe("rescued");
+    expect(merged[0].pendingSync).toBe(false);
+  });
+
   it("pushes a never-synced local entry up (legacy migration)", async () => {
     const { syncSongbook } = await import("../song-cloud");
     const { saveSong, getSongs } = await import("../song-bank");

--- a/src/lib/cloud-autosave.ts
+++ b/src/lib/cloud-autosave.ts
@@ -46,6 +46,11 @@ export async function autosaveToCloud(
   const folder = localEntry?.folder ?? null;
   const expectedVersion = localEntry?.cloudVersion;
 
+  // Mark dirty up front so the entry is protected from the tombstone path in
+  // syncSongbook if this push never lands (flaky network, tab closed mid-push,
+  // conflict left unresolved). Cleared below once the push is confirmed.
+  if (localEntry) updateSong(songId, { pendingSync: true });
+
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent(SAVING_EVENT));
   }
@@ -62,7 +67,7 @@ export async function autosaveToCloud(
     // Mirror to local entry so list views show the latest savedAt and
     // the cloudVersion advances in lockstep with cloud.
     if (localEntry) {
-      updateSong(songId, { score, savedAt: now, cloudVersion: dto.version });
+      updateSong(songId, { score, savedAt: now, cloudVersion: dto.version, pendingSync: false });
     }
     lastPushedScore = score;
     lastPushedSongId = songId;
@@ -99,6 +104,7 @@ export async function autosaveToCloud(
               score: merge.score,
               savedAt: now2,
               cloudVersion: dto.version,
+              pendingSync: false,
             });
             lastPushedScore = merge.score;
             lastPushedSongId = songId;

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -12,6 +12,12 @@ export interface SongBankEntry {
    *  expectedVersion on cloudPutSong so concurrent writes from another
    *  device get caught with a 409 instead of silently overwriting (#87). */
   cloudVersion?: string;
+  /** True when the entry has local edits that haven't been confirmed pushed
+   *  to cloud. Set on autosave, cleared on a successful push/pull. Guards the
+   *  tombstone path in syncSongbook: an entry that is dirty is RE-PUSHED
+   *  rather than dropped, so a song the user just edited can't vanish when a
+   *  push hasn't landed yet (e.g. flaky network mid-conflict). */
+  pendingSync?: boolean;
 }
 
 const STORAGE_KEY = "notation-app-songs";
@@ -172,7 +178,7 @@ export function renameSong(id: string, title: string): SongBankEntry | null {
  *  current song) instead of saveSong (which always creates a new entry). */
 export function updateSong(
   id: string,
-  patch: Partial<Pick<SongBankEntry, "title" | "score" | "savedAt" | "folder" | "cloudVersion">>,
+  patch: Partial<Pick<SongBankEntry, "title" | "score" | "savedAt" | "folder" | "cloudVersion" | "pendingSync">>,
 ): SongBankEntry | null {
   const songs = getSongs();
   const idx = songs.findIndex(s => s.id === id);
@@ -184,6 +190,7 @@ export function updateSong(
     ...(patch.savedAt !== undefined ? { savedAt: patch.savedAt } : {}),
     ...(patch.folder !== undefined ? { folder: patch.folder } : {}),
     ...(patch.cloudVersion !== undefined ? { cloudVersion: patch.cloudVersion } : {}),
+    ...(patch.pendingSync !== undefined ? { pendingSync: patch.pendingSync } : {}),
   };
   songs[idx] = next;
   setSongs(songs);

--- a/src/lib/song-cloud.ts
+++ b/src/lib/song-cloud.ts
@@ -284,7 +284,7 @@ export async function syncSongbook(opts?: {
         }
         merged.push({
           ...localEntry,
-          ...(pushedDto?.version !== undefined && { cloudVersion: pushedDto.version }),
+          ...(pushedDto?.version !== undefined && { cloudVersion: pushedDto.version, pendingSync: false }),
         });
       } else {
         try {
@@ -342,11 +342,16 @@ export async function syncSongbook(opts?: {
     // intentional." Without it we'd assume migration and push back up.
     for (const entry of local) {
       if (cloudIds.has(entry.id)) continue;
-      if (entry.cloudVersion) {
-        // Tombstone respect — cloud deleted it, propagate the deletion
-        // locally. Don't add to merged.
+      if (entry.cloudVersion && !entry.pendingSync) {
+        // Tombstone respect — entry was synced before and cloud no longer
+        // lists it, with NO pending local edits → an intentional deletion
+        // from another device. Propagate by dropping it (#101).
         continue;
       }
+      // Either never-synced (legacy/migration) OR has unpushed local edits
+      // (pendingSync). In both cases (re)push instead of dropping — this is
+      // what stops "edited a song, then it vanished from this device" when a
+      // prior push didn't land (e.g. a flaky-network conflict resolution).
       try {
         const dto = await cloudPutSong({
           id: entry.id,
@@ -355,7 +360,7 @@ export async function syncSongbook(opts?: {
           savedAt: entry.savedAt,
           folder: entry.folder ?? null,
         });
-        merged.push({ ...entry, cloudVersion: dto.version });
+        merged.push({ ...entry, cloudVersion: dto.version, pendingSync: false });
       } catch (err) {
         merged.push(entry);
         if (isTransient(err)) {


### PR DESCRIPTION
## The bug you hit
Edit a song on the iPad → conflict modal → pick a version → **song vanishes from the iPad** (still on desktop). That's data loss.

## Root cause
`syncSongbook` (`song-cloud.ts`) treated *any* local entry that has a `cloudVersion` but is missing from the cloud's song list as an **intentional remote deletion** and dropped it (the tombstone logic from #101). But if a push hadn't actually landed — e.g. the "keep mine" resolution's PUT failed on flaky iPad network (we saw "Failed to fetch" in the transcript) — the just-edited song looked identical to a remotely-deleted one and got silently tombstoned.

## Fix
Add a `pendingSync` dirty flag on `SongBankEntry`:
- **Set** on autosave (before the push) and on a failed conflict-resolution.
- **Cleared** on every confirmed push/pull.
- The tombstone branch now drops only **clean** entries (genuine remote deletions); **dirty** entries are **re-pushed** to cloud instead — so the song reappears locally *and* propagates to the other device.

Also hardened the conflict **"keep mine"** path: instead of swallowing a failed push with `console.warn`, it keeps the entry dirty and queues an offline retry, so the work still reaches the cloud later.

This preserves the #101 resurrection guard: a song genuinely deleted on another device is still clean (no pending edits) → still tombstoned correctly.

## Verification
- Typecheck clean; **213 tests pass** (was 212).
- Existing tombstone + never-synced-migration tests unchanged and green.
- Added a regression test: a dirty entry absent from the cloud list is **re-pushed, not dropped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)