### PR TITLE
Add move_section patch op + merge (not wipe) on songbook join

### DIFF
--- a/src/components/ChordChartView.tsx
+++ b/src/components/ChordChartView.tsx
@@ -1113,6 +1113,20 @@ export default function ChordChartView({ score, performMode = false, performColu
         label: "Add section below",
         onClick: () => handleAddSection(idx >= 0 ? idx + 1 : undefined),
       },
+      // Reorder this section in the printed/edited order.
+      {
+        divider: true,
+        label: "Move section up",
+        disabled: idx <= 0,
+        onClick: () =>
+          applyPatches([{ op: "move_section", sectionId: ctx.sectionId, toIndex: idx - 1 }]),
+      },
+      {
+        label: "Move section down",
+        disabled: idx < 0 || idx >= score.sections.length - 1,
+        onClick: () =>
+          applyPatches([{ op: "move_section", sectionId: ctx.sectionId, toIndex: idx + 1 }]),
+      },
       // Repeats — clicking a flag toggles it.
       { divider: true, label: section?.repeatStart ? "Remove start repeat 𝄆" : "Start repeat 𝄆",
         onClick: () => setSectionField("repeatStart", section?.repeatStart ? null : true) },

--- a/src/components/JoinSongbookModal.tsx
+++ b/src/components/JoinSongbookModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { setDeviceId, syncSongbook } from "@/lib/song-cloud";
+import { switchToSongbook, syncSongbook } from "@/lib/song-cloud";
 
 interface JoinSongbookModalProps {
   code: string;
@@ -25,10 +25,11 @@ export default function JoinSongbookModal({
   const handleJoin = async () => {
     if (busy) return;
     setBusy(true);
-    // Switch identity first; syncSongbook() then pulls the linked device's
-    // songs AND auto-pushes any local-only songs (this browser's existing
-    // songs) up under the new id, so neither side loses content.
-    setDeviceId(code);
+    // Switch identity AND re-home this browser's songs (clear their old-
+    // songbook cloudVersion) so syncSongbook() migrates them up under the new
+    // id instead of tombstoning them — that's what makes "neither side loses
+    // anything" actually hold once cross-device deletes are tombstoned.
+    switchToSongbook(code);
     try {
       await syncSongbook();
     } catch {

--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -16,7 +16,6 @@ import {
   deleteSong,
   renameSong,
   setSongFolder,
-  setSongs as writeLocalSongs,
   updateSong,
   SongBankEntry,
 } from "@/lib/song-bank";
@@ -29,7 +28,7 @@ import {
   extractJoinCode,
   getDeviceId,
   isTransient,
-  setDeviceId,
+  switchToSongbook,
   syncSongbook,
   type SyncStatus as CloudSyncStatus,
 } from "@/lib/song-cloud";
@@ -292,13 +291,12 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
   const handleApplyPastedCode = async () => {
     const next = extractJoinCode(pasteCode);
     if (!next || next === deviceId) return;
-    setDeviceId(next);
+    // Re-home onto the new songbook AND keep this browser's songs: they're
+    // migrated up into the joined songbook by the sync below (matching the
+    // share-link join). Previously this wiped local songs — silent data loss.
+    switchToSongbook(next);
     setDeviceIdState(next);
     setPasteCode("");
-    // After switching identity, the local list is from the OLD device — wipe
-    // it so we don't push old songs into the new songbook.
-    writeLocalSongs([]);
-    setSongsState([]);
     await runSync();
   };
 

--- a/src/lib/__tests__/cloud-autosave.test.ts
+++ b/src/lib/__tests__/cloud-autosave.test.ts
@@ -399,6 +399,43 @@ describe("syncSongbook — tombstone deletion", () => {
   });
 });
 
+// ── switchToSongbook — re-home merge on device switch ──────────────────
+
+describe("switchToSongbook", () => {
+  it("migrates previously-synced local songs into the joined songbook instead of tombstoning them", async () => {
+    const { switchToSongbook, syncSongbook, getDeviceId } = await import("../song-cloud");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    // A song synced under the OLD device id (has a cloudVersion).
+    saveSong("Mine", buildScore({ title: "Mine" }));
+    const id = getSongs()[0].id;
+    updateSong(id, { cloudVersion: "old-songbook-v3" });
+
+    // Switch to a different device's songbook.
+    switchToSongbook("friends-device-id");
+    expect(getDeviceId()).toBe("friends-device-id");
+    // Re-home cleared the stale cloudVersion and marked it pending.
+    expect(getSongs()[0].cloudVersion).toBeUndefined();
+    expect(getSongs()[0].pendingSync).toBe(true);
+
+    // The new songbook is empty in cloud; sync must PUSH our song up, not drop it.
+    let pushed = false;
+    mockFetch({
+      "GET /songs": () => ({ songs: [] }),
+      [`PUT /songs/${id}`]: () => {
+        pushed = true;
+        return dto(buildScore({ id, title: "Mine" }), "new-songbook-v1");
+      },
+    });
+
+    const merged = await syncSongbook();
+    expect(pushed).toBe(true);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].title).toBe("Mine");
+    expect(merged[0].cloudVersion).toBe("new-songbook-v1");
+  });
+});
+
 // ── enqueueOffline / hasPendingOps / flushQueue ────────────────────────
 
 describe("offline queue", () => {

--- a/src/lib/__tests__/patches-reflow.test.ts
+++ b/src/lib/__tests__/patches-reflow.test.ts
@@ -141,3 +141,26 @@ describe("applyPatch: reflow_section", () => {
     }
   });
 });
+
+describe("applyPatch: move_section", () => {
+  const sec = (id: string) => ({ id, label: id, lines: [{ chords: "", lyrics: "" }] });
+
+  it("moves a section to the target index (move chorus before verse 3)", () => {
+    // Order: intro V V2 V3 C B  → move C (idx 4) before V3 (idx 3)
+    const score = fixtureScore([sec("intro"), sec("V"), sec("V2"), sec("V3"), sec("C"), sec("B")]);
+    const out = applyPatch(score, { op: "move_section", sectionId: "C", toIndex: 3 });
+    expect(out.sections.map((s) => s.id)).toEqual(["intro", "V", "V2", "C", "V3", "B"]);
+  });
+
+  it("clamps an out-of-range toIndex to the end", () => {
+    const score = fixtureScore([sec("a"), sec("b"), sec("c")]);
+    const out = applyPatch(score, { op: "move_section", sectionId: "a", toIndex: 99 });
+    expect(out.sections.map((s) => s.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("is a no-op for an unknown section id", () => {
+    const score = fixtureScore([sec("a"), sec("b")]);
+    const out = applyPatch(score, { op: "move_section", sectionId: "zzz", toIndex: 0 });
+    expect(out.sections.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+});

--- a/src/lib/ai-provider.ts
+++ b/src/lib/ai-provider.ts
@@ -126,6 +126,7 @@ Chord-chart (songbook) patches — prefer these over \`replace_score\` when the 
 - { "op": "set_section_label", "sectionId": string, "label": string }  (rename a section)
 - { "op": "add_section", "section": { id, label, lines: [...] }, "index"?: number }
 - { "op": "remove_section", "sectionId": string }
+- { "op": "move_section", "sectionId": string, "toIndex": number }  (reorder a section in the printed list; toIndex is its 0-based position in the resulting order. Use for "move the chorus before verse 3" — prefer this over set_form, which only changes playback order.)
 - { "op": "update_section_line", "sectionId": string, "lineIdx": number, "chords"?: string, "lyrics"?: string }  (edit chord overlay or lyrics in place)
 - { "op": "add_section_line", "sectionId": string, "index"?: number, "line": { "chords": string, "lyrics": string } }
 - { "op": "remove_section_line", "sectionId": string, "lineIdx": number }

--- a/src/lib/patches.ts
+++ b/src/lib/patches.ts
@@ -295,6 +295,17 @@ export function applyPatch(score: Score, patch: ScorePatch): Score {
       };
     }
 
+    case "move_section": {
+      const sections = [...score.sections];
+      const from = sections.findIndex((s) => s.id === patch.sectionId);
+      if (from === -1) return score; // unknown section → no-op
+      const [moved] = sections.splice(from, 1);
+      // toIndex is the desired final position; clamp into the post-removal range.
+      const target = Math.max(0, Math.min(patch.toIndex, sections.length));
+      sections.splice(target, 0, moved);
+      return { ...score, sections };
+    }
+
     case "update_section_line": {
       return {
         ...score,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -462,6 +462,18 @@ export const ScorePatchSchema = z.discriminatedUnion("op", [
     op: z.literal("remove_section"),
     sectionId: z.string(),
   }),
+  /**
+   * Reorder: move a section to a new position in `sections[]`. `toIndex` is
+   * the 0-based position the section should occupy in the FINAL array
+   * (clamped to the valid range). Use this for "move the chorus before verse
+   * 3" style requests — it reorders the printed/edited section order, unlike
+   * `set_form` which only reorders playback. No-op if `sectionId` is unknown.
+   */
+  z.object({
+    op: z.literal("move_section"),
+    sectionId: z.string(),
+    toIndex: z.number().int().min(0),
+  }),
   z.object({
     op: z.literal("update_section_line"),
     sectionId: z.string(),

--- a/src/lib/song-cloud.ts
+++ b/src/lib/song-cloud.ts
@@ -32,6 +32,34 @@ export function setDeviceId(id: string): void {
   localStorage.setItem(DEVICE_ID_KEY, id);
 }
 
+/**
+ * Re-home this browser onto another device's songbook (pairing before auth).
+ * Switches the device id AND re-homes the current local songs so they MERGE
+ * into the joined songbook instead of being lost.
+ *
+ * The re-home is the important part: a previously-synced local entry carries
+ * a `cloudVersion` from the OLD songbook, which is meaningless under the new
+ * device id. Left as-is, syncSongbook's tombstone path would see "has
+ * cloudVersion, absent from the new cloud list" and drop it as a remote
+ * deletion. Clearing `cloudVersion` (and marking pending) makes the next sync
+ * treat each song as a migration and push it up into the joined songbook.
+ *
+ * Callers MUST follow with a sync (syncSongbook / runSync) to complete the
+ * merge. No-op on the songs if there are none locally.
+ */
+export function switchToSongbook(id: string): void {
+  setDeviceId(id);
+  const local = getSongs();
+  if (!local.length) return;
+  writeLocalSongs(
+    local.map((e) => {
+      const next: SongBankEntry = { ...e, pendingSync: true };
+      delete next.cloudVersion;
+      return next;
+    })
+  );
+}
+
 class TerminalCloudError extends Error {}
 class TransientCloudError extends Error {}
 


### PR DESCRIPTION
Fixes the two follow-ups flagged last session.

## 1. Dedicated section-reorder op
Reordering sections had no patch op, so the AI used `set_form` (playback order only) or `replace_score`. Added **`move_section { sectionId, toIndex }`** across all three surfaces (the parity rule):
- **Patch/CLI:** typed op in `schema.ts` + `applyPatch` handler in `patches.ts` (clamps `toIndex`, no-ops on unknown id).
- **LLM:** documented in the revise system prompt — "prefer this over set_form for 'move the chorus before verse 3'".
- **GUI:** "Move section up / down" in the chord-chart section header context menu.

## 2. Songbook join no longer loses songs
Joining another device's songbook lost local songs two ways: the **paste-code** path called `writeLocalSongs([])` (outright wipe), and the **share-link** path didn't wipe but its songs were then **tombstoned** by `syncSongbook` (they still carried the *old* songbook's `cloudVersion` but were absent from the *new* cloud list → looked like a remote deletion).

Added **`switchToSongbook(deviceId)`**: sets the device id AND re-homes local entries (clears the stale `cloudVersion`, marks `pendingSync`) so the next sync **migrates** them into the joined songbook instead of dropping them. Both join paths now use it, so "neither side loses anything" actually holds.

## Verification
- tsc clean; **217 tests pass** (was 213).
- New tests: `move_section` (reorder / clamp / unknown-id no-op) and `switchToSongbook` (previously-synced song migrates up rather than being tombstoned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)