### PR TITLE
Chord-chart paste: sanitize pasted text (tabs, smart quotes, iOS chord periods)

### DIFF
--- a/src/lib/__tests__/lyric-parser.test.ts
+++ b/src/lib/__tests__/lyric-parser.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizePastedText,
+  parseToChordChartLines,
+  parseToSections,
+} from "../lyric-parser";
+
+describe("sanitizePastedText", () => {
+  it("normalizes smart quotes to ASCII", () => {
+    // ‘’ single, “” double
+    const out = sanitizePastedText("‘don’t’ “stop”");
+    expect(out).toBe("'don't' \"stop\"");
+  });
+
+  it("normalizes en/em dash and minus to hyphen", () => {
+    expect(sanitizePastedText("Pre–Chorus—end−now")).toBe(
+      "Pre-Chorus-end-now",
+    );
+  });
+
+  it("normalizes non-breaking and narrow spaces to a regular space", () => {
+    expect(sanitizePastedText("C   G")).toBe("C   G");
+  });
+
+  it("expands tabs to spaces (tab stop 8) so column math holds", () => {
+    // "C" then a tab lands at column 8.
+    expect(sanitizePastedText("C\tG")).toBe("C       G");
+  });
+
+  it("normalizes CRLF/CR to LF", () => {
+    expect(sanitizePastedText("a\r\nb\rc")).toBe("a\nb\nc");
+  });
+
+  it("is idempotent", () => {
+    const once = sanitizePastedText("‘C’\tG");
+    expect(sanitizePastedText(once)).toBe(once);
+  });
+});
+
+describe("parseToChordChartLines — iOS autocorrect chord periods", () => {
+  it("recognizes a chord line whose tokens carry trailing periods", () => {
+    // "C." / "G." are what iOS double-space autocorrect produces.
+    const lines = parseToChordChartLines("C.      G.\nAmazing grace");
+    expect(lines).toHaveLength(1);
+    // Periods stripped, columns preserved so the chords still sit over the words.
+    expect(lines[0].lyrics).toBe("Amazing grace");
+    expect(lines[0].chords.startsWith("C ")).toBe(true);
+    expect(lines[0].chords).not.toContain(".");
+  });
+
+  it("keeps a chord-only line (with periods) as chords, not lyrics", () => {
+    const lines = parseToChordChartLines("C. G. Am.");
+    expect(lines).toHaveLength(1);
+    expect(lines[0].lyrics).toBe("");
+    expect(lines[0].chords).not.toContain(".");
+    // Periods become spaces (columns preserved), so tokens survive intact.
+    expect(lines[0].chords.trim().split(/\s+/)).toEqual(["C", "G", "Am"]);
+  });
+
+  it("does NOT strip periods from a real lyric line", () => {
+    const lines = parseToChordChartLines("I walked alone.");
+    expect(lines[0].chords).toBe("");
+    expect(lines[0].lyrics).toBe("I walked alone.");
+  });
+});
+
+describe("parseToSections — tabbed above-line paste aligns", () => {
+  it("uses expanded-tab columns to place chords over the right words", () => {
+    // Chord line uses a tab; without pre-parse expansion the G column would be
+    // wrong. After sanitize, "G" sits at column 8, nearest to "grace".
+    const sections = parseToSections("Verse 1\nC\tG\nAmazing grace here");
+    expect(sections).toHaveLength(1);
+    expect(sections[0].label).toBe("Verse 1");
+    const line = sections[0].lines[0];
+    expect(line.lyrics).toBe("Amazing grace here");
+    expect(line.chords).not.toContain("\t");
+  });
+});

--- a/src/lib/lyric-parser.ts
+++ b/src/lib/lyric-parser.ts
@@ -1,6 +1,29 @@
 // ── Inline chord / lyric parser ──────────────────────────────────────────────
 
 import type { ChordChartLine } from "@/lib/schema";
+import { expandTabs } from "@/lib/chord-line";
+
+/**
+ * Normalize pasted text BEFORE parsing. Paste sources (iOS, Word, Google Docs)
+ * inject characters that silently break the parser's column math and chord
+ * detection:
+ *  - Tabs render at variable widths but count as one char, so the column
+ *    offsets the above-the-line parser reads no longer match what the user
+ *    sees. Expand them to spaces (tab stops of 8) first. (expandTabs also runs
+ *    at patch-apply time, but that's too late for the parse-time column math.)
+ *  - Smart quotes / en–em dashes / non-breaking + narrow spaces → ASCII, so
+ *    word splitting and chord tokens behave and the text stays plain.
+ * Pure and idempotent — safe to run on any pasted blob, or twice.
+ */
+export function sanitizePastedText(text: string): string {
+  const normalized = text
+    .replace(/\r\n?/g, "\n")                        // CRLF / CR -> LF
+    .replace(/[‘’‛′]/g, "'")    // smart single quotes, prime -> '
+    .replace(/[“”‟″]/g, '"')    // smart double quotes, dbl prime -> "
+    .replace(/[–—−]/g, "-")          // en/em dash, minus -> -
+    .replace(/[   ]/g, " ");         // nbsp / figure / narrow-nbsp -> space
+  return expandTabs(normalized);
+}
 
 // ── Section header detection ──────────────────────────────────────────────────
 
@@ -49,7 +72,23 @@ export interface WordChordPair {
 
 // Matches chord names: G, Am, C#m, Bb, D7, Cmaj7, G/B, D/F#, sus4, etc.
 const CHORD_RE = /^[A-G][b#]?(m|M|maj|min|dim|aug|sus[24]?|add)?\d*(\/[A-G][b#]?)?$/;
-function isChordToken(s: string): boolean { return CHORD_RE.test(s); }
+
+// iOS/Word autocorrect can tack a trailing period or comma onto a chord token
+// ("C" + double-space -> "C.", or a comma from a list). Strip it before the
+// chord test so the token is still recognized. Only trailing punctuation is
+// removed — chords never contain '.' or ',' internally.
+function stripChordPunct(s: string): string {
+  return s.replace(/[.,]+$/, "");
+}
+function isChordToken(s: string): boolean { return CHORD_RE.test(stripChordPunct(s)); }
+
+// Clean a line already confirmed to be chord-only: overwrite each token's
+// trailing autocorrect punctuation with spaces (not delete it) so every
+// remaining chord keeps its original column and still aligns with the lyric
+// line beneath it. On a chord-only line the only '.'/',' are that debris.
+function cleanChordLine(line: string): string {
+  return line.replace(/[.,]+(?=\s|$)/g, (m) => " ".repeat(m.length)).replace(/\s+$/, "");
+}
 
 /** Parse [G]Amazing [C]grace bracketed-chord format. Newlines are treated as spaces. */
 function parseBracketed(text: string): WordChordPair[] {
@@ -59,7 +98,7 @@ function parseBracketed(text: string): WordChordPair[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(text.replace(/\n/g, " "))) !== null) {
     if (m[1] !== undefined) {
-      pendingChord = m[1].trim();
+      pendingChord = stripChordPunct(m[1].trim());
     } else {
       pairs.push({ word: m[2], chord: pendingChord });
       pendingChord = undefined;
@@ -88,7 +127,7 @@ function parseAboveLine(text: string): WordChordPair[] {
       let cm: RegExpExecArray | null;
       const cr = /\S+/g;
       while ((cm = cr.exec(line)) !== null) {
-        if (isChordToken(cm[0])) chordCols.push({ col: cm.index, chord: cm[0] });
+        if (isChordToken(cm[0])) chordCols.push({ col: cm.index, chord: stripChordPunct(cm[0]) });
       }
 
       const wordCols: { col: number; word: string }[] = [];
@@ -126,7 +165,7 @@ function parseAboveLine(text: string): WordChordPair[] {
  * Pure lyrics return pairs with no chord field set.
  */
 export function parseLyricsWithChords(text: string): WordChordPair[] {
-  const trimmed = text.trim();
+  const trimmed = sanitizePastedText(text).trim();
   if (!trimmed) return [];
   if (/\[[A-G][^\]]*\]/.test(trimmed)) return parseBracketed(trimmed);
   return parseAboveLine(trimmed);
@@ -170,7 +209,7 @@ function pairsToChordChartLine(pairs: WordChordPair[]): ChordChartLine {
  * Blank lines produce { chords: "", lyrics: "" } for visual spacing.
  */
 export function parseToChordChartLines(text: string): ChordChartLine[] {
-  const trimmed = text.trim();
+  const trimmed = sanitizePastedText(text).trim();
   if (!trimmed) return [];
 
   // Bracketed format: process line by line
@@ -202,10 +241,10 @@ export function parseToChordChartLines(text: string): ChordChartLine[] {
     const nextIsLyric = nextTokens.length > 0 && !nextTokens.every(isChordToken);
 
     if (isChordLine && nextIsLyric) {
-      result.push({ chords: line, lyrics: nextLine! });
+      result.push({ chords: cleanChordLine(line), lyrics: nextLine! });
       i += 2;
     } else if (isChordLine) {
-      result.push({ chords: line, lyrics: "" });
+      result.push({ chords: cleanChordLine(line), lyrics: "" });
       i++;
     } else {
       result.push({ chords: "", lyrics: line });
@@ -226,14 +265,14 @@ export function parseToChordChartLines(text: string): ChordChartLine[] {
  * (header immediately followed by another header) are dropped.
  */
 export function parseToSections(text: string): ParsedSection[] {
-  const trimmed = text.trim();
+  const trimmed = sanitizePastedText(text).trim();
   if (!trimmed) return [];
 
   const rawLines = trimmed.split("\n");
   const hasHeaders = rawLines.some(l => parseSectionHeader(l) !== null);
 
   if (!hasHeaders) {
-    return [{ label: "", lines: parseToChordChartLines(text) }];
+    return [{ label: "", lines: parseToChordChartLines(trimmed) }];
   }
 
   // Collect raw line blocks keyed by label


### PR DESCRIPTION
## Notes-paste hardening

Pasting from iOS / Word / Google Docs into a chord chart produced misaligned chords and dropped chord lines. Root causes, all fixed by a pure `sanitizePastedText` run at every parse entry point (`parseToSections`, `parseToChordChartLines`, `parseLyricsWithChords`):

- **Tabs** — `expandTabs` only ran at *patch-apply* time, too late for the above-the-line parser's column math, so tabbed chord rows landed over the wrong words. Now expanded before parsing.
- **Unicode punctuation** — smart quotes, en/em dashes, and non-breaking / figure / narrow spaces normalized to ASCII so word-splitting and chord-token detection behave and the text stays plain.
- **iOS chord-period autocorrect** — double-space after a chord turns "C" into "C.", which failed the chord regex and made a chord line parse as lyrics. Chord tokens now tolerate a trailing `.`/`,`; on a confirmed chord-only line the punctuation is overwritten with a space so remaining chords keep their column alignment. Real lyric-line periods (e.g. "I walked alone.") are left untouched.

`sanitizePastedText` is pure and idempotent (parse functions call each other; double-sanitize is safe).

## Note on the second item from the handoff
The **MySongsModal paste-code merge** ("writeLocalSongs([]) wipes local songs") is already fixed in the current tree — `handleApplyPastedCode` uses `switchToSongbook + runSync` (merges, matching the share-link join). The remaining `writeLocalSongs([])` in `page.tsx` is the intentional, `window.confirm`-guarded "Reset and pull from cloud" recovery action. No change needed.

## Tests
- New `lyric-parser.test.ts` (10 cases): smart-quote/dash/nbsp normalization (asserted against explicit U+00A0/U+2007/U+202F etc.), tab expansion, CRLF, idempotency, and the chord-period cases.
- Full suite green (236 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)