### PR TITLE
Fix cloud data-loss: import currentSongId clobber + device-id orphaning

### DIFF
--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -292,6 +292,11 @@ export default function MenuBar({
           addMessage({ id: uuidv4(), role: "assistant", content: `Import error: Invalid score JSON \u2014 ${result.error.issues.map(i => i.message).join(", ")}`, timestamp: Date.now() });
           return;
         }
+        // An imported file is a fresh, unsaved document — it must NOT
+        // inherit the previously-loaded song's cloud identity, or the 8s
+        // cloud autosave would push it onto that song's row and clobber it.
+        // reset() clears currentSongId (+ history/messages), like handleNew.
+        reset();
         setScore(result.data);
         addMessage({ id: uuidv4(), role: "assistant", content: `Loaded ${file.name}.`, timestamp: Date.now() });
       } catch (err: any) {
@@ -315,6 +320,9 @@ export default function MenuBar({
       const res = await fetch("/api/score/import", { method: "POST", body: formData });
       const data = await res.json();
       if (!res.ok) throw new Error((data.error || "Import failed") + (data.debug ? `\n\nDebug: ${JSON.stringify(data.debug, null, 2)}` : ""));
+      // Fresh document — drop any prior song's cloud identity before load
+      // so cloud autosave can't clobber it (see handleImport JSON path).
+      reset();
       setScore(data.score);
       if (data.warnings?.length) setWarnings(data.warnings);
       addMessage({ id: uuidv4(), role: "assistant", content: data.message || `Imported ${file.name}.`, timestamp: Date.now() });

--- a/src/lib/__tests__/cloud-autosave.test.ts
+++ b/src/lib/__tests__/cloud-autosave.test.ts
@@ -517,6 +517,42 @@ describe("switchToSongbook", () => {
   });
 });
 
+// ── getDeviceId — cookie mirror survives localStorage eviction ─────────
+
+describe("getDeviceId cookie durability", () => {
+  const clearDeviceCookie = () => {
+    document.cookie = "notation_device_id=; path=/; max-age=0";
+  };
+
+  it("recovers the id from the cookie when localStorage was evicted (iOS ITP)", async () => {
+    const { getDeviceId } = await import("../song-cloud");
+    clearDeviceCookie();
+    // beforeEach seeded localStorage with 'test-device-id'. First read mirrors
+    // it into the cookie.
+    expect(getDeviceId()).toBe("test-device-id");
+    expect(document.cookie).toContain("notation_device_id=test-device-id");
+
+    // Simulate ITP wiping localStorage but leaving the cookie.
+    localStorage.removeItem("notation-app-device-id");
+
+    // Must recover the SAME id (not mint a fresh one that orphans the songbook).
+    expect(getDeviceId()).toBe("test-device-id");
+    // ...and reseed localStorage from the cookie.
+    expect(localStorage.getItem("notation-app-device-id")).toBe("test-device-id");
+  });
+
+  it("mints a new id only when BOTH stores are empty", async () => {
+    const { getDeviceId } = await import("../song-cloud");
+    clearDeviceCookie();
+    localStorage.removeItem("notation-app-device-id");
+    const id = getDeviceId();
+    expect(id).toMatch(/[0-9a-f-]{36}/);
+    // The freshly minted id is written to both mirrors.
+    expect(localStorage.getItem("notation-app-device-id")).toBe(id);
+    expect(document.cookie).toContain(`notation_device_id=${id}`);
+  });
+});
+
 // ── enqueueOffline / hasPendingOps / flushQueue ────────────────────────
 
 describe("offline queue", () => {

--- a/src/lib/song-cloud.ts
+++ b/src/lib/song-cloud.ts
@@ -3,6 +3,10 @@ import type { SongDTO, SongSummary, VersionEntry } from "@/lib/song-cloud-types"
 import { getSongs, setSongs as writeLocalSongs, type SongBankEntry } from "@/lib/song-bank";
 
 const DEVICE_ID_KEY = "notation-app-device-id";
+const DEVICE_ID_COOKIE = "notation_device_id";
+// 400 days is the browser cap for a persistent script-set cookie. Refreshed
+// on every getDeviceId call so an active user keeps extending the window.
+const DEVICE_ID_COOKIE_MAX_AGE = 60 * 60 * 24 * 400;
 const QUEUE_KEY = "notation-app-cloud-queue";
 const TIMEOUT_MS = 8000;
 const MAX_PAYLOAD = 380 * 1024; // DDB cap is 400 KB; keep headroom.
@@ -10,18 +14,51 @@ const MAX_PAYLOAD = 380 * 1024; // DDB cap is 400 KB; keep headroom.
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
 export const CLOUD_ENABLED = !!API_BASE;
 
+function readDeviceIdCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  const m = document.cookie.match(
+    new RegExp("(?:^|; )" + DEVICE_ID_COOKIE + "=([^;]*)"),
+  );
+  // Treat an empty value (a deleted/cleared cookie often lingers as
+  // `name=`) as absent, so getDeviceId falls through to minting instead of
+  // adopting "" as the device id.
+  return m && m[1] ? decodeURIComponent(m[1]) : null;
+}
+
+// Mirror the device id into BOTH localStorage and a cookie. They are evicted
+// by iOS ITP independently and on their own timers, so keeping two copies
+// means an eviction has to wipe both before a new id gets minted. Best-effort
+// on each — a full/blocked store just leaves the other as the survivor.
+function persistDeviceId(id: string): void {
+  try {
+    localStorage.setItem(DEVICE_ID_KEY, id);
+  } catch {
+    // localStorage full / blocked — cookie may still carry it across reloads.
+  }
+  if (typeof document !== "undefined") {
+    try {
+      document.cookie =
+        `${DEVICE_ID_COOKIE}=${encodeURIComponent(id)}; path=/; ` +
+        `max-age=${DEVICE_ID_COOKIE_MAX_AGE}; samesite=lax`;
+    } catch {
+      // cookies disabled — localStorage is the only mirror.
+    }
+  }
+}
+
 export function getDeviceId(): string {
   if (typeof window === "undefined") return "";
   let id = localStorage.getItem(DEVICE_ID_KEY);
   if (!id) {
-    id = crypto.randomUUID();
-    try {
-      localStorage.setItem(DEVICE_ID_KEY, id);
-    } catch {
-      // localStorage full / blocked — return ephemeral id; sync won't persist
-      // across reloads but the session still works.
-    }
+    // localStorage was cleared/evicted (classic iOS ITP behaviour). Recover
+    // from the cookie mirror BEFORE minting a fresh uuid — a new id would
+    // orphan the user's entire cloud songbook, which lives under the old id
+    // in DynamoDB and would become permanently unreachable from this browser.
+    id = readDeviceIdCookie() ?? crypto.randomUUID();
   }
+  // Re-persist to both stores on every read: reseeds whichever store lost the
+  // value and refreshes the cookie's max-age so the window keeps sliding.
+  persistDeviceId(id);
   return id;
 }
 
@@ -29,7 +66,7 @@ export function getDeviceId(): string {
 // songbook before auth lands. Caller is responsible for re-syncing.
 export function setDeviceId(id: string): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(DEVICE_ID_KEY, id);
+  persistDeviceId(id);
 }
 
 /**


### PR DESCRIPTION
## Two cloud data-loss bugs (both flagged in the #167 deep-dive, never fixed)

### 1. Import clobbers the currently-loaded song
`MenuBar` import paths — the JSON branch and the file/MusicXML upload branch — called `setScore()` **without** `reset()`, so the previously-loaded song's `currentSongId` stayed set. The 8s cloud autosave (`page.tsx:643`) then pushed the imported score onto that song's cloud row, silently overwriting it and spawning a duplicate. `handleNew` / `handleNewChordChart` / `handleOpenProject` all already `reset()` first; the import paths now do too.

### 2. iOS ITP eviction orphans the whole cloud songbook
`getDeviceId` read only localStorage. When iOS ITP evicts localStorage, a fresh uuid was minted → the browser pointed at an empty cloud partition and the user's real songbook (under the old id in DynamoDB) became permanently unreachable. The #167 empty-cloud guard prevents local *loss* but not this *orphaning*.

Now the device id is mirrored into a 400-day cookie (an independent store with its own eviction timer) and recovered from it before minting a new id; both stores are re-seeded on every read so the surviving copy heals the other. An empty/cleared cookie is treated as absent so `""` can't be adopted as the id. Kept fully synchronous — no API change.

## Tests
- Full suite green (226 tests).
- Added regression tests: cookie recovery after localStorage eviction, and minting only when both stores are empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)