### PR TITLE
Fix disappearing iPad saves (sync race + empty-cloud wipe + silent quota)

### DIFF
--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -310,17 +310,25 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     if (!score) return;
     const title = saveTitle.trim() || score.title || "Untitled Song";
 
-    let entry: SongBankEntry | undefined;
+    let entry: SongBankEntry;
     const localList = getSongs();
     const existing = !asNew && currentSongId ? localList.find(s => s.id === currentSongId) : null;
     if (existing) {
-      // Update in place — no new id, no duplicate.
+      // Update in place — no new id, no duplicate. If the local write failed
+      // (quota), fall back to an in-memory entry so the cloud push below still
+      // runs; the song then re-hydrates from cloud on the next sync.
       const updated = updateSong(existing.id, { title, score, savedAt: Date.now() });
-      entry = updated || undefined;
+      entry = updated ?? { ...existing, title, score, savedAt: Date.now() };
     } else {
-      saveSong(title, score);
-      const fresh = getSongs();
-      entry = fresh[fresh.length - 1];
+      // saveSong returns the created entry directly (don't read getSongs()[last]
+      // — a colliding id could make "last" the wrong song). null = local write
+      // failed; keep an in-memory entry so the cloud still gets it.
+      entry = saveSong(title, score) ?? {
+        id: `song-${Date.now()}`,
+        title,
+        savedAt: Date.now(),
+        score,
+      };
     }
     refreshLocal();
     setJustSaved(true);

--- a/src/lib/__tests__/cloud-autosave.test.ts
+++ b/src/lib/__tests__/cloud-autosave.test.ts
@@ -272,21 +272,76 @@ describe("autosaveToCloud — 409 auto-merge", () => {
 // ── syncSongbook — tombstone respect ───────────────────────────────────
 
 describe("syncSongbook — tombstone deletion", () => {
-  it("drops a local entry when cloud lists nothing AND cloudVersion is set", async () => {
+  it("tombstones a synced song when cloud returns a NON-EMPTY list that omits it", async () => {
+    // Genuine remote deletion: cloud still has other songs, just not this one.
     const { syncSongbook } = await import("../song-cloud");
     const { saveSong, getSongs, updateSong } = await import("../song-bank");
 
+    saveSong("Keeper", buildScore({ title: "Keeper" }));
     saveSong("Tombstoned", buildScore({ title: "Tombstoned" }));
-    const id = getSongs()[0].id;
-    updateSong(id, { cloudVersion: "v9" });
+    const [keeper, tomb] = getSongs();
+    updateSong(keeper.id, { cloudVersion: "kv1" });
+    updateSong(tomb.id, { cloudVersion: "v9" });
 
     mockFetch({
-      "GET /songs": () => ({ songs: [] }),
+      // Non-empty list that proves the partition is alive but omits `tomb`.
+      "GET /songs": () => ({
+        songs: [{ id: keeper.id, title: "Keeper", savedAt: 1, updatedAt: 9e15, version: "kv1" }],
+      }),
+      [`GET /songs/${keeper.id}`]: () => dto(buildScore({ id: keeper.id, title: "Keeper" }), "kv1"),
     });
 
     const merged = await syncSongbook();
-    expect(merged).toHaveLength(0);
-    expect(getSongs()).toHaveLength(0);
+    expect(merged.map((e) => e.id)).toContain(keeper.id);
+    expect(merged.map((e) => e.id)).not.toContain(tomb.id);
+    expect(getSongs().map((e) => e.id)).not.toContain(tomb.id);
+  });
+
+  it("does NOT mass-tombstone on an EMPTY cloud list — re-pushes instead (device-id reset / transient empty read)", async () => {
+    const { syncSongbook } = await import("../song-cloud");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    saveSong("Survivor", buildScore({ title: "Survivor" }));
+    const id = getSongs()[0].id;
+    updateSong(id, { cloudVersion: "v9" });
+
+    let pushed = false;
+    mockFetch({
+      "GET /songs": () => ({ songs: [] }), // empty → suspect (NOT "user deleted everything")
+      [`PUT /songs/${id}`]: () => {
+        pushed = true;
+        return dto(buildScore({ id, title: "Survivor" }), "re-pushed");
+      },
+    });
+
+    const merged = await syncSongbook();
+    expect(pushed).toBe(true);
+    expect(merged.map((e) => e.id)).toContain(id);
+    expect(getSongs().map((e) => e.id)).toContain(id);
+  });
+
+  it("preserves a brand-new song saved DURING an in-flight sync (no blind overwrite)", async () => {
+    // The headline race: syncSongbook snapshots getSongs() up front, awaits
+    // network I/O, then writes back. A save that lands during the awaits must
+    // survive. Simulate by saving mid-sync from inside the cloud-list handler.
+    const { syncSongbook } = await import("../song-cloud");
+    const { saveSong, getSongs } = await import("../song-bank");
+
+    let injected = false;
+    mockFetch({
+      "GET /songs": () => {
+        if (!injected) {
+          injected = true;
+          saveSong("Made on iPad", buildScore({ title: "Made on iPad" }));
+        }
+        return { songs: [{ id: "remote", title: "Remote", savedAt: 1, updatedAt: 1, version: "rv1" }] };
+      },
+      "GET /songs/remote": () => dto(buildScore({ id: "remote", title: "Remote" }), "rv1"),
+    });
+
+    const merged = await syncSongbook();
+    expect(merged.map((e) => e.title)).toContain("Made on iPad");
+    expect(getSongs().map((e) => e.title)).toContain("Made on iPad");
   });
 
   it("does NOT tombstone an entry with unpushed local edits — re-pushes it instead", async () => {

--- a/src/lib/song-bank.ts
+++ b/src/lib/song-bank.ts
@@ -126,20 +126,30 @@ export function getSongs(): SongBankEntry[] {
   }
 }
 
-export function saveSong(title: string, score: Score): void {
+/** Collision-proof song id. `song-${Date.now()}` collides when two songs are
+ *  created in the same millisecond (rapid double-tap on iPad, AI-generate then
+ *  immediate save) — and a colliding id makes one save silently overwrite the
+ *  other. Prefer a uuid. */
+function newSongId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `song-${crypto.randomUUID()}`;
+  }
+  return `song-${Date.now()}-${Math.floor(Math.random() * 1e9).toString(36)}`;
+}
+
+/** Create a new song entry. Returns the created entry, or null if the local
+ *  write failed (e.g. iOS Safari quota) — callers should still push to cloud
+ *  so the work isn't lost. */
+export function saveSong(title: string, score: Score): SongBankEntry | null {
   const songs = getSongs();
-  songs.push({
-    id: `song-${Date.now()}`,
+  const entry: SongBankEntry = {
+    id: newSongId(),
     title,
     savedAt: Date.now(),
     score: JSON.parse(JSON.stringify(score)),
-  });
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(songs));
-    fireSongsUpdated();
-  } catch {
-    console.warn("[song-bank] localStorage quota exceeded");
-  }
+  };
+  songs.push(entry);
+  return setSongs(songs) ? entry : null;
 }
 
 export function deleteSong(id: string): void {
@@ -152,12 +162,31 @@ export function deleteSong(id: string): void {
   }
 }
 
-export function setSongs(songs: SongBankEntry[]): void {
+/** Write the whole song bank. Returns true on success, false if the write
+ *  failed (almost always iOS Safari QuotaExceededError). On failure it fires
+ *  `notation-persist-failed` so PersistFailureBanner surfaces it — previously
+ *  this was a silent console.warn and the user lost work without any warning.
+ *  On success it fires `notation-persist-ok` to clear the banner. */
+export function setSongs(songs: SongBankEntry[]): boolean {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(songs));
     fireSongsUpdated();
-  } catch {
-    console.warn("[song-bank] localStorage quota exceeded");
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("notation-persist-ok"));
+    }
+    return true;
+  } catch (err) {
+    console.warn("[song-bank] localStorage write failed", err);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("notation-persist-failed", {
+          detail: {
+            error: err instanceof Error ? err.message : "Local save failed",
+          },
+        })
+      );
+    }
+    return false;
   }
 }
 
@@ -193,8 +222,9 @@ export function updateSong(
     ...(patch.pendingSync !== undefined ? { pendingSync: patch.pendingSync } : {}),
   };
   songs[idx] = next;
-  setSongs(songs);
-  return next;
+  // Return null if the local write failed (quota) so save callers can fall
+  // back to the cloud instead of reporting a phantom success.
+  return setSongs(songs) ? next : null;
 }
 
 /** Set or clear a song's folder. Pass null/"" to remove it (back to

--- a/src/lib/song-cloud.ts
+++ b/src/lib/song-cloud.ts
@@ -278,7 +278,25 @@ export function isTransient(err: unknown): boolean {
 
 export type SyncStatus = "syncing" | "ok" | "offline";
 
-export async function syncSongbook(opts?: {
+// Coalesce concurrent syncs. syncSongbook is a read-modify-write over
+// localStorage with seconds of network I/O in the middle; two overlapping
+// runs would each snapshot the bank, then race to writeLocalSongs and clobber
+// each other (and any save the user made in between). Keep one run in flight
+// at a time; concurrent callers share its result.
+let syncInFlight: Promise<SongBankEntry[]> | null = null;
+
+export function syncSongbook(opts?: {
+  onStatus?: (status: SyncStatus) => void;
+}): Promise<SongBankEntry[]> {
+  if (!CLOUD_ENABLED) return Promise.resolve(getSongs());
+  if (syncInFlight) return syncInFlight;
+  syncInFlight = runSyncSongbook(opts).finally(() => {
+    syncInFlight = null;
+  });
+  return syncInFlight;
+}
+
+async function runSyncSongbook(opts?: {
   onStatus?: (status: SyncStatus) => void;
 }): Promise<SongBankEntry[]> {
   const onStatus = opts?.onStatus ?? (() => {});
@@ -370,10 +388,20 @@ export async function syncSongbook(opts?: {
     // intentional." Without it we'd assume migration and push back up.
     for (const entry of local) {
       if (cloudIds.has(entry.id)) continue;
-      if (entry.cloudVersion && !entry.pendingSync) {
+      if (entry.cloudVersion && !entry.pendingSync && summaries.length > 0) {
         // Tombstone respect — entry was synced before and cloud no longer
         // lists it, with NO pending local edits → an intentional deletion
         // from another device. Propagate by dropping it (#101).
+        //
+        // CRUCIAL guard: only honor this when the cloud returned a NON-EMPTY
+        // list. A totally-empty list almost never means "the user deleted
+        // every song" — it's a device-id reset (iOS evicted localStorage and
+        // getDeviceId minted a fresh uuid → empty partition), a cold/eventually-
+        // consistent read, or a transient server blip. Honoring tombstones
+        // then would wipe the entire local bank. When the list is empty we
+        // fall through and RE-PUSH instead, so nothing is lost (worst case a
+        // genuine last-song deletion has to be repeated — a fair trade against
+        // catastrophic loss).
         continue;
       }
       // Either never-synced (legacy/migration) OR has unpushed local edits
@@ -403,10 +431,40 @@ export async function syncSongbook(opts?: {
       }
     }
 
-    merged.sort((a, b) => a.savedAt - b.savedAt);
-    writeLocalSongs(merged);
+    // Reconcile against CURRENT storage before writing. We snapshotted `local`
+    // at the top, then awaited seconds of network I/O; any save or autosave the
+    // user made during those awaits is in localStorage now but NOT in `merged`.
+    // Blind-writing `merged` would destroy it — the "I saved it and it
+    // disappeared" bug. Re-read and preserve anything created or edited since
+    // the snapshot, while still honoring genuine tombstone drops (entries that
+    // are UNCHANGED since the snapshot and were intentionally omitted).
+    const mergedById = new Map(merged.map((e) => [e.id, e]));
+    for (const cur of getSongs()) {
+      const m = mergedById.get(cur.id);
+      const snap = localById.get(cur.id);
+      // "Written during the sync" = absent from the snapshot, or its savedAt
+      // moved (saveSong/updateSong always stamp a fresh Date.now()). We must
+      // NOT key off pendingSync here — it's often already set in the snapshot,
+      // and the merged entry is this sync's own (pushed, pending cleared)
+      // result, which we'd wrongly revert.
+      const changedSinceSnapshot = !snap || cur.savedAt !== snap.savedAt;
+      if (m) {
+        // Already represented — keep the live copy only if it's a fresh edit
+        // made during the sync, so we don't revert the user's in-flight save.
+        if (changedSinceSnapshot && cur.savedAt >= m.savedAt) {
+          mergedById.set(cur.id, cur);
+        }
+      } else if (changedSinceSnapshot) {
+        // Absent from merged AND written during the sync → a brand-new or
+        // freshly-edited song the snapshot never saw. Preserve it. (A genuine
+        // tombstone is unchanged since the snapshot, so it stays dropped.)
+        mergedById.set(cur.id, cur);
+      }
+    }
+    const finalSongs = [...mergedById.values()].sort((a, b) => a.savedAt - b.savedAt);
+    writeLocalSongs(finalSongs);
     onStatus("ok");
-    return merged;
+    return finalSongs;
   } catch (err) {
     console.warn("[song-cloud] sync failed", err);
     onStatus("offline");


### PR DESCRIPTION
Deep dive into **"I save a song on my iPad and it keeps disappearing."** Three independent data-loss paths, none of which the earlier #165 (pendingSync) / #166 (join-merge) fixes touched. Found via parallel investigation of the whole save/persist/sync pipeline.

## 1. Read-modify-write race in `syncSongbook` (the primary cause)
`syncSongbook` snapshotted `getSongs()` at the top, then `await`ed **seconds** of network I/O (`cloudListSongs` + a per-song get/put loop, 8s timeout each), then blind-wrote `writeLocalSongs(merged)` built from the **stale** snapshot. Any `saveSong`/autosave that landed during those awaits was silently destroyed. On iPad this fires constantly — slow network widens the window, and My Songs auto-syncs on open, so a long sync is usually in flight exactly when you're saving.

**Fix:** (a) coalesce concurrent syncs behind one in-flight promise; (b) before writing, **reconcile against a fresh `getSongs()` read** — preserve any entry created or edited since the snapshot (new id, or `savedAt` moved), while still honoring genuine tombstones (entries unchanged since the snapshot that the merge intentionally dropped).

## 2. An empty cloud list wiped the entire local bank
The tombstone path dropped **every** synced local song whenever `cloudListSongs()` returned `[]`. But an empty list almost never means "the user deleted everything" — it's an iOS Safari localStorage eviction (→ fresh device id → empty cloud partition), or a transient/eventually-consistent read. **Fix:** only honor tombstones when the list is **non-empty**; on an empty list, re-push instead. Nothing gets mass-deleted.

## 3. localStorage quota failed silently (iPad ~5 MB cap)
`saveSong`/`setSongs`/`updateSong` swallowed `QuotaExceededError` with a `console.warn` while the UI still showed **"Saved"** — so a save just vanished on reload with no warning. **Fix:** `setSongs` now returns success and dispatches `notation-persist-failed`, lighting the existing `PersistFailureBanner`; `saveSong` returns the entry (null on failure) and `performSave` still pushes to the cloud so the work survives and re-hydrates on next sync. Also switched to **collision-proof song ids** (uuid instead of `song-${Date.now()}`, which collides on rapid/double-tap saves).

## Verification
- tsc clean; **219 tests pass** (was 217).
- New tests: save-during-sync survives (race), empty-cloud keeps+re-pushes (no wipe), non-empty list still tombstones correctly (#101 preserved). Updated the old "drop on empty cloud" test to the new safe behavior.

## Known follow-ups (identified, not in this PR)
- **Stale `currentSongId`**: AI-generating a new song while another is loaded leaves `currentSongId` pointing at the old song, so autosave can push the new content onto the old cloud row. Needs a `currentSongId` reset on new-score creation (touches the AI flow) — filing separately.
- **Device-id durability**: mirror the device id to IndexedDB/cookie so iOS eviction doesn't orphan the cloud songbook. (Largely de-risked for *loss* by fix #2, which keeps local songs and re-homes them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)