### PR TITLE
Force explicit Save into the DB (stop swallowing 409s)

### DIFF
--- a/src/components/MySongsModal.tsx
+++ b/src/components/MySongsModal.tsx
@@ -310,60 +310,72 @@ export default function MySongsModal({ onClose }: { onClose: () => void }) {
     if (!score) return;
     const title = saveTitle.trim() || score.title || "Untitled Song";
 
+    const now = Date.now();
     let entry: SongBankEntry;
     const localList = getSongs();
     const existing = !asNew && currentSongId ? localList.find(s => s.id === currentSongId) : null;
     if (existing) {
-      // Update in place — no new id, no duplicate. If the local write failed
-      // (quota), fall back to an in-memory entry so the cloud push below still
-      // runs; the song then re-hydrates from cloud on the next sync.
-      const updated = updateSong(existing.id, { title, score, savedAt: Date.now() });
-      entry = updated ?? { ...existing, title, score, savedAt: Date.now() };
+      // Update in place — no new id, no duplicate. Mark pendingSync so syncing
+      // can't drop it before the cloud push lands. If the local write failed
+      // (quota), fall back to an in-memory entry so the cloud push still runs.
+      const updated = updateSong(existing.id, { title, score, savedAt: now, pendingSync: true });
+      entry = updated ?? { ...existing, title, score, savedAt: now, pendingSync: true };
     } else {
-      // saveSong returns the created entry directly (don't read getSongs()[last]
-      // — a colliding id could make "last" the wrong song). null = local write
-      // failed; keep an in-memory entry so the cloud still gets it.
-      entry = saveSong(title, score) ?? {
-        id: `song-${Date.now()}`,
-        title,
-        savedAt: Date.now(),
-        score,
-      };
+      // saveSong returns the created entry directly (a colliding id could make
+      // getSongs()[last] the wrong song). null = local write failed; keep an
+      // in-memory entry so the cloud still gets it.
+      const created = saveSong(title, score);
+      if (created) updateSong(created.id, { pendingSync: true });
+      entry = created
+        ? { ...created, pendingSync: true }
+        : { id: `song-${now}`, title, savedAt: now, score, pendingSync: true };
     }
     refreshLocal();
-    setJustSaved(true);
-    setTimeout(() => setJustSaved(false), 2000);
+    setUIState({ currentSongId: entry.id });
 
-    if (entry) setUIState({ currentSongId: entry.id });
-
-    if (!CLOUD_ENABLED || !entry) return;
+    if (!CLOUD_ENABLED) {
+      setJustSaved(true);
+      setTimeout(() => setJustSaved(false), 2000);
+      return;
+    }
     setSyncStatus("syncing");
     try {
+      // Explicit user Save is AUTHORITATIVE — force last-write-wins by omitting
+      // expectedVersion. Sending it (as before) meant a stale cloudVersion got
+      // a 409, which the old catch swallowed as "ok" while the write was
+      // actually rejected — so the save silently never reached the DB and the
+      // next sync pulled the old version back. The user clicked Save; this
+      // version wins. (Background autosave still uses expectedVersion + the
+      // conflict modal for concurrent-edit detection.)
       const dto = await cloudPutSong({
         id: entry.id,
         title: entry.title,
         score: entry.score,
         savedAt: entry.savedAt,
         folder: entry.folder ?? null,
-        ...(entry.cloudVersion !== undefined && { expectedVersion: entry.cloudVersion }),
       });
-      // Advance the local entry's cloudVersion so the autosave can keep
-      // sending matching expectedVersion on subsequent edits.
-      updateSong(entry.id, { cloudVersion: dto.version });
+      updateSong(entry.id, { cloudVersion: dto.version, pendingSync: false });
       setSyncStatus("ok");
+      setJustSaved(true);
+      setTimeout(() => setJustSaved(false), 2000);
     } catch (err) {
-      if (isTransient(err)) {
-        enqueueOffline({
-          type: "put",
-          id: entry.id,
-          title: entry.title,
-          score: entry.score,
-          savedAt: entry.savedAt,
-        });
-        setSyncStatus("offline");
-      } else {
-        setSyncStatus("ok");
-        console.warn("[my-songs] cloud save failed", err);
+      // Do NOT fake success. Keep the entry pendingSync (so syncSongbook
+      // re-pushes it) and queue a retry. Surface terminal failures loudly via
+      // the PersistFailureBanner — e.g. a song too large for the cloud cap.
+      enqueueOffline({
+        type: "put",
+        id: entry.id,
+        title: entry.title,
+        score: entry.score,
+        savedAt: entry.savedAt,
+      });
+      setSyncStatus("offline");
+      if (!isTransient(err)) {
+        const msg = err instanceof Error ? err.message : "Cloud save failed";
+        window.dispatchEvent(
+          new CustomEvent("notation-persist-failed", { detail: { error: `Cloud save failed: ${msg}` } })
+        );
+        console.warn("[my-songs] cloud save failed (terminal)", err);
       }
     }
   };

--- a/src/lib/__tests__/cloud-autosave.test.ts
+++ b/src/lib/__tests__/cloud-autosave.test.ts
@@ -320,6 +320,32 @@ describe("syncSongbook — tombstone deletion", () => {
     expect(getSongs().map((e) => e.id)).toContain(id);
   });
 
+  it("force-pushes a pendingSync entry WITHOUT expectedVersion (explicit save must land)", async () => {
+    // A forced/explicit save marks the entry pendingSync with a possibly-stale
+    // cloudVersion. The sync push must omit expectedVersion so it can't 409 into
+    // a stuck loop — the user's save wins.
+    const { syncSongbook } = await import("../song-cloud");
+    const { saveSong, getSongs, updateSong } = await import("../song-bank");
+
+    saveSong("Forced", buildScore({ title: "Forced" }));
+    const id = getSongs()[0].id;
+    updateSong(id, { cloudVersion: "stale-v1", savedAt: 9e15, pendingSync: true });
+
+    let sentExpected: string | undefined = "UNSET";
+    mockFetch({
+      "GET /songs": () => ({ songs: [{ id, title: "Forced", savedAt: 1, updatedAt: 1, version: "cloud-v5" }] }),
+      [`PUT /songs/${id}`]: ({ body }) => {
+        sentExpected = (body as { expectedVersion?: string }).expectedVersion;
+        return dto(buildScore({ id, title: "Forced" }), "forced-v6");
+      },
+    });
+
+    const merged = await syncSongbook();
+    expect(sentExpected).toBeUndefined(); // forced LWW — no optimistic-concurrency check
+    expect(merged[0].cloudVersion).toBe("forced-v6");
+    expect(merged[0].pendingSync).toBe(false);
+  });
+
   it("preserves a brand-new song saved DURING an in-flight sync (no blind overwrite)", async () => {
     // The headline race: syncSongbook snapshots getSongs() up front, awaits
     // network I/O, then writes back. A save that lands during the awaits must

--- a/src/lib/song-cloud.ts
+++ b/src/lib/song-cloud.ts
@@ -323,7 +323,12 @@ async function runSyncSongbook(opts?: {
             score: localEntry.score,
             savedAt: localEntry.savedAt,
             folder: localEntry.folder ?? null,
-            ...(localEntry.cloudVersion !== undefined && { expectedVersion: localEntry.cloudVersion }),
+            // pendingSync entries hold an explicit/forced save that must land —
+            // omit expectedVersion so a stale version can't 409 it into a stuck
+            // loop. Clean entries keep optimistic-concurrency for conflict detect.
+            ...(localEntry.cloudVersion !== undefined && !localEntry.pendingSync && {
+              expectedVersion: localEntry.cloudVersion,
+            }),
           });
         } catch {
           /* keep local; retry next time */


### PR DESCRIPTION
## The actual bug
`performSave` sent `expectedVersion` on the cloud PUT. When the cloud version had moved (another device, or a prior write), the server returned **409** — a *terminal* error the catch block swallowed as `setSyncStatus('ok')` + `console.warn`. The UI said **"Saved"** while the write was **rejected**, so the song never reached the DB and the next sync pulled the old version back over it. That's the disappearance — my prior PRs (#165/#167) never touched this swallow.

## Fix — force the write, never fake success
- **Explicit Save is authoritative**: omit `expectedVersion` → last-write-wins, so the Save button can't 409. (Background autosave keeps `expectedVersion` + the conflict modal for concurrent-edit detection.)
- **pendingSync through the save**: the entry stays dirty until the cloud confirms, so `syncSongbook` re-pushes it if the immediate push fails — and `syncSongbook` now also force-pushes `pendingSync` entries without `expectedVersion`, so a forced save can't get stuck behind a 409 either.
- **No phantom success**: on failure we keep it pending, queue a retry, and surface terminal errors (e.g. song-too-large) via the existing `PersistFailureBanner`. The "Saved" indicator only flips after the cloud write actually confirms.

## Verification
- tsc clean; **220 tests pass** (+1: force-push omits expectedVersion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)